### PR TITLE
Preallocate memory when SecStreamInBodyInspection is on

### DIFF
--- a/apache2/apache2_io.c
+++ b/apache2/apache2_io.c
@@ -281,7 +281,9 @@ apr_status_t read_request_body(modsec_rec *msr, char **error_msg) {
             }
 
             if (msr->txcfg->stream_inbody_inspection == 1)   {
-                modsecurity_request_body_to_stream(msr, buf, buflen, error_msg);
+                if (modsecurity_request_body_to_stream(msr, buf, buflen, error_msg) < 0) {
+                    return -1;
+                }
             }
 
             msr->reqbody_length += buflen;

--- a/apache2/apache2_io.c
+++ b/apache2/apache2_io.c
@@ -281,7 +281,6 @@ apr_status_t read_request_body(modsec_rec *msr, char **error_msg) {
             }
 
             if (msr->txcfg->stream_inbody_inspection == 1)   {
-                msr->stream_input_length+=buflen;
                 modsecurity_request_body_to_stream(msr, buf, buflen, error_msg);
             }
 

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -287,6 +287,7 @@ struct modsec_rec {
     unsigned int         resbody_contains_html;
 
     apr_size_t           stream_input_length;
+    apr_size_t           stream_input_allocated_length;
     char                *stream_input_data;
     apr_size_t           stream_output_length;
     char                *stream_output_data;

--- a/apache2/msc_reqbody.c
+++ b/apache2/msc_reqbody.c
@@ -432,7 +432,7 @@ apr_status_t modsecurity_request_body_to_stream(modsec_rec *msr, const char *buf
     char* allocated = NULL;
 
     if (msr->stream_input_data == NULL)  {
-        // Is the request body length is known beforehand? (requests that are not Transfer-Encoding: chunked)
+        // Is the request body length known beforehand? (requests that are not Transfer-Encoding: chunked)
         if (msr->request_content_length > 0) {
             // Use min of Content-Length and SecRequestBodyLimit
             allocate_length = min(msr->request_content_length, msr->txcfg->reqbody_limit);

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -636,15 +636,15 @@ nextround:
         msr->stream_input_length = 0;
         msr->stream_input_allocated_length  = 0;
 
-        msr->stream_input_data = (char *)malloc(size+1);
+        msr->stream_input_data = (char *)malloc(size);
 
         if(msr->stream_input_data == NULL)  {
             return -1;
         }
 
         msr->stream_input_length = size;
-        msr->stream_input_allocated_length = size + 1;
-        memset(msr->stream_input_data, 0x0, size + 1);
+        msr->stream_input_allocated_length = size;
+        memset(msr->stream_input_data, 0x0, size);
 
         msr->if_stream_changed = 1;
 

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -634,6 +634,7 @@ nextround:
         free(msr->stream_input_data);
         msr->stream_input_data = NULL;
         msr->stream_input_length = 0;
+        msr->stream_input_allocated_length  = 0;
 
         msr->stream_input_data = (char *)malloc(size+1);
 
@@ -642,7 +643,8 @@ nextround:
         }
 
         msr->stream_input_length = size;
-        memset(msr->stream_input_data, 0x0, size+1);
+        msr->stream_input_allocated_length = size + 1;
+        memset(msr->stream_input_data, 0x0, size + 1);
 
         msr->if_stream_changed = 1;
 

--- a/iis/dependencies/build_yajl.bat
+++ b/iis/dependencies/build_yajl.bat
@@ -28,7 +28,7 @@ copy /y "%WORK_DIR%\yajl\build\%YAJL_DIR%\lib\yajl_s.lib" "%OUTPUT_DIR%"
 @exit /B 0
 
 :file_not_found_bin
-@echo File not found: "%SOURCE_DIR%\%PCRE%"
+@echo File not found: "%SOURCE_DIR%\%YAJL%"
 @goto failed
 
 :build_failed


### PR DESCRIPTION
Preallocate memory when SecStreamInBodyInspection is on. 20x speed improvement for 10mb upload (and even more for larger files). Also simplified modsecurity_request_body_to_stream and fixed typo in build_yajl.bat.