### PR TITLE
Copy rules optimization

### DIFF
--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -413,10 +413,14 @@ void *merge_directory_configs(apr_pool_t *mp, void *_parent, void *_child)
             ap_log_perror(APLOG_MARK, APLOG_STARTUP|APLOG_NOERRNO, 0, mp, "Using parent rules in this context.");
             #endif
 
-            /* Copy the rules from the parent context. */
-            merged->ruleset = msre_ruleset_create(parent->ruleset->engine, mp);
             /* TODO: copy_rules return code should be taken into consideration. */
-            copy_rules(mp, parent->ruleset, merged->ruleset, child->rule_exceptions);
+            if(child->rule_exceptions->nelts > 0) {
+                /* Copy the rules from the parent context. */
+                merged->ruleset = msre_ruleset_create(parent->ruleset->engine, mp);
+                copy_rules(mp, parent->ruleset, merged->ruleset, child->rule_exceptions);
+            } else {
+                merged->ruleset = msre_ruleset_create_and_copy(parent->ruleset->engine, mp, parent->ruleset);
+            }
         } else
         if (parent->ruleset == NULL) {
             #ifdef DEBUG_CONF

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -1970,6 +1970,48 @@ msre_ruleset *msre_ruleset_create(msre_engine *engine, apr_pool_t *mp) {
 
     return ruleset;
 }
+/**
+
+
+ * Creates a ruleset by copy the parent ruleset.
+ *
+ * @param mp apr pool structure
+ * @param parent_ruleset Parent's msre_ruleset
+ *
+ * return the address of created ruleset if OK.
+ * return NULL if Something went wrong.
+ */
+
+msre_ruleset *msre_ruleset_create_and_copy(msre_engine *engine, apr_pool_t *mp, msre_ruleset *parent_ruleset) {
+    msre_ruleset *child_ruleset;
+
+    child_ruleset = apr_pcalloc(mp, sizeof(msre_ruleset));
+    if (child_ruleset == NULL) return NULL;
+    child_ruleset->mp = mp;
+    child_ruleset->engine = engine;
+
+    if (parent_ruleset == NULL) {
+        child_ruleset->phase_request_headers  = apr_array_make(mp, 25, sizeof(const msre_rule *));
+        child_ruleset->phase_request_body     = apr_array_make(mp, 25, sizeof(const msre_rule *));
+        child_ruleset->phase_response_headers = apr_array_make(mp, 25, sizeof(const msre_rule *));
+        child_ruleset->phase_response_body    = apr_array_make(mp, 25, sizeof(const msre_rule *));
+        child_ruleset->phase_logging          = apr_array_make(mp, 25, sizeof(const msre_rule *));
+        return child_ruleset;
+    }
+
+    child_ruleset->phase_request_headers  = apr_array_copy(mp, parent_ruleset->phase_request_headers);
+    child_ruleset->phase_request_body     = apr_array_copy(mp, parent_ruleset->phase_request_body);
+    child_ruleset->phase_response_headers = apr_array_copy(mp, parent_ruleset->phase_response_headers);
+    child_ruleset->phase_response_body    = apr_array_copy(mp, parent_ruleset->phase_response_body);
+    child_ruleset->phase_logging          = apr_array_copy(mp, parent_ruleset->phase_logging);
+
+    if((child_ruleset->phase_request_headers == NULL) || (child_ruleset->phase_request_body == NULL) || (child_ruleset->phase_response_headers == NULL)
+       || (child_ruleset->phase_response_body == NULL) || (child_ruleset->phase_logging == NULL)) {
+        return NULL;
+    }
+
+    return child_ruleset;
+}
 
 /**
  * Adds one rule to the given phase of the ruleset.

--- a/apache2/re.h
+++ b/apache2/re.h
@@ -114,6 +114,8 @@ apr_status_t DSOLOCAL msre_ruleset_process_phase_internal(msre_ruleset *ruleset,
 
 msre_ruleset DSOLOCAL *msre_ruleset_create(msre_engine *engine, apr_pool_t *mp);
 
+msre_ruleset DSOLOCAL *msre_ruleset_create_and_copy(msre_engine *engine, apr_pool_t *mp, msre_ruleset *parent_ruleset);
+
 int DSOLOCAL msre_ruleset_rule_add(msre_ruleset *ruleset, msre_rule *rule, int phase);
 
 msre_rule DSOLOCAL *msre_ruleset_fetch_rule(msre_ruleset *ruleset, const char *id, int offset);


### PR DESCRIPTION
  Problem
       Modsecurity supports rules removing by ID, Message and Tag at runtime
      At requestBody phase, copy rules() generates a runtime ruleset from the original one but excludes removed ruleset

Solution:
     If we don't remove any rule at runtime, we can directly use the original ruleset instead of generating a new one