### PR TITLE
first version of persistent lock utitlity and intergration

### DIFF
--- a/apache2/Makefile.am
+++ b/apache2/Makefile.am
@@ -6,6 +6,7 @@ mod_security2_la_SOURCES = acmp.c \
     ag_mdb/ag_mdb.cpp \
     waf_logging/waf_format.pb.cc \
     waf_logging/waf_log_util.cc \
+    waf_lock/waf_lock.cpp \
     apache2_config.c \
     apache2_io.c \
     apache2_util.c \

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -1200,6 +1200,7 @@ static const char *cmd_waf_instanceId(cmd_parms *cmd,
 
     return NULL;
 }
+#endif
 
 static const char *cmd_waf_lock_owner(cmd_parms *cmd,
         void *_dcfg, const char *p1)
@@ -1213,7 +1214,6 @@ static const char *cmd_waf_lock_owner(cmd_parms *cmd,
 
     return NULL;
 }
-#endif
 
 static const char *cmd_action(cmd_parms *cmd, void *_dcfg, const char *p1)
 {
@@ -4045,6 +4045,7 @@ const command_rec module_directives[] = {
         CMD_SCOPE_ANY,
         "Set waf instanceId"
     ),
+#endif
     AP_INIT_TAKE1 (
         "SecWafLockOwner",
         cmd_waf_lock_owner,
@@ -4052,6 +4053,5 @@ const command_rec module_directives[] = {
         CMD_SCOPE_ANY,
         "Set waf lock owner"
     ),
-#endif
     { NULL }
 };

--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -19,6 +19,7 @@
 
 #ifdef WAF_JSON_LOGGING_ENABLE
 #include "waf_log_util_external.h"
+#include "waf_lock_external.h"
 #include "string.h"
 #endif
 
@@ -289,7 +290,7 @@ static void get_ruleset_type_version(char* waf_ruleset_info, char* waf_ruleset_t
     }
 }
 
-static int write_file_with_lock(apr_global_mutex_t* lock, apr_file_t* fd, char* str) {
+static int write_file_with_lock(struct waf_lock* lock, apr_file_t* fd, char* str) {
     int rc;
     apr_size_t nbytes, nbytes_written;
 
@@ -297,16 +298,16 @@ static int write_file_with_lock(apr_global_mutex_t* lock, apr_file_t* fd, char* 
         return WAF_LOG_UTIL_FAILED;
     }
 
-    rc = apr_global_mutex_lock(lock);
-    if (rc != APR_SUCCESS) {
+    rc = Waf_getExclusiveLock(lock);
+    if (Waf_lock_isError(rc)) {
         return WAF_LOG_UTIL_FAILED;
     }
 
     nbytes = strlen(str);
     apr_file_write_full(fd, str, nbytes, &nbytes_written);
 
-    rc = apr_global_mutex_unlock(lock);
-    if (rc != APR_SUCCESS) {
+    rc = Waf_freeExclusiveLock(lock);
+    if (Waf_lock_isError(rc)) {
         return WAF_LOG_UTIL_FAILED;
     }
 
@@ -316,7 +317,7 @@ static int write_file_with_lock(apr_global_mutex_t* lock, apr_file_t* fd, char* 
 /**
  * send all waf fields in json format to a file.
  */
-static void send_waf_log(apr_global_mutex_t* lock, apr_file_t* fd, const char* str1, const char* ip_port, const char* uri, int mode, const char* hostname, request_rec *r) {
+static void send_waf_log(struct waf_lock* lock, apr_file_t* fd, const char* str1, const char* ip_port, const char* uri, int mode, const char* hostname, request_rec *r) {
     int rc = 0;
     char* json_str;
     char waf_filename[1024] = "";

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -95,8 +95,8 @@ TreeRoot DSOLOCAL *conn_write_state_suspicious_list = 0;
 #ifdef WAF_JSON_LOGGING_ENABLE
 char DSOLOCAL *msc_waf_resourceId = "";
 char DSOLOCAL *msc_waf_instanceId = "";
-char DSOLOCAL *msc_waf_lock_owner = "root";
 #endif
+char DSOLOCAL *msc_waf_lock_owner = "root";
 
 #if defined(WIN32) || defined(VERSION_NGINX)
 int (*modsecDropAction)(request_rec *r) = NULL;
@@ -833,7 +833,7 @@ static int hook_post_config(apr_pool_t *mp, apr_pool_t *mp_log, apr_pool_t *mp_t
  * Initialisation performed for every new child process.
  */
 static void hook_child_init(apr_pool_t *mp, server_rec *s) {
-    modsecurity_child_init(modsecurity);
+    modsecurity_child_init(mp, modsecurity);
 }
 
 /**

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -154,8 +154,9 @@ int modsecurity_init(msc_engine *msce, apr_pool_t *mp) {
     curl_global_init(CURL_GLOBAL_ALL);
 #endif
     /* Serial audit log mutext */
-    rc = apr_global_mutex_create(&msce->auditlog_lock, NULL, APR_LOCK_DEFAULT, mp);
-    if (rc != APR_SUCCESS) {
+    msce->auditlog_lock = apr_pcalloc(mp, sizeof(struct waf_lock));
+    rc = Waf_createLock(msce->auditlog_lock, "auditlog_lock", strlen("auditlog_lock"), msc_waf_lock_owner);    
+    if (Waf_lock_isError(rc)) {
         //ap_log_error(APLOG_MARK, APLOG_ERR, rv, s, "mod_security: Could not create modsec_auditlog_lock");
         //return HTTP_INTERNAL_SERVER_ERROR;
         return -1;
@@ -163,76 +164,27 @@ int modsecurity_init(msc_engine *msce, apr_pool_t *mp) {
 
 #ifdef WAF_JSON_LOGGING_ENABLE
     /* Serial wafjson log mutext */
-    rc = apr_global_mutex_create(&msce->wafjsonlog_lock, NULL, APR_LOCK_DEFAULT, mp);
-    if (rc != APR_SUCCESS) {
+    msce->wafjsonlog_lock = apr_pcalloc(mp, sizeof(struct waf_lock));
+    rc = Waf_createLock(msce->wafjsonlog_lock, "wafjsonlog_lock", strlen("wafjsonlog_lock"), msc_waf_lock_owner);    
+    if (Waf_lock_isError(rc)) {
         //ap_log_error(APLOG_MARK, APLOG_ERR, rv, s, "mod_security: Could not create modsec_wafjsonlog_lock");
         //return HTTP_INTERNAL_SERVER_ERROR;
         return -1;
     }
 #endif
 
-#if !defined(MSC_TEST)
-#ifdef __SET_MUTEX_PERMS
-#if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER > 2
-    rc = ap_unixd_set_global_mutex_perms(msce->auditlog_lock);
-#else
-    rc = unixd_set_global_mutex_perms(msce->auditlog_lock);
-#endif
-    if (rc != APR_SUCCESS) {
-        // ap_log_error(APLOG_MARK, APLOG_ERR, rc, s, "mod_security: Could not set permissions on modsec_auditlog_lock; check User and Group directives");
-        // return HTTP_INTERNAL_SERVER_ERROR;
+    msce->geo_lock = apr_pcalloc(mp, sizeof(struct waf_lock));
+    rc = Waf_createLock(msce->geo_lock, "geo_lock", strlen("geo_lock"), msc_waf_lock_owner);    
+    if (Waf_lock_isError(rc)) {
         return -1;
     }
-#endif /* SET_MUTEX_PERMS */
-
-#ifdef WAF_JSON_LOGGING_ENABLE
-#ifdef __SET_MUTEX_PERMS
-#if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER > 2
-    rc = ap_unixd_set_global_mutex_perms(msce->wafjsonlog_lock);
-#else
-    rc = unixd_set_global_mutex_perms(msce->wafjsonlog_lock);
-#endif
-    if (rc != APR_SUCCESS) {
-        // ap_log_error(APLOG_MARK, APLOG_ERR, rc, s, "mod_security: Could not set permissions on modsec_wafjsonlog_lock; check User and Group directives");
-        // return HTTP_INTERNAL_SERVER_ERROR;
-        return -1;
-    }
-#endif /* SET_MUTEX_PERMS */
-#endif
-
-    rc = apr_global_mutex_create(&msce->geo_lock, NULL, APR_LOCK_DEFAULT, mp);
-    if (rc != APR_SUCCESS) {
-        return -1;
-    }
-
-#ifdef __SET_MUTEX_PERMS
-#if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER > 2
-    rc = ap_unixd_set_global_mutex_perms(msce->geo_lock);
-#else
-    rc = unixd_set_global_mutex_perms(msce->geo_lock);
-#endif
-    if (rc != APR_SUCCESS) {
-        return -1;
-    }
-#endif /* SET_MUTEX_PERMS */
 
 #ifdef GLOBAL_COLLECTION_LOCK
-    rc = apr_global_mutex_create(&msce->dbm_lock, NULL, APR_LOCK_DEFAULT, mp);
-    if (rc != APR_SUCCESS) {
+    msce->dbm_lock = apr_pcalloc(mp, sizeof(struct waf_lock));
+    rc = Waf_createLock(msce->dbm_lock, "dbm_lock", strlen("dbm_lock"), msc_waf_lock_owner);    
+    if (Waf_lock_isError(rc)) {
         return -1;
     }
-
-#ifdef __SET_MUTEX_PERMS
-#if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER > 2
-    rc = ap_unixd_set_global_mutex_perms(msce->dbm_lock);
-#else
-    rc = unixd_set_global_mutex_perms(msce->dbm_lock);
-#endif
-    if (rc != APR_SUCCESS) {
-        return -1;
-    }
-#endif /* SET_MUTEX_PERMS */
-#endif
 #endif
 
     return 1;
@@ -241,40 +193,32 @@ int modsecurity_init(msc_engine *msce, apr_pool_t *mp) {
 /**
  * Performs per-child (new process) initialisation.
  */
-void modsecurity_child_init(msc_engine *msce) {
+void modsecurity_child_init(apr_pool_t *mp, msc_engine *msce) {
     /* Need to call this once per process before any other XML calls. */
     xmlInitParser();
 
-    if (msce->auditlog_lock != NULL) {
-        apr_status_t rc = apr_global_mutex_child_init(&msce->auditlog_lock, NULL, msce->mp);
-        if (rc != APR_SUCCESS) {
-            // ap_log_error(APLOG_MARK, APLOG_ERR, rs, s, "Failed to child-init auditlog mutex");
-        }
+    if (msce->auditlog_lock == NULL) {
+        msce->auditlog_lock = apr_pcalloc(mp, sizeof(struct waf_lock));
     }
+    Waf_createLock(msce->auditlog_lock, "auditlog_lock", strlen("auditlog_lock"), msc_waf_lock_owner);
 
 #ifdef WAF_JSON_LOGGING_ENABLE
-    if (msce->wafjsonlog_lock != NULL) {
-        apr_status_t rc = apr_global_mutex_child_init(&msce->wafjsonlog_lock, NULL, msce->mp);
-        if (rc != APR_SUCCESS) {
-            // ap_log_error(APLOG_MARK, APLOG_ERR, rs, s, "Failed to child-init auditlog mutex");
-        }
+    if (msce->wafjsonlog_lock == NULL) {
+        msce->wafjsonlog_lock = apr_pcalloc(mp, sizeof(struct waf_lock));
     }
+    Waf_createLock(msce->wafjsonlog_lock, "wafjsonlog_lock", strlen("wafjsonlog_lock"), msc_waf_lock_owner);
 #endif
 
     if (msce->geo_lock != NULL) {
-        apr_status_t rc = apr_global_mutex_child_init(&msce->geo_lock, NULL, msce->mp);
-        if (rc != APR_SUCCESS) {
-            // ap_log_error(APLOG_MARK, APLOG_ERR, rs, s, "Failed to child-init geo mutex");
-        }
+        msce->geo_lock = apr_pcalloc(mp, sizeof(struct waf_lock));
     }
+    Waf_createLock(msce->geo_lock, "geo_lock", strlen("geo_lock"), msc_waf_lock_owner);
 
 #ifdef GLOBAL_COLLECTION_LOCK
-    if (msce->dbm_lock != NULL) {
-        apr_status_t rc = apr_global_mutex_child_init(&msce->dbm_lock, NULL, msce->mp);
-        if (rc != APR_SUCCESS) {
-            // ap_log_error(APLOG_MARK, APLOG_ERR, rs, s, "Failed to child-init dbm mutex");
-        }
+    if (msce->dbm_lock == NULL) {
+        msce->dbm_lock = apr_pcalloc(mp, sizeof(struct waf_lock));
     }
+    Waf_createLock(msce->dbm_lock, "dbm_lock", strlen("dbm_lock"), msc_waf_lock_owner);
 #endif
 
 }

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -56,6 +56,7 @@ typedef struct msc_parm msc_parm;
 #include "http_config.h"
 #include "http_log.h"
 #include "http_protocol.h"
+#include "waf_lock_external.h"
 
 #if defined(WITH_LUA)
 #include "msc_lua.h"
@@ -170,8 +171,8 @@ extern DSOLOCAL int *unicode_map_table;
 #ifdef WAF_JSON_LOGGING_ENABLE
 extern DSOLOCAL char *msc_waf_resourceId;
 extern DSOLOCAL char *msc_waf_instanceId;
-extern DSOLOCAL char *msc_waf_lock_owner;
 #endif
+extern DSOLOCAL char *msc_waf_lock_owner;
 
 #define RESBODY_STATUS_NOT_READ         0   /* we were not configured to read the body */
 #define RESBODY_STATUS_ERROR            1   /* error occured while we were reading the body */
@@ -674,13 +675,13 @@ struct error_message_t {
 
 struct msc_engine {
     apr_pool_t              *mp;
-    apr_global_mutex_t      *auditlog_lock;
+    struct waf_lock         *auditlog_lock;
 #ifdef WAF_JSON_LOGGING_ENABLE
-    apr_global_mutex_t      *wafjsonlog_lock;
+    struct waf_lock         *wafjsonlog_lock;
 #endif
-    apr_global_mutex_t      *geo_lock;
+    struct waf_lock         *geo_lock;
 #ifdef GLOBAL_COLLECTION_LOCK
-    apr_global_mutex_t      *dbm_lock;
+    struct waf_lock         *dbm_lock;
 #endif
     msre_engine             *msre;
     unsigned int             processing_mode;
@@ -723,7 +724,7 @@ msc_engine DSOLOCAL *modsecurity_create(apr_pool_t *mp, int processing_mode);
 
 int DSOLOCAL modsecurity_init(msc_engine *msce, apr_pool_t *mp);
 
-void DSOLOCAL modsecurity_child_init(msc_engine *msce);
+void DSOLOCAL modsecurity_child_init(apr_pool_t *mp, msc_engine *msce);
 
 void DSOLOCAL modsecurity_shutdown(msc_engine *msce);
 

--- a/apache2/msc_geo.c
+++ b/apache2/msc_geo.c
@@ -13,6 +13,7 @@
 */
 
 #include "msc_geo.h"
+#include "waf_lock_external.h"
 
 
 /* -- Lookup Tables -- */
@@ -315,9 +316,9 @@ int geo_lookup(modsec_rec *msr, geo_rec *georec, const char *target, char **erro
         msr_log(msr, 9, "GEO: Using address \"%s\" (0x%08lx). %lu", targetip, ipnum, ipnum);
     }
 
-    ret = apr_global_mutex_lock(msr->modsecurity->geo_lock);
-    if (ret != APR_SUCCESS) {
-        msr_log(msr, 1, "Geo Lookup: Failed to lock proc mutex: %s",
+    ret = Waf_getExclusiveLock(msr->modsecurity->geo_lock);
+    if (Waf_lock_isError(ret)) {
+        msr_log(msr, 1, "Geo Lookup: Failed to lock: %s",
                 get_apr_error(msr->mp, ret));
     }
 
@@ -352,9 +353,9 @@ int geo_lookup(modsec_rec *msr, geo_rec *georec, const char *target, char **erro
         *error_msg = apr_psprintf(msr->mp, "No geo data for \"%s\").", log_escape(msr->mp, target));
         msr_log(msr, 4, "%s", *error_msg);
 
-        ret = apr_global_mutex_unlock(msr->modsecurity->geo_lock);
-        if (ret != APR_SUCCESS) {
-            msr_log(msr, 1, "Geo Lookup: Failed to lock proc mutex: %s",
+        ret = Waf_freeExclusiveLock(msr->modsecurity->geo_lock);
+        if (Waf_lock_isError(ret)) {
+            msr_log(msr, 1, "Geo Lookup: Failed to unlock: %s",
                     get_apr_error(msr->mp, ret));
         }
 
@@ -368,9 +369,9 @@ int geo_lookup(modsec_rec *msr, geo_rec *georec, const char *target, char **erro
             *error_msg = apr_psprintf(msr->mp, "No geo data for \"%s\" (country %d).", log_escape(msr->mp, target), country);
             msr_log(msr, 4, "%s", *error_msg);
 
-            ret = apr_global_mutex_unlock(msr->modsecurity->geo_lock);
-            if (ret != APR_SUCCESS) {
-                msr_log(msr, 1, "Geo Lookup: Failed to lock proc mutex: %s",
+            ret = Waf_freeExclusiveLock(msr->modsecurity->geo_lock);
+            if (Waf_lock_isError(ret)) {
+                msr_log(msr, 1, "Geo Lookup: Failed to unlock: %s",
                         get_apr_error(msr->mp, ret));
             }
 
@@ -399,9 +400,9 @@ int geo_lookup(modsec_rec *msr, geo_rec *georec, const char *target, char **erro
             *error_msg = apr_psprintf(msr->mp, "No geo data for \"%s\" (country %d).", log_escape(msr->mp, target), country);
             msr_log(msr, 4, "%s", *error_msg);
 
-            ret = apr_global_mutex_unlock(msr->modsecurity->geo_lock);
-            if (ret != APR_SUCCESS) {
-                msr_log(msr, 1, "Geo Lookup: Failed to lock proc mutex: %s",
+            ret = Waf_freeExclusiveLock(msr->modsecurity->geo_lock);
+            if (Waf_lock_isError(ret)) {
+                msr_log(msr, 1, "Geo Lookup: Failed to unlock: %s",
                         get_apr_error(msr->mp, ret));
             }
 
@@ -494,9 +495,9 @@ int geo_lookup(modsec_rec *msr, geo_rec *georec, const char *target, char **erro
 
     *error_msg = apr_psprintf(msr->mp, "Geo lookup for \"%s\" succeeded.", log_escape(msr->mp, target));
 
-    ret = apr_global_mutex_unlock(msr->modsecurity->geo_lock);
-    if (ret != APR_SUCCESS) {
-        msr_log(msr, 1, "Geo Lookup: Failed to lock proc mutex: %s",
+    ret = Waf_freeExclusiveLock(msr->modsecurity->geo_lock);
+    if (Waf_lock_isError(ret)) {
+        msr_log(msr, 1, "Geo Lookup: Failed to unlock: %s",
                 get_apr_error(msr->mp, ret));
     }
 

--- a/apache2/msc_logging.c
+++ b/apache2/msc_logging.c
@@ -29,6 +29,7 @@
 #include <yajl/yajl_gen.h>
 #include "msc_logging_json.h"
 #endif
+#include "waf_lock_external.h"
 
 /**
  * Write the supplied data to the audit log (if the FD is ready), update
@@ -734,9 +735,9 @@ void sec_audit_logger_json(modsec_rec *msr) {
 
     /* Lock the mutex, but only if we are using serial format. */
     if (msr->txcfg->auditlog_type != AUDITLOG_CONCURRENT) {
-        rc = apr_global_mutex_lock(msr->modsecurity->auditlog_lock);
-        if (rc != APR_SUCCESS) {
-            msr_log(msr, 1, "Audit log: Failed to lock global mutex: %s",
+	rc = Waf_getExclusiveLock(msr->modsecurity->auditlog_lock);
+        if (Waf_lock_isError(rc)) {
+            msr_log(msr, 1, "Audit log: Failed to lock: %s",
                 get_apr_error(msr->mp, rc));
         }
     }
@@ -1446,9 +1447,9 @@ void sec_audit_logger_json(modsec_rec *msr) {
     if (msr->txcfg->auditlog_type != AUDITLOG_CONCURRENT) {
 
         /* Unlock the mutex we used to serialise access to the audit log file. */
-        rc = apr_global_mutex_unlock(msr->modsecurity->auditlog_lock);
-        if (rc != APR_SUCCESS) {
-            msr_log(msr, 1, "Audit log: Failed to unlock global mutex: %s",
+	rc = Waf_freeExclusiveLock(msr->modsecurity->auditlog_lock);
+        if (Waf_lock_isError(rc)) {
+            msr_log(msr, 1, "Audit log: Failed to unlock: %s",
                     get_apr_error(msr->mp, rc));
         }
 
@@ -1621,9 +1622,9 @@ void sec_audit_logger_native(modsec_rec *msr) {
 
     /* Lock the mutex, but only if we are using serial format. */
     if (msr->txcfg->auditlog_type != AUDITLOG_CONCURRENT) {
-        rc = apr_global_mutex_lock(msr->modsecurity->auditlog_lock);
-        if (rc != APR_SUCCESS) {
-            msr_log(msr, 1, "Audit log: Failed to lock global mutex: %s",
+	rc = Waf_getExclusiveLock(msr->modsecurity->auditlog_lock);
+        if (Waf_lock_isError(rc)) {
+            msr_log(msr, 1, "Audit log: Failed to lock: %s",
                 get_apr_error(msr->mp, rc));
         }
     }
@@ -2226,9 +2227,9 @@ void sec_audit_logger_native(modsec_rec *msr) {
         sec_auditlog_write(msr, "\n", 1);
 
         /* Unlock the mutex we used to serialise access to the audit log file. */
-        rc = apr_global_mutex_unlock(msr->modsecurity->auditlog_lock);
-        if (rc != APR_SUCCESS) {
-            msr_log(msr, 1, "Audit log: Failed to unlock global mutex: %s",
+	rc = Waf_freeExclusiveLock(msr->modsecurity->auditlog_lock);
+        if (Waf_lock_isError(rc)) {
+            msr_log(msr, 1, "Audit log: Failed to unlock: %s",
                     get_apr_error(msr->mp, rc));
         }
 

--- a/apache2/persist_dbm.c
+++ b/apache2/persist_dbm.c
@@ -172,7 +172,7 @@ static apr_table_t *collection_retrieve_ex(int db_option, void *existing_dbm, mo
         if (existing_dbm == NULL) {
 #ifdef GLOBAL_COLLECTION_LOCK
 	    rc = WAF_getExclusiveLock(msr->modsecurity->dbm_lock);
-            if (rc != WAF_LOCK_SUCCESS) {
+            if (Waf_lock_isError(rc)) {
                 msr_log(msr, 1, "collection_retrieve_ex: Failed to lock: %s",
                         get_apr_error(msr->mp, rc));
                 goto cleanup;
@@ -340,7 +340,7 @@ static apr_table_t *collection_retrieve_ex(int db_option, void *existing_dbm, mo
             if (existing_dbm == NULL) {
 #ifdef GLOBAL_COLLECTION_LOCK
 	        rc = WAF_getExclusiveLock(msr->modsecurity->dbm_lock);
-                if (rc != WAF_LOCK_SUCCESS) {
+                if (Waf_lock_isError(rc)) {
                     msr_log(msr, 1, "collection_retrieve_ex: Failed to lock: %s",
                             get_apr_error(msr->mp, rc));
                     goto cleanup;
@@ -645,7 +645,7 @@ static int collection_store_ex(int db_option, modsec_rec *msr, apr_table_t *col)
 #ifdef GLOBAL_COLLECTION_LOCK
         /* Need to lock to pull in the stored data again and apply deltas. */
 	rc = WAF_getExclusiveLock(msr->modsecurity->dbm_lock);
-        if (rc != WAF_LOCK_SUCCESS) {
+        if (Waf_lock_isError(rc)) {
             msr_log(msr, 1, "collection_retrieve_ex: Failed to lock: %s",
                     get_apr_error(msr->mp, rc));
             goto error;
@@ -973,7 +973,7 @@ static int collections_remove_stale_ex(int db_option, modsec_rec *msr, const cha
 
 #ifdef GLOBAL_COLLECTION_LOCK
     rc = WAF_getExclusiveLock(msr->modsecurity->dbm_lock);
-    if (rc != WAF_LOCK_SUCCESS) {
+    if (Waf_lock_isError(rc)) {
         msr_log(msr, 1, "collection_retrieve_ex: Failed to lock: %s",
                 get_apr_error(msr->mp, rc));
         goto error;

--- a/apache2/persist_dbm.c
+++ b/apache2/persist_dbm.c
@@ -17,6 +17,7 @@
 #ifdef MEMORY_DATABASE_ENABLE
 #include "ag_mdb_external.h"
 #endif
+#include "waf_lock_external.h"
 
 #ifdef MEMORY_DATABASE_ENABLE
 void* dcfg_searchAGMDBhandler(const char* col_name, struct agmdb_handle_entry *handles){
@@ -170,9 +171,9 @@ static apr_table_t *collection_retrieve_ex(int db_option, void *existing_dbm, mo
         
         if (existing_dbm == NULL) {
 #ifdef GLOBAL_COLLECTION_LOCK
-            rc = apr_global_mutex_lock(msr->modsecurity->dbm_lock);
-            if (rc != APR_SUCCESS) {
-                msr_log(msr, 1, "collection_retrieve_ex: Failed to lock proc mutex: %s",
+	    rc = WAF_getExclusiveLock(msr->modsecurity->dbm_lock);
+            if (rc != WAF_LOCK_SUCCESS) {
+                msr_log(msr, 1, "collection_retrieve_ex: Failed to lock: %s",
                         get_apr_error(msr->mp, rc));
                 goto cleanup;
             }
@@ -182,7 +183,7 @@ static apr_table_t *collection_retrieve_ex(int db_option, void *existing_dbm, mo
             if (rc != APR_SUCCESS) {
                 apr_dbm = NULL;
 #ifdef GLOBAL_COLLECTION_LOCK
-                apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+		WAF_freeExclusiveLock(msr->modsecurity->dbm_lock);
 #endif
                 goto cleanup;
             }
@@ -255,7 +256,7 @@ static apr_table_t *collection_retrieve_ex(int db_option, void *existing_dbm, mo
         if (existing_dbm == NULL) {
             apr_sdbm_close(apr_dbm);
 #ifdef GLOBAL_COLLECTION_LOCK
-            apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+	    WAF_freeExclusiveLock(msr->modsecurity->dbm_lock);
 #endif
             apr_dbm = NULL;
         }
@@ -338,9 +339,9 @@ static apr_table_t *collection_retrieve_ex(int db_option, void *existing_dbm, mo
 #endif
             if (existing_dbm == NULL) {
 #ifdef GLOBAL_COLLECTION_LOCK
-                rc = apr_global_mutex_lock(msr->modsecurity->dbm_lock);
-                if (rc != APR_SUCCESS) {
-                    msr_log(msr, 1, "collection_retrieve_ex: Failed to lock proc mutex: %s",
+	        rc = WAF_getExclusiveLock(msr->modsecurity->dbm_lock);
+                if (rc != WAF_LOCK_SUCCESS) {
+                    msr_log(msr, 1, "collection_retrieve_ex: Failed to lock: %s",
                             get_apr_error(msr->mp, rc));
                     goto cleanup;
                 }
@@ -352,7 +353,7 @@ static apr_table_t *collection_retrieve_ex(int db_option, void *existing_dbm, mo
                         log_escape(msr->mp, dbm_filename), get_apr_error(msr->mp, rc));
                     apr_dbm = NULL;
 #ifdef GLOBAL_COLLECTION_LOCK
-                    apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+	            WAF_freeExclusiveLock(msr->modsecurity->dbm_lock);
 #endif
                     goto cleanup;
                 }
@@ -367,7 +368,7 @@ static apr_table_t *collection_retrieve_ex(int db_option, void *existing_dbm, mo
             if (existing_dbm == NULL) {
                 apr_sdbm_close(apr_dbm);
 #ifdef GLOBAL_COLLECTION_LOCK
-                apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+	        WAF_freeExclusiveLock(msr->modsecurity->dbm_lock);
 #endif
                 apr_dbm = NULL;
             }
@@ -450,7 +451,7 @@ static apr_table_t *collection_retrieve_ex(int db_option, void *existing_dbm, mo
 
         apr_sdbm_close(apr_dbm);
 #ifdef GLOBAL_COLLECTION_LOCK
-        apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+	WAF_freeExclusiveLock(msr->modsecurity->dbm_lock);
 #endif
     }
 
@@ -465,7 +466,7 @@ cleanup:
         if ((existing_dbm == NULL) && apr_dbm) {
             apr_sdbm_close(apr_dbm);
 #ifdef GLOBAL_COLLECTION_LOCK
-            apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+	    WAF_freeExclusiveLock(msr->modsecurity->dbm_lock);
 #endif
         }
 #ifdef MEMORY_DATABASE_ENABLE
@@ -643,9 +644,9 @@ static int collection_store_ex(int db_option, modsec_rec *msr, apr_table_t *col)
         
 #ifdef GLOBAL_COLLECTION_LOCK
         /* Need to lock to pull in the stored data again and apply deltas. */
-        rc = apr_global_mutex_lock(msr->modsecurity->dbm_lock);
-        if (rc != APR_SUCCESS) {
-            msr_log(msr, 1, "collection_store: Failed to lock proc mutex: %s",
+	rc = WAF_getExclusiveLock(msr->modsecurity->dbm_lock);
+        if (rc != WAF_LOCK_SUCCESS) {
+            msr_log(msr, 1, "collection_retrieve_ex: Failed to lock: %s",
                     get_apr_error(msr->mp, rc));
             goto error;
         }
@@ -655,7 +656,7 @@ static int collection_store_ex(int db_option, modsec_rec *msr, apr_table_t *col)
             CREATEMODE, msr->mp);
         if (rc != APR_SUCCESS) {
 #ifdef GLOBAL_COLLECTION_LOCK
-            apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+	    WAF_freeExclusiveLock(msr->modsecurity->dbm_lock);
 #endif
             msr_log(msr, 1, "collection_store_ex_origin: Failed to access DBM file \"%s\": %s", log_escape(msr->mp, dbm_filename),
                 get_apr_error(msr->mp, rc));
@@ -783,7 +784,7 @@ static int collection_store_ex(int db_option, modsec_rec *msr, apr_table_t *col)
             if (apr_dbm != NULL) {
 #ifdef GLOBAL_COLLECTION_LOCK
                 apr_sdbm_close(apr_dbm);
-                apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+	        WAF_freeExclusiveLock(msr->modsecurity->dbm_lock);
 #else
                 apr_sdbm_unlock(apr_dbm);
                 apr_sdbm_close(apr_dbm);
@@ -865,7 +866,7 @@ static int collection_store_ex(int db_option, modsec_rec *msr, apr_table_t *col)
             if (apr_dbm != NULL) {
 #ifdef GLOBAL_COLLECTION_LOCK
                 apr_sdbm_close(apr_dbm);
-                apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+	        WAF_freeExclusiveLock(msr->modsecurity->dbm_lock);
 #else
                 apr_sdbm_unlock(apr_dbm);
                 apr_sdbm_close(apr_dbm);
@@ -876,7 +877,7 @@ static int collection_store_ex(int db_option, modsec_rec *msr, apr_table_t *col)
         }
 #ifdef GLOBAL_COLLECTION_LOCK
         apr_sdbm_close(apr_dbm);
-        apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+	WAF_freeExclusiveLock(msr->modsecurity->dbm_lock);
 #else
         apr_sdbm_unlock(apr_dbm);
         apr_sdbm_close(apr_dbm);
@@ -971,9 +972,9 @@ static int collections_remove_stale_ex(int db_option, modsec_rec *msr, const cha
     }
 
 #ifdef GLOBAL_COLLECTION_LOCK
-    rc = apr_global_mutex_lock(msr->modsecurity->dbm_lock);
-    if (rc != APR_SUCCESS) {
-        msr_log(msr, 1, "collections_remove_stale: Failed to lock proc mutex: %s",
+    rc = WAF_getExclusiveLock(msr->modsecurity->dbm_lock);
+    if (rc != WAF_LOCK_SUCCESS) {
+        msr_log(msr, 1, "collection_retrieve_ex: Failed to lock: %s",
                 get_apr_error(msr->mp, rc));
         goto error;
     }
@@ -982,7 +983,7 @@ static int collections_remove_stale_ex(int db_option, modsec_rec *msr, const cha
             CREATEMODE, msr->mp);
     if (rc != APR_SUCCESS) {
 #ifdef GLOBAL_COLLECTION_LOCK
-        apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+	WAF_freeExclusiveLock(msr->modsecurity->dbm_lock);
 #endif
         msr_log(msr, 1, "collections_remove_stale: Failed to access DBM file \"%s\": %s", log_escape(msr->mp, dbm_filename),
                 get_apr_error(msr->mp, rc));
@@ -1085,7 +1086,7 @@ static int collections_remove_stale_ex(int db_option, modsec_rec *msr, const cha
 
     apr_sdbm_close(apr_dbm);
 #ifdef GLOBAL_COLLECTION_LOCK
-    apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+    WAF_freeExclusiveLock(msr->modsecurity->dbm_lock);
 #endif
     return 1;
 
@@ -1094,7 +1095,7 @@ error:
     if (apr_dbm) {
         apr_sdbm_close(apr_dbm);
 #ifdef GLOBAL_COLLECTION_LOCK
-        apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+        WAF_freeExclusiveLock(msr->modsecurity->dbm_lock);
 #endif
     }
     return -1;

--- a/apache2/waf_lock/murmur3.c
+++ b/apache2/waf_lock/murmur3.c
@@ -1,0 +1,319 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+// Note - The x86 and x64 versions do _not_ produce the same results, as the
+// algorithms are optimized for their respective platforms. You can still
+// compile and run any of them on any platform, but your performance with the
+// non-native version will be less than optimal.
+
+#include "murmur3.h"
+
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+#ifdef _MSC_VER
+#define FORCE_INLINE __forceinline
+#elif defined(__GNUC__)
+#define FORCE_INLINE __attribute__((always_inline)) inline
+#else
+#define FORCE_INLINE inline
+#endif
+
+static FORCE_INLINE uint32_t rotl32 ( uint32_t x, int8_t r )
+{
+  return (x << r) | (x >> (32 - r));
+}
+
+static FORCE_INLINE uint64_t rotl64 ( uint64_t x, int8_t r )
+{
+  return (x << r) | (x >> (64 - r));
+}
+
+#define	ROTL32(x,y)	rotl32(x,y)
+#define ROTL64(x,y)	rotl64(x,y)
+
+#define BIG_CONSTANT(x) (x##LLU)
+
+//-----------------------------------------------------------------------------
+// Block read - if your platform needs to do endian-swapping or can only
+// handle aligned reads, do the conversion here
+
+#define getblock(p, i) (p[i])
+
+//-----------------------------------------------------------------------------
+// Finalization mix - force all bits of a hash block to avalanche
+
+static FORCE_INLINE uint32_t fmix32 ( uint32_t h )
+{
+  h ^= h >> 16;
+  h *= 0x85ebca6b;
+  h ^= h >> 13;
+  h *= 0xc2b2ae35;
+  h ^= h >> 16;
+
+  return h;
+}
+
+//----------
+
+static FORCE_INLINE uint64_t fmix64 ( uint64_t k )
+{
+  k ^= k >> 33;
+  k *= BIG_CONSTANT(0xff51afd7ed558ccd);
+  k ^= k >> 33;
+  k *= BIG_CONSTANT(0xc4ceb9fe1a85ec53);
+  k ^= k >> 33;
+
+  return k;
+}
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x86_32 ( const void * key, int len,
+                          uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 4;
+  int i;
+
+  uint32_t h1 = seed;
+
+  uint32_t c1 = 0xcc9e2d51;
+  uint32_t c2 = 0x1b873593;
+
+  //----------
+  // body
+
+  const uint32_t * blocks = (const uint32_t *)(data + nblocks*4);
+
+  for(i = -nblocks; i; i++)
+  {
+    uint32_t k1 = getblock(blocks,i);
+
+    k1 *= c1;
+    k1 = ROTL32(k1,15);
+    k1 *= c2;
+    
+    h1 ^= k1;
+    h1 = ROTL32(h1,13); 
+    h1 = h1*5+0xe6546b64;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*4);
+
+  uint32_t k1 = 0;
+
+  switch(len & 3)
+  {
+  case 3: k1 ^= tail[2] << 16;
+  case 2: k1 ^= tail[1] << 8;
+  case 1: k1 ^= tail[0];
+          k1 *= c1; k1 = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len;
+
+  h1 = fmix32(h1);
+
+  *(uint32_t*)out = h1;
+} 
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x86_128 ( const void * key, int len,
+                           uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 16;
+  int i;
+
+  uint32_t h1 = seed;
+  uint32_t h2 = seed;
+  uint32_t h3 = seed;
+  uint32_t h4 = seed;
+
+  uint32_t c1 = 0x239b961b; 
+  uint32_t c2 = 0xab0e9789;
+  uint32_t c3 = 0x38b34ae5; 
+  uint32_t c4 = 0xa1e38b93;
+
+  //----------
+  // body
+
+  const uint32_t * blocks = (const uint32_t *)(data + nblocks*16);
+
+  for(i = -nblocks; i; i++)
+  {
+    uint32_t k1 = getblock(blocks,i*4+0);
+    uint32_t k2 = getblock(blocks,i*4+1);
+    uint32_t k3 = getblock(blocks,i*4+2);
+    uint32_t k4 = getblock(blocks,i*4+3);
+
+    k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+
+    h1 = ROTL32(h1,19); h1 += h2; h1 = h1*5+0x561ccd1b;
+
+    k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
+
+    h2 = ROTL32(h2,17); h2 += h3; h2 = h2*5+0x0bcaa747;
+
+    k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
+
+    h3 = ROTL32(h3,15); h3 += h4; h3 = h3*5+0x96cd1c35;
+
+    k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
+
+    h4 = ROTL32(h4,13); h4 += h1; h4 = h4*5+0x32ac3b17;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*16);
+
+  uint32_t k1 = 0;
+  uint32_t k2 = 0;
+  uint32_t k3 = 0;
+  uint32_t k4 = 0;
+
+  switch(len & 15)
+  {
+  case 15: k4 ^= tail[14] << 16;
+  case 14: k4 ^= tail[13] << 8;
+  case 13: k4 ^= tail[12] << 0;
+           k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
+
+  case 12: k3 ^= tail[11] << 24;
+  case 11: k3 ^= tail[10] << 16;
+  case 10: k3 ^= tail[ 9] << 8;
+  case  9: k3 ^= tail[ 8] << 0;
+           k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
+
+  case  8: k2 ^= tail[ 7] << 24;
+  case  7: k2 ^= tail[ 6] << 16;
+  case  6: k2 ^= tail[ 5] << 8;
+  case  5: k2 ^= tail[ 4] << 0;
+           k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
+
+  case  4: k1 ^= tail[ 3] << 24;
+  case  3: k1 ^= tail[ 2] << 16;
+  case  2: k1 ^= tail[ 1] << 8;
+  case  1: k1 ^= tail[ 0] << 0;
+           k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len; h2 ^= len; h3 ^= len; h4 ^= len;
+
+  h1 += h2; h1 += h3; h1 += h4;
+  h2 += h1; h3 += h1; h4 += h1;
+
+  h1 = fmix32(h1);
+  h2 = fmix32(h2);
+  h3 = fmix32(h3);
+  h4 = fmix32(h4);
+
+  h1 += h2; h1 += h3; h1 += h4;
+  h2 += h1; h3 += h1; h4 += h1;
+
+  ((uint32_t*)out)[0] = h1;
+  ((uint32_t*)out)[1] = h2;
+  ((uint32_t*)out)[2] = h3;
+  ((uint32_t*)out)[3] = h4;
+}
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x64_128 ( const void * key, int len,
+                           uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 16;
+  int i;
+
+  uint64_t h1 = seed;
+  uint64_t h2 = seed;
+
+  uint64_t c1 = BIG_CONSTANT(0x87c37b91114253d5);
+  uint64_t c2 = BIG_CONSTANT(0x4cf5ad432745937f);
+
+  //----------
+  // body
+
+  const uint64_t * blocks = (const uint64_t *)(data);
+
+  for(i = 0; i < nblocks; i++)
+  {
+    uint64_t k1 = getblock(blocks,i*2+0);
+    uint64_t k2 = getblock(blocks,i*2+1);
+
+    k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+
+    h1 = ROTL64(h1,27); h1 += h2; h1 = h1*5+0x52dce729;
+
+    k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+
+    h2 = ROTL64(h2,31); h2 += h1; h2 = h2*5+0x38495ab5;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*16);
+
+  uint64_t k1 = 0;
+  uint64_t k2 = 0;
+
+  switch(len & 15)
+  {
+  case 15: k2 ^= (uint64_t)(tail[14]) << 48;
+  case 14: k2 ^= (uint64_t)(tail[13]) << 40;
+  case 13: k2 ^= (uint64_t)(tail[12]) << 32;
+  case 12: k2 ^= (uint64_t)(tail[11]) << 24;
+  case 11: k2 ^= (uint64_t)(tail[10]) << 16;
+  case 10: k2 ^= (uint64_t)(tail[ 9]) << 8;
+  case  9: k2 ^= (uint64_t)(tail[ 8]) << 0;
+           k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+
+  case  8: k1 ^= (uint64_t)(tail[ 7]) << 56;
+  case  7: k1 ^= (uint64_t)(tail[ 6]) << 48;
+  case  6: k1 ^= (uint64_t)(tail[ 5]) << 40;
+  case  5: k1 ^= (uint64_t)(tail[ 4]) << 32;
+  case  4: k1 ^= (uint64_t)(tail[ 3]) << 24;
+  case  3: k1 ^= (uint64_t)(tail[ 2]) << 16;
+  case  2: k1 ^= (uint64_t)(tail[ 1]) << 8;
+  case  1: k1 ^= (uint64_t)(tail[ 0]) << 0;
+           k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len; h2 ^= len;
+
+  h1 += h2;
+  h2 += h1;
+
+  h1 = fmix64(h1);
+  h2 = fmix64(h2);
+
+  h1 += h2;
+  h2 += h1;
+
+  ((uint64_t*)out)[0] = h1;
+  ((uint64_t*)out)[1] = h2;
+}
+
+//-----------------------------------------------------------------------------
+

--- a/apache2/waf_lock/murmur3.h
+++ b/apache2/waf_lock/murmur3.h
@@ -1,0 +1,31 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the
+// public domain. The author hereby disclaims copyright to this source
+// code.
+
+#ifndef _MURMURHASH3_H_
+#define _MURMURHASH3_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x86_32 (const void *key, int len, uint32_t seed, void *out);
+
+void MurmurHash3_x86_128(const void *key, int len, uint32_t seed, void *out);
+
+void MurmurHash3_x64_128(const void *key, int len, uint32_t seed, void *out);
+
+//-----------------------------------------------------------------------------
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _MURMURHASH3_H_

--- a/apache2/waf_lock/waf_lock.cpp
+++ b/apache2/waf_lock/waf_lock.cpp
@@ -1,0 +1,533 @@
+#include"waf_lock_external.h"
+#include"waf_lock_internal.h"
+
+
+/**
+**========================================================
+** Waf Lock Internal Function
+**========================================================
+*/
+
+/**
+** Create and initialize a waf_lock, if the lock with given key exists, just link to the lock.
+** The new_lock should have been created before calling this function.
+** @param new_lock:        The pointer to save the information of the lock.
+** @param lock_name:       The name of lock.
+** @param lock_name_length:The length of the lock_name.
+** return: WAF_SUCCESS_LOCK_CREATE if successfully created a new lock,
+**         WAF_SUCCESS_LOCK_OPEN if successfully link to an existed lock,
+**         WAF_LOCK_ERROR if failed.
+*/
+int lock_create(struct waf_lock *new_lock, const char* lock_name, int lock_name_length, const char* owner) {
+#ifndef _WIN32
+    union semun sem_union;
+    int lock_id = -1;
+    uid_t uid;
+    gid_t gid;
+#else
+    int read_lock_name_len = 0;
+    int write_lock_name_len = 0;
+    char* read_lock_name = NULL;
+    char* write_lock_name = NULL;
+    bool lock_exists = false;
+#endif
+    if (new_lock == NULL)
+        return WAF_LOCK_ERROR_HANDLE_NULL;
+#ifndef _WIN32
+    lock_id = Waf_lock_hash(lock_name, lock_name_length, DEFAULT_WAF_LOCK_ID_RANGE);
+    new_lock->sem_id = semget(lock_id, SEM_NUMBERS, IPC_CREAT | IPC_EXCL);
+    if (new_lock->sem_id != -1) {
+        // A new semaphore set is created, need to initialize the semaphore set
+	// Set permssion
+	struct semid_ds buf;
+	if ((GetUserId(owner, &uid) == WAF_LOCK_ERROR) || (GetGroupId(owner, &gid) == WAF_LOCK_ERROR)) {
+            lock_destroy(new_lock);
+            return WAF_ERROR_LOCK_LINUX_SEM_GET_USER_FAIL;
+	}
+
+	buf.sem_perm.uid = uid; 
+	buf.sem_perm.gid = gid; 
+	buf.sem_perm.mode = 0600;
+	sem_union.buf = &buf;
+        if (semctl(new_lock->sem_id, 0, IPC_SET, sem_union) == -1) {
+            lock_destroy(new_lock);
+            return WAF_ERROR_LOCK_LINUX_SEM_SET_PERMISSION_FAIL;
+        }
+	
+        sem_union.val = SEM_READ_INITVAL;
+        if (semctl(new_lock->sem_id, SEM_ID_READ, SETVAL, sem_union) == -1) {
+            lock_destroy(new_lock);
+            return WAF_ERROR_LOCK_LINUX_SEM_CREATE_FAIL;
+        }
+
+        sem_union.val = SEM_WRITE_INITVAL;
+        if (semctl(new_lock->sem_id, SEM_ID_WRITE, SETVAL, sem_union) == -1) {
+            // If failed, destroy the lock
+            lock_destroy(new_lock);
+            return WAF_ERROR_LOCK_LINUX_SEM_INIT_FAIL;
+        }
+        return WAF_SUCCESS_LOCK_CREATE;
+    }
+    else {
+        new_lock->sem_id = semget(lock_id, SEM_NUMBERS, IPC_CREAT);
+        if (new_lock->sem_id == -1) {
+            return WAF_ERROR_LOCK_LINUX_SEM_OPEN_FAIL;
+        }
+        return WAF_SUCCESS_LOCK_OPEN;
+    }
+#else
+    read_lock_name_len = (strlen(READ_LOCK_SUFFIX) + strlen(lock_name) + 1) * sizeof(char);
+    write_lock_name_len = (strlen(WRITE_LOCK_SUFFIX) + strlen(lock_name) + 1) * sizeof(char);
+
+    if (Waf_lock_isstring(lock_name, lock_name_length) != WAF_LOCK_SUCCESS)
+        return WAF_ERROR_LOCK_WIN_NAME_INVALID_STRING;
+
+    read_lock_name = (char *)malloc(read_lock_name_len * sizeof(char));
+    sprintf_s(read_lock_name, read_lock_name_len, "%s%s", lock_name, READ_LOCK_SUFFIX);
+    new_lock->read_lock_handle = CreateMutex(
+        NULL,               // Default security settings.
+        FALSE,              // Do not take the lock after created.
+        read_lock_name);    // The name of read lock.
+    free(read_lock_name);
+
+    if (new_lock->read_lock_handle == NULL) {
+        new_lock->read_lock_handle = INVALID_HANDLE_VALUE;
+        return WAF_ERROR_LOCK_WIN_MUTEX_CREATE_FAIL;
+    }
+
+    if (GetLastError() == ERROR_ALREADY_EXISTS)
+        lock_exists = true;
+
+    write_lock_name = (char *)malloc(write_lock_name_len * sizeof(char));
+    sprintf_s(write_lock_name, write_lock_name_len, "%s%s", lock_name, WRITE_LOCK_SUFFIX);
+    new_lock->write_lock_handle = CreateMutex(
+        NULL,               // Default security settings.
+        FALSE,              // Do not take the lock after created.
+        write_lock_name);   // The name of write lock.
+    free(write_lock_name);
+
+    if (new_lock->write_lock_handle == NULL) {
+        CloseHandle(new_lock->read_lock_handle);
+        new_lock->read_lock_handle = INVALID_HANDLE_VALUE;
+        new_lock->write_lock_handle = INVALID_HANDLE_VALUE;
+        return WAF_ERROR_LOCK_WIN_MUTEX_CREATE_FAIL;
+    }
+
+    if ((GetLastError() == ERROR_ALREADY_EXISTS) != lock_exists) {
+        // One lock exists, another not.
+        CloseHandle(new_lock->read_lock_handle);
+        new_lock->read_lock_handle = INVALID_HANDLE_VALUE;
+        CloseHandle(new_lock->write_lock_handle);
+        new_lock->write_lock_handle = INVALID_HANDLE_VALUE;
+        return WAF_ERROR_LOCK_WIN_ONLY_ONE_LOCK_EXISTS;
+    }
+
+    if (lock_exists == true)
+        return WAF_SUCCESS_LOCK_OPEN;
+    else
+        return WAF_SUCCESS_LOCK_CREATE;
+#endif
+    // Should never get here
+    return WAF_SUCCESS_LOCK_CREATE;
+}
+
+/**
+** Destroy the lock
+** @param waf_lock: The waf_lock sturcture
+** return: WAF_LOCK_SUCCESS if successfully destroy the lock,
+**         WAF_LOCK_ERROR if failed.
+*/
+int lock_destroy(struct waf_lock *waf_lock) {
+    int rc = WAF_LOCK_SUCCESS;
+    if (waf_lock == NULL)
+        return WAF_LOCK_ERROR_HANDLE_NULL;
+    rc = lock_close(waf_lock);
+    if (Waf_lock_isError(rc))
+        return rc;
+#ifndef _WIN32
+    if (waf_lock->sem_id == -1)
+        return WAF_LOCK_SUCCESS;
+    rc = semctl(waf_lock->sem_id, 0, IPC_RMID);
+    if (rc == -1)
+        return WAF_ERROR_LOCK_LINUX_SEM_DESTROY_FAIL;
+    else
+        waf_lock->sem_id = -1;
+    return WAF_LOCK_SUCCESS;
+#else
+    /* Locks destroy doesn't support on Windows */
+    return WAF_ERROR_LOCK_WIN_DESTROY_NOT_SUPPORT;
+#endif
+}
+
+/**
+** Close the lock
+** @param waf_lock: The waf_lock sturcture
+** return: WAF_LOCK_SUCCESS if successfully close the lock,
+**         WAF_LOCK_ERROR if failed.
+*/
+int lock_close(struct waf_lock *waf_lock) {
+    if (waf_lock == NULL)
+        return WAF_LOCK_ERROR_HANDLE_NULL;
+    /* Linux doesn't do anything */
+#ifdef _WIN32
+    BOOL rc_read = 1;
+    BOOL rc_write = 1;
+    if (waf_lock->read_lock_handle != INVALID_HANDLE_VALUE)
+    {
+        rc_read = CloseHandle(waf_lock->read_lock_handle);
+        if (rc_read != 0)
+            waf_lock->read_lock_handle = INVALID_HANDLE_VALUE;
+    }
+
+    if (waf_lock->write_lock_handle != INVALID_HANDLE_VALUE)
+    {
+        rc_write = CloseHandle(waf_lock->write_lock_handle);
+        if (rc_write != 0)
+            waf_lock->write_lock_handle = INVALID_HANDLE_VALUE;
+    }
+
+    if (rc_read == 0 || rc_write == 0)
+        return WAF_ERROR_LOCK_WIN_CLOSE_MUTEX_FAIL;
+#endif
+    return WAF_LOCK_SUCCESS;
+}
+
+/**
+** Decrease a lock's value by a given number.
+** @param waf_lock: The waf_lock sturcture
+** @param index:   The index of atom lock (read or write) .
+** @param val:     The value you want to decrease from the lock.
+** return: WAF_LOCK_SUCCESS if success;
+**         or WAF_LOCK_ERROR if failed
+*/
+int lock_P(const struct waf_lock *waf_lock, int index, int val) {
+#ifndef _WIN32
+    struct sembuf sem_op;
+    if (val < 0)
+        return WAF_ERROR_LOCK_OP_NEGATIVE_VAL;
+
+    sem_op.sem_num = index;
+    sem_op.sem_op = -val;
+    sem_op.sem_flg = SEM_UNDO;
+    if (semop(waf_lock->sem_id, &sem_op, 1) == -1)
+        return WAF_ERROR_LOCK_LINUX_SEM_MODIFY_FAIL;
+    return WAF_LOCK_SUCCESS;
+#else
+    int rc;
+    HANDLE lock_handle;
+    if (val < 0)
+        return WAF_ERROR_LOCK_OP_NEGATIVE_VAL;
+
+    if (index == SEM_ID_READ)
+        lock_handle = waf_lock->read_lock_handle;
+    else
+        lock_handle = waf_lock->write_lock_handle;
+
+    if (lock_handle == INVALID_HANDLE_VALUE)
+        return WAF_ERROR_LOCK_WIN_GET_MUTEX_FAIL;
+
+    rc = WaitForSingleObject(lock_handle, INFINITE);
+    if (rc != WAIT_OBJECT_0)
+        return WAF_ERROR_LOCK_WIN_GET_MUTEX_FAIL;
+    return WAF_LOCK_SUCCESS;
+#endif
+}
+
+/**
+** Increase a lock's value by a given number.
+** @param waf_lock: The waf_lock sturcture
+** @param index:   The index of atom lock (read or write) .
+** @param val:     The value you want to add to the lock.
+** return: WAF_LOCK_SUCCESS if success;
+**         or WAF_LOCK_ERROR if failed
+*/
+int lock_V(const struct waf_lock *waf_lock, int index, int val) {
+#ifndef _WIN32
+    struct sembuf sem_op;
+    if (val < 0)
+        return WAF_ERROR_LOCK_OP_NEGATIVE_VAL;
+
+    sem_op.sem_num = index;
+    sem_op.sem_op = val;
+    sem_op.sem_flg = SEM_UNDO;
+    if (semop(waf_lock->sem_id, &sem_op, 1) == -1)
+        return WAF_ERROR_LOCK_LINUX_SEM_MODIFY_FAIL;
+    return WAF_LOCK_SUCCESS;
+#else
+    int rc;
+    HANDLE lock_handle;
+    if (val < 0)
+        return WAF_ERROR_LOCK_OP_NEGATIVE_VAL;
+
+    if (index == SEM_ID_READ)
+        lock_handle = waf_lock->read_lock_handle;
+    else
+        lock_handle = waf_lock->write_lock_handle;
+
+    if (lock_handle == INVALID_HANDLE_VALUE)
+        return WAF_ERROR_LOCK_WIN_RELEASE_MUTEX_FAIL;
+
+    rc = ReleaseMutex(lock_handle);
+    if (rc == 0)
+        return WAF_ERROR_LOCK_WIN_RELEASE_MUTEX_FAIL;
+    return WAF_LOCK_SUCCESS;
+#endif
+}
+
+/**
+** Check the string format.
+** @param str: the string you want to check.
+** @param str_len: given string length (not include '\0').
+** return: WAF_LOCK_SUCCESS if the string length equals str_len;
+**             WAF_LOCK_ERROR if not
+*/
+int Waf_lock_isstring(const char* str, int str_len) {
+    int i;
+    for (i = 0;i < str_len;i++)
+        if (str[i] == '\0')
+            return WAF_LOCK_ERROR;
+    if (str[i] != '\0')
+        return WAF_LOCK_ERROR;
+    return WAF_LOCK_SUCCESS;
+}
+
+/**
+** Check whether a return_code is an error.
+** @param return_code: the code returned by a Waf Lock function.
+** return: True if there is an error;
+False if not.
+*/
+bool Waf_lock_isError(int return_code) {
+    if (return_code < WAF_LOCK_ERROR)
+        return false;
+    else
+        return true;
+}
+
+/**
+** Use WAF lock's hash function to hash a string into an integer.
+** @param key: the key string.
+** @param key_len: the length of the key string.
+** @param output_val_range: the range of output value.
+** return: hash result if success
+**      or WAF_LOCK_ERROR if failed.
+*/
+unsigned int Waf_lock_hash(const char* key, int key_len, unsigned int output_val_range) {
+    unsigned char buf[DEFAULT_HASH_VALUE_STR_LENGTH] = { 0 };
+    unsigned int hash = 0;
+
+    MurmurHash3_x86_32(key, key_len, DEFAULT_HASH_MAGIC_SEED, buf);
+    hash = ((buf[0] << 24) + (buf[1] << 16) + (buf[2] << 8) + buf[3]) % (output_val_range);
+    return hash;
+}
+
+/**
+** Initialize the handle of Waf Lock.
+** @param waf_lock: the handle of Waf Lock.
+** return:  if WAF_LOCK_SUCCESS if success
+**          or WAF_LOCK_ERROR if the handle is NULL.
+*/
+int Waf_lock_init(struct waf_lock* waf_lock) {
+    if (waf_lock == NULL)
+        return WAF_LOCK_ERROR_HANDLE_NULL;
+#ifndef _WIN32
+    waf_lock->sem_id = -1;
+#else
+    waf_lock->read_lock_handle = INVALID_HANDLE_VALUE;
+    waf_lock->write_lock_handle = INVALID_HANDLE_VALUE;
+#endif
+    return WAF_LOCK_SUCCESS;
+}
+
+/**
+**========================================================
+** Waf Lock External Function
+**========================================================
+*/
+
+/**
+** Get a shared lock for read only.
+** @param waf_lock: lock handler you want to lock.
+** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+*/
+int Waf_getSharedLock(struct waf_lock *waf_lock) {
+    int rc;
+    if (waf_lock == NULL)
+        return WAF_LOCK_ERROR_HANDLE_NULL;
+
+    rc = lock_P(waf_lock, SEM_ID_WRITE, 1);
+    if (rc != WAF_LOCK_SUCCESS)
+        return rc;
+
+    rc = lock_P(waf_lock, SEM_ID_READ, 1);
+    if (rc != WAF_LOCK_SUCCESS) {
+        lock_V(waf_lock, SEM_ID_WRITE, 1);
+        return rc;
+    }
+
+    rc = lock_V(waf_lock, SEM_ID_WRITE, 1);
+    if (rc != WAF_LOCK_SUCCESS) {
+        lock_V(waf_lock, SEM_ID_READ, 1);
+        return rc;
+    }
+
+    return WAF_LOCK_SUCCESS;
+}
+
+/**
+** Get a exclusive lock for read and write.
+** @param waf_lock: the lock handler you want to return the lock.
+** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+*/
+int Waf_getExclusiveLock(struct waf_lock *waf_lock) {
+    int rc;
+    if (waf_lock == NULL)
+        return WAF_LOCK_ERROR_HANDLE_NULL;
+
+    rc = lock_P(waf_lock, SEM_ID_WRITE, 1);
+    if (rc != WAF_LOCK_SUCCESS)
+        return rc;
+
+    rc = lock_P(waf_lock, SEM_ID_READ, SEM_READ_INITVAL);
+    if (rc != WAF_LOCK_SUCCESS) {
+        lock_V(waf_lock, SEM_ID_WRITE, 1);
+        return rc;
+    }
+
+    return WAF_LOCK_SUCCESS;
+}
+
+/**
+** Free a shared lock that you have got before.
+** @param waf_lock: the lock handler you want to return the lock.
+** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+*/
+int Waf_freeSharedLock(struct waf_lock *waf_lock) {
+    int rc;
+    if (waf_lock == NULL)
+        return WAF_LOCK_ERROR_HANDLE_NULL;
+
+    rc = lock_V(waf_lock, SEM_ID_READ, 1);
+    if (rc != WAF_LOCK_SUCCESS)
+        return rc;
+
+    return WAF_LOCK_SUCCESS;
+}
+
+/**
+** Free a exclusive lock that you have got before.
+** @param waf_lock: the lock handler you want to return the lock.
+** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+*/
+int Waf_freeExclusiveLock(struct waf_lock *waf_lock) {
+    int rc;
+    if (waf_lock == NULL)
+        return WAF_LOCK_ERROR_HANDLE_NULL;
+
+    rc = lock_V(waf_lock, SEM_ID_READ, SEM_READ_INITVAL);
+    if (rc != WAF_LOCK_SUCCESS)
+        return rc;
+    rc = lock_V(waf_lock, SEM_ID_WRITE, 1);
+    if (rc != WAF_LOCK_SUCCESS)
+        return rc;
+
+    return WAF_LOCK_SUCCESS;
+}
+/**
+** Open a Lock with given name, and intialize the lock handler for further operation.
+** If the lock doesn't exist, a new lock will be created.
+** @param lock: a created sturcture to save the lock information.
+** @param lock_name: the unique identifier of a lock.
+** @param lock_name_length: the length of the unique_name.
+** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+*/
+int Waf_createLock(struct waf_lock* waf_lock, const char* waf_lock_name, int waf_lock_name_length, const char* owner) {
+    int rc = WAF_LOCK_SUCCESS;
+
+    rc = Waf_lock_init(waf_lock);
+    if (rc != WAF_LOCK_SUCCESS) {
+        return rc;
+    }
+
+    /* Check the format of db_name */
+    if (waf_lock_name == NULL) {
+        return WAF_LOCK_ERROR_NAME_NULL;
+    }
+    else if (waf_lock_name_length <= 0) {
+        return WAF_LOCK_ERROR_NAME_INVALID_STRING;
+    }
+    else if (Waf_lock_isstring(waf_lock_name, waf_lock_name_length) == WAF_LOCK_ERROR) {
+        return WAF_LOCK_ERROR_NAME_INVALID_STRING;
+    }
+
+    /* Create or open the lock */
+    rc = lock_create(waf_lock, waf_lock_name, waf_lock_name_length, owner);
+    if (Waf_lock_isError(rc))
+    {
+        return rc;
+    }
+    else if (rc != WAF_SUCCESS_LOCK_CREATE && rc != WAF_SUCCESS_LOCK_OPEN) {
+        return WAF_LOCK_ERROR_UNEXPECTED;
+    }
+
+    return rc;
+}
+
+/**
+** Close and destroy a lock.
+** @param waf_lock: the waf_lock you want to destroy.
+** return: WAF_LOCK_SUCCESS if successfully destroyed or WAF_LOCK_ERROR if failed.
+*/
+int Waf_destroyLock(struct waf_lock *waf_lock) {
+    int rc_lock = WAF_LOCK_SUCCESS;
+
+    if (waf_lock == NULL)
+        return WAF_LOCK_ERROR_HANDLE_NULL;
+
+    rc_lock = lock_destroy(waf_lock);
+
+    if (Waf_lock_isError(rc_lock))
+        return rc_lock;
+    else
+        return WAF_LOCK_SUCCESS;
+}
+
+/**
+** Close a Lock, but does not destroy it.
+** @param lock: the lock you want to close.
+** return: WAF_LOCK_SUCCESS if successfully closed or WAF_LOCK_ERROR if failed.
+*/
+int Waf_closeLock(struct waf_lock *waf_lock) {
+    int rc_lock = WAF_LOCK_SUCCESS;
+
+    if (waf_lock == NULL)
+        return WAF_LOCK_ERROR_HANDLE_NULL;
+
+    rc_lock = lock_close(waf_lock);
+    if (Waf_lock_isError(rc_lock))
+        return rc_lock;
+    else
+        return WAF_LOCK_SUCCESS;
+}
+
+int GetGroupId(const char *name, gid_t *id)
+{
+    struct group *grp = getgrnam(name); /* don't free, see getgrnam() for details */
+    if(grp == NULL) {
+        return WAF_LOCK_ERROR;
+    } 
+
+    *id = grp->gr_gid;
+    return WAF_LOCK_SUCCESS;
+}
+
+int GetUserId(const char *name, uid_t *id)
+{
+    struct passwd *pwd = getpwnam(name); /* don't free, see getpwnam() for details */
+    if(pwd == NULL) {
+        return WAF_LOCK_ERROR;
+    } 
+
+    *id = pwd->pw_uid;
+    return WAF_LOCK_SUCCESS;
+}

--- a/apache2/waf_lock/waf_lock_external.h
+++ b/apache2/waf_lock/waf_lock_external.h
@@ -1,0 +1,154 @@
+#ifndef _WAF_LOCK_EXTERNAL_HEADER
+#define _WAF_LOCK_EXTERNAL_HEADER
+
+#include "stdbool.h"
+#ifdef _WIN32
+#ifdef inline
+#undef inline
+#endif
+#include <windows.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ **========================================================
+ ** Lock Status Definition
+ **========================================================
+ */
+/**
+ ** First Digit: equals 1 if it is an error code.
+ ** Second Digit: the platform where the error happens.
+ **              0 means general, 1 means LINUX, 2 means WINDOWS.
+ ** 3th & 4th Digit: the detailed error number.
+ */
+
+#define WAF_LOCK_SUCCESS                                        0000
+#define WAF_SUCCESS_LOCK_CREATE                                 0001
+#define WAF_SUCCESS_LOCK_OPEN                                   0002
+
+#define WAF_LOCK_ERROR                                          1000
+#define WAF_ERROR_LOCK_LINUX_SEM_CREATE_FAIL                    1100
+#define WAF_ERROR_LOCK_LINUX_SEM_OPEN_FAIL                      1101
+#define WAF_ERROR_LOCK_LINUX_SEM_INIT_FAIL                      1102
+#define WAF_ERROR_LOCK_LINUX_SEM_MODIFY_FAIL                    1103
+#define WAF_ERROR_LOCK_LINUX_SEM_DESTROY_FAIL                   1104
+#define	WAF_ERROR_LOCK_LINUX_SEM_SET_PERMISSION_FAIL            1105
+#define	WAF_ERROR_LOCK_LINUX_SEM_GET_USER_FAIL                  1106
+
+#define WAF_ERROR_LOCK_WIN_NAME_INVALID_STRING                  1200
+#define WAF_ERROR_LOCK_WIN_MUTEX_CREATE_FAIL                    1201
+#define WAF_ERROR_LOCK_WIN_ONLY_ONE_LOCK_EXISTS                 1202
+#define WAF_ERROR_LOCK_WIN_GET_MUTEX_FAIL                       1203
+#define WAF_ERROR_LOCK_WIN_RELEASE_MUTEX_FAIL                   1204
+#define WAF_ERROR_LOCK_WIN_CLOSE_MUTEX_FAIL                     1205
+#define WAF_ERROR_LOCK_WIN_DESTROY_NOT_SUPPORT                  1206
+
+#define WAF_LOCK_ERROR_NAME_NULL                                1001
+#define WAF_LOCK_ERROR_NAME_INVALID_STRING                      1002
+#define WAF_ERROR_LOCK_OP_NEGATIVE_VAL                          1003
+#define WAF_LOCK_ERROR_HANDLE_NULL                              1004
+#define WAF_LOCK_ERROR_UNEXPECTED                               1005
+
+
+/**
+ **========================================================
+ ** Waf Lock Handler Definition
+ **========================================================
+ */
+
+/**
+ ** The structure stores the Read/Write locks information.
+ ** In Linux, a set of semaphores is used to implement the Read/Write locks.
+ ** In Windows, The Windows Mutex is used to implement the Read/Write locks.
+ ** @param sem_id: The identifier of semaphore set in Linux.
+ ** @param read_lock_handle: The handler of the read locks in Windows.
+ ** @param write_lock_handle: The handler of the write lock in Windows.
+ */
+struct waf_lock {
+#ifndef _WIN32
+    int sem_id;
+#else
+    HANDLE read_lock_handle;
+    HANDLE write_lock_handle;
+#endif
+};
+
+
+/**
+ **========================================================
+ ** Waf Lock API
+ **========================================================
+ */
+
+/**
+ ** Create a lock.
+ ** @param lock: lock handler.
+ ** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+ */
+int Waf_createLock(struct waf_lock *lock, const char* lock_name, int lock_name_length, const char* owner);
+
+/**
+ ** Destroy a lock.
+ ** @param lock: lock handler.
+ ** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+ */
+int Waf_destroyLock(struct waf_lock *lock);
+
+/**
+ ** Close a lock.
+ ** @param lock: lock handler.
+ ** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+ */
+int Waf_cLoseLock(struct waf_lock *lock);
+
+/**
+ ** Get a shared lock for read only.
+ ** @param lock: lock handler.
+ ** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+ */
+
+int Waf_getSharedLock(struct waf_lock *lock);
+
+/**
+ ** Get a exclusive lock for read and write.
+ ** @param lock: lock handler.
+ ** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+ */
+int Waf_getExclusiveLock(struct waf_lock *lock);
+
+/**
+ ** Free a shared lock that you have got before.
+ ** @param lock: lock handler.
+ ** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+ */
+int Waf_freeSharedLock(struct waf_lock *lock);
+
+/**
+ ** Free a exclusive lock that you have got before.
+ ** @param lock: lock handler.
+ ** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+ */
+int Waf_freeExclusiveLock(struct waf_lock *lock);
+
+/**
+ **========================================================
+ ** Lock Debug API
+ **========================================================
+ */
+/**
+ ** Check whether a return_code is an error.
+ ** @param return_code: the code returned by a Lock function.
+ ** return: True if there is an error;
+            False if not.
+ */
+bool Waf_lock_isError(int return_code);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/apache2/waf_lock/waf_lock_internal.h
+++ b/apache2/waf_lock/waf_lock_internal.h
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#ifndef _WAF_LOCK_INTERNAL_HEADER
+#define _WAF_LOCK_INTERNAL_HEADER
+
+#ifdef _WIN32
+#ifdef inline
+#undef inline
+#endif
+#include <windows.h>
+#include<Synchapi.h>
+#else
+#include<sys/shm.h>
+#include<sys/sem.h>
+#include<sys/ipc.h>
+#include <errno.h>
+#endif
+#include<cstring>
+#include<stdlib.h>
+#include<time.h>
+#include<stdio.h>
+#include<pwd.h>
+#include<grp.h>
+#include"murmur3.h"
+#include"waf_lock_external.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ **========================================================
+ ** Semaphore Operator Structure and Function
+ **========================================================
+ */
+
+#define DEFAULT_WAF_LOCK_ID_RANGE  0x8fffffff  // the default range of lock ID mapped by lock's name
+  /* Hash Function Default Setting */
+#define DEFAULT_HASH_MAGIC_SEED 0           // the seed of hash function in AGMDB_hash()
+#define DEFAULT_HASH_VALUE_STR_LENGTH 4     // the length of the result value from hash function
+
+/**
+ **========================================================
+ ** Defaut Setting of Semaphore Set
+ **========================================================
+ */
+
+#define SEM_NUMBERS             2  // the number of semaphores in a semaphore set
+#define SEM_READ_INITVAL        10 // the initial value of read semaphore
+#define SEM_WRITE_INITVAL       1  // the initial value of write semaphore
+
+#define SEM_ID_READ             0  // the index of read semaphore in a semaphore set
+#define SEM_ID_WRITE            1  // the index of write semaphore in a semaphore set
+
+/**
+ ** Define the name suffix of Read/Write lock on Windows
+ */
+#ifdef _WIN32
+#define READ_LOCK_SUFFIX "_DB_LOCK_READ"
+#define WRITE_LOCK_SUFFIX "_DB_LOCK_WRITE"
+#endif
+
+/**
+ ** Required by Linux.
+ ** @param val:
+ ** @param buf:
+ ** @param array:
+ */
+union semun {
+    int val;
+    struct semid_ds *buf;
+    unsigned short *array;
+};
+
+/**
+ ** Create and initialize a waf_lock, if the lock with given key exists, just link to the lock.
+ ** The new_lock should have been created before calling this function.
+ ** @param new_lock:        The pointer to save the information of the lock.
+ ** @param lock_name:       The name of lock.
+ ** @param lock_name_length:The length of the lock_name.
+ ** return: WAF_SUCCESS_LOCK_CREATE if successfully created a new lock,
+ **         WAF_SUCCESS_LOCK_OPEN if successfully link to an existed lock,
+ **         WAF_LOCK_ERROR if failed.
+ */
+int lock_create(struct waf_lock *new_lock, const char* lock_name, int lock_name_length, const char* owner);
+
+/**
+ ** Destroy the lock
+ ** @param waf_lock: The waf_lock sturcture
+ ** return: WAF_LOCK_SUCCESS if successfully destroy the lock,
+ **         WAF_LOCK_ERROR if failed.
+ */
+int lock_destroy(struct waf_lock *waf_lock);
+
+/**
+ ** Close the lock
+ ** @param waf_lock: The waf_lock sturcture
+ ** return: WAF_LOCK_SUCCESS if successfully close the lock,
+ **         WAF_LOCK_ERROR if failed.
+ */
+int lock_close(struct waf_lock *waf_lock);
+
+/**
+ ** Decrease a lock's value by a given number.
+ ** @param waf_lock: The waf_lock sturcture
+ ** @param index:   The index of atom lock (read or write) .
+ ** @param val:     The value you want to decrease from the lock.
+ ** return: WAF_LOCK_SUCCESS if success;
+ **         or WAF_LOCK_ERROR if failed
+ */
+int lock_P(const struct waf_lock *waf_lock, int index, int val);
+
+/**
+ ** Increase a lock's value by a given number.
+ ** @param waf_lock: The waf_lock sturcture
+ ** @param index:   The index of atom lock (read or write) .
+ ** @param val:     The value you want to add to the lock.
+ ** return: WAF_LOCK_SUCCESS if success;
+ **         or WAF_LOCK_ERROR if failed
+ */
+int lock_V(const struct waf_lock *waf_lock, int index, int val);
+
+/**
+ **========================================================
+ ** Other Function
+ **========================================================
+ */
+
+/**
+ ** Check the string format.
+ ** @param str: the string you want to check.
+ ** @param str_len: given string length (not include '\0').
+ ** return: WAF_LOCK_SUCCESS if the string length equals str_len;
+ **             WAF_LOCK_ERROR if not
+ */
+int Waf_lock_isstring(const char* str, int str_len);
+
+/**
+ ** Use waf lock's hash function to hash a string into an integer.
+ ** @param key: the key string.
+ ** @param key_len: the length of the key string.
+ ** @param output_val_range: the range of output value.
+ ** return: hash result if success
+ **      or WAF_LOCK_ERROR if failed.
+ */
+unsigned int Waf_lock_hash(const char* key, int key_len, unsigned int output_val_range);
+
+/**
+** Initialize the handle of lock.
+** @param waf_lock: the handle of Lock.
+** return:  if WAF_LOCK_SUCCESS if success
+**          or WAF_LOCK_ERROR if the handle is NULL.
+*/
+int Waf_lock_init(struct waf_lock* waf_lock);
+
+/**
+** Get user id by name.
+** @param name: name.
+** return:  if WAF_LOCK_SUCCESS if success
+**          or WAF_LOCK_ERROR if the handle is NULL.
+*/
+int GetUserId(const char* name, uid_t* id);
+
+/**
+** Get group id by name.
+** @param name: name.
+** return:  if WAF_LOCK_SUCCESS if success
+**          or WAF_LOCK_ERROR if the handle is NULL.
+*/
+int GetGroupId(const char* name, gid_t* id);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/configure.ac
+++ b/configure.ac
@@ -603,7 +603,7 @@ AC_ARG_ENABLE(waf_json_logging,
 [
   if test "$enableval" != "no"; then
     waf_json_logging="-I"`pwd`"/apache2/waf_logging -DWAF_JSON_LOGGING_ENABLE"
-    MODSEC_EXTRA_CFLAGS="$MODSEC_EXTRA_CFLAGS $collection_memory_database"
+    MODSEC_EXTRA_CFLAGS="$MODSEC_EXTRA_CFLAGS $waf_json_logging"
   else
     waf_json_logging=""
   fi
@@ -612,6 +612,8 @@ AC_ARG_ENABLE(waf_json_logging,
   waf_json_logging=""
 ])
 
+# Always Enable json waf logging support
+waf_lock="-I"`pwd`"/apache2/waf_lock"
 
 # Ignore configure errors
 AC_ARG_ENABLE(errors,
@@ -879,7 +881,7 @@ else
   fi
 fi
 
-MODSEC_EXTRA_CFLAGS="$pcre_study $pcre_match_limit $pcre_match_limit_recursion $pcre_jit $request_early $htaccess_config $lua_cache $debug_conf $debug_cache $debug_acmp $debug_mem $perf_meas $modsec_api $cpu_type $unique_id $log_filename $log_server $log_collection_delete_problem $log_dechunk $log_stopwatch $log_handler $log_server_context $collection_global_lock $large_stream_input $collection_memory_database $waf_json_logging"
+MODSEC_EXTRA_CFLAGS="$pcre_study $pcre_match_limit $pcre_match_limit_recursion $pcre_jit $request_early $htaccess_config $lua_cache $debug_conf $debug_cache $debug_acmp $debug_mem $perf_meas $modsec_api $cpu_type $unique_id $log_filename $log_server $log_collection_delete_problem $log_dechunk $log_stopwatch $log_handler $log_server_context $collection_global_lock $large_stream_input $collection_memory_database $waf_json_logging $waf_lock"
 
 APXS_WRAPPER=build/apxs-wrapper
 APXS_EXTRA_CFLAGS=""

--- a/standalone/Makefile.am
+++ b/standalone/Makefile.am
@@ -7,6 +7,7 @@ standalone_la_SOURCES = ../apache2/acmp.c \
     ../apache2/ag_mdb/ag_mdb.cpp \
     ../apache2/waf_logging/waf_format.pb.cc \
     ../apache2/waf_logging/waf_log_util.cc \
+    ../apache2/waf_lock/waf_lock.cpp \
     ../apache2/apache2_config.c \
     ../apache2/apache2_io.c \
     ../apache2/apache2_util.c \

--- a/standalone/server.c
+++ b/standalone/server.c
@@ -998,26 +998,14 @@ AP_DECLARE(void) unixd_pre_config(apr_pool_t *ptemp)
     apr_finfo_t wrapper;
 
 #if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER < 3
-#ifdef WAF_JSON_LOGGING_ENABLE
-    unixd_config.user_name = msc_waf_lock_owner;
-    unixd_config.user_id = ap_uname2id(msc_waf_lock_owner);
-    unixd_config.group_id = ap_gname2id(msc_waf_lock_owner);
-#else
     unixd_config.user_name = DEFAULT_USER;
     unixd_config.user_id = ap_uname2id(DEFAULT_USER);
     unixd_config.group_id = ap_gname2id(DEFAULT_GROUP);
-#endif
     unixd_config.suexec_enabled = 0;
-#else
-#ifdef WAF_JSON_LOGGING_ENABLE
-    ap_unixd_config.user_name = msc_waf_lock_owner;
-    ap_unixd_config.user_id = ap_uname2id(msc_waf_lock_owner);
-    ap_unixd_config.group_id = ap_gname2id(msc_waf_lock_owner);
 #else
     ap_unixd_config.user_name = DEFAULT_USER;
     ap_unixd_config.user_id = ap_uname2id(DEFAULT_USER);
     ap_unixd_config.group_id = ap_gname2id(DEFAULT_GROUP);
-#endif
     ap_unixd_config.suexec_enabled = 0;
 #endif
 


### PR DESCRIPTION
first version of persistent lock utility for modsec
In Nginx, modsecurity_init will be called whenever there is config update and never released, so it will cause semaphore leak, and apr run time library doesn't have persistent lock api, so we implement this utility. 

Have tested on the multiple work process and works fine. Also you need SecWafLockOwner to set permission of the lock if you want to use in non-root process