### PR TITLE
IIS: no lock on ProcessRequest. No reload of config.

### DIFF
--- a/iis/moduleconfig.cpp
+++ b/iis/moduleconfig.cpp
@@ -466,11 +466,8 @@ MODSECURITY_STORED_CONTEXT::~MODSECURITY_STORED_CONTEXT()
 MODSECURITY_STORED_CONTEXT::MODSECURITY_STORED_CONTEXT():
     m_bIsEnabled ( FALSE ),
     m_pszPath( NULL ),
-	m_Config( NULL ),
-	m_dwLastCheck( 0 )
+	m_Config( NULL )
 {
-	m_LastChange.dwLowDateTime = 0;
-	m_LastChange.dwHighDateTime = 0;
 }
 
 DWORD 

--- a/iis/moduleconfig.h
+++ b/iis/moduleconfig.h
@@ -68,8 +68,6 @@ class MODSECURITY_STORED_CONTEXT : public IHttpStoredContext
             USHORT*  pdwLengthDestination );
 
 	void*			  m_Config;
-	DWORD			  m_dwLastCheck;
-	FILETIME		  m_LastChange;
 
 private:
     HRESULT 


### PR DESCRIPTION
Issue: modsecProcessRequest(r) can take tens of seconds. It is therefore not acceptable that it keeps the lock, preventing all other threads from processing meanwhile, some of which might take just miliseconds.

This change releases the lock around modsecProcessRequest(r).

Removing the auto-reload of config feature, because now that there is no lock around modsecProcessRequest(r), the config could get reloaded while another thread is processing.

Tested by running running 80 difficult requests in parallel overnight, and ensuring no requests had mixup between 200 and 403.