### PR TITLE
set Default to disable waf_json_logging, so people could still compile

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -609,7 +609,7 @@ AC_ARG_ENABLE(waf_json_logging,
   fi
 ],
 [
-  waf_json_logging="-I"`pwd`"/apache2/waf_logging -DWAF_JSON_LOGGING_ENABLE"
+  waf_json_logging=""
 ])
 
 


### PR DESCRIPTION
the ModSec without installing Protobuf