### PR TITLE
Let body parsers observe SecRequestBodyNoFilesLimit

### DIFF
--- a/apache2/apache2_io.c
+++ b/apache2/apache2_io.c
@@ -329,8 +329,7 @@ apr_status_t read_request_body(modsec_rec *msr, char **error_msg) {
         apr_brigade_cleanup(bb_in);
     } while(!finished_reading);
 
-    // TODO: Why ignore the return code here?
-    modsecurity_request_body_end(msr, error_msg);
+    apr_status_t rcbe = modsecurity_request_body_end(msr, error_msg);
 
     if (msr->txcfg->debuglog_level >= 4) {
         msr_log(msr, 4, "Input filter: Completed receiving request body (length %" APR_SIZE_T_FMT ").",
@@ -339,7 +338,7 @@ apr_status_t read_request_body(modsec_rec *msr, char **error_msg) {
 
     msr->if_status = IF_STATUS_WANTS_TO_RUN;
 
-    return 1;
+    return rcbe;
 }
 
 

--- a/apache2/msc_reqbody.c
+++ b/apache2/msc_reqbody.c
@@ -396,12 +396,13 @@ apr_status_t modsecurity_request_body_store(modsec_rec *msr,
 
     /* Check that we are not over the request body no files limit. */
     if (msr->msc_reqbody_no_files_length >= (unsigned long) msr->txcfg->reqbody_no_files_limit) {
-
         *error_msg = apr_psprintf(msr->mp, "Request body no files data length is larger than the "
                 "configured limit (%ld).", msr->txcfg->reqbody_no_files_limit);
         if (msr->txcfg->debuglog_level >= 1) {
             msr_log(msr, 1, "%s", *error_msg);
         }
+
+        msr->msc_reqbody_error = 1;
 
         if ((msr->txcfg->is_enabled == MODSEC_ENABLED) && (msr->txcfg->if_limit_action == REQUEST_BODY_LIMIT_ACTION_REJECT))   {
             return -5;
@@ -410,7 +411,6 @@ apr_status_t modsecurity_request_body_store(modsec_rec *msr,
                 return -5;
         }
     }
-
 
     /* Store data. */
     if (msr->msc_reqbody_storage == MSC_REQBODY_MEMORY) {
@@ -606,6 +606,19 @@ apr_status_t modsecurity_request_body_end(modsec_rec *msr, char **error_msg) {
 
     /* Note that we've read the body. */
     msr->msc_reqbody_read = 1;
+
+
+    /* Check that we are not over the request body no files limit. */
+    if (msr->msc_reqbody_no_files_length >= (unsigned long)msr->txcfg->reqbody_no_files_limit) {
+        *error_msg = apr_psprintf(msr->mp, "Request body no files data length is larger than the "
+            "configured limit (%ld).", msr->txcfg->reqbody_no_files_limit);
+        if (msr->txcfg->debuglog_level >= 1) {
+            msr_log(msr, 1, "%s", *error_msg);
+        }
+
+        return -5;
+    }
+
 
     /* Finalise body processing. */
     if ((msr->msc_reqbody_processor != NULL) && (msr->msc_reqbody_error == 0)) {


### PR DESCRIPTION
Previously, modsecurity_request_body_store would keep feeding the body parsers (JSON/XML/Multipart) even after the SecRequestBodyNoFilesLimit limit was met. This change prevents this. Also, modsecurity_request_body_end now returns an error code when the limit is met, so that a message can be logged for this event.