### PR TITLE
persistent lock utitlity and intergration 

### DIFF
--- a/apache2/Makefile.am
+++ b/apache2/Makefile.am
@@ -6,6 +6,7 @@ mod_security2_la_SOURCES = acmp.c \
     ag_mdb/ag_mdb.cpp \
     waf_logging/waf_format.pb.cc \
     waf_logging/waf_log_util.cc \
+    waf_lock/waf_lock.cpp \
     apache2_config.c \
     apache2_io.c \
     apache2_util.c \

--- a/apache2/waf_lock/waf_lock.cpp
+++ b/apache2/waf_lock/waf_lock.cpp
@@ -18,6 +18,7 @@
 **         WAF_LOCK_ERROR if failed.
 */
 #ifndef _WIN32
+// Linux
 int lock_create(struct waf_lock *new_lock, struct waf_lock_args *new_lock_args) {
     union semun sem_union;
     uid_t uid;
@@ -71,7 +72,9 @@ int lock_create(struct waf_lock *new_lock, struct waf_lock_args *new_lock_args) 
     // Should never get here
     return WAF_SUCCESS_LOCK_CREATE;
 }
+// Linux
 #else
+// Windows
 int lock_create(struct waf_lock *new_lock, struct waf_lock_args *new_lock_args) {
     int read_lock_name_len = 0;
     int write_lock_name_len = 0;
@@ -145,6 +148,7 @@ int lock_create(struct waf_lock *new_lock, struct waf_lock_args *new_lock_args) 
     // Should never get here
     return WAF_SUCCESS_LOCK_CREATE;
 }
+// Windows
 #endif
 
 /**
@@ -154,6 +158,7 @@ int lock_create(struct waf_lock *new_lock, struct waf_lock_args *new_lock_args) 
 **         WAF_LOCK_ERROR if failed.
 */
 #ifndef _WIN32
+// Linux
 int lock_destroy(struct waf_lock *waf_lock) {
     int rc = WAF_LOCK_SUCCESS;
     if (waf_lock == NULL)
@@ -170,7 +175,9 @@ int lock_destroy(struct waf_lock *waf_lock) {
         waf_lock->sem_id = -1;
     return WAF_LOCK_SUCCESS;
 }
+// Linux
 #else
+// Windows
 int lock_destroy(struct waf_lock *waf_lock) {
     int rc = WAF_LOCK_SUCCESS;
     if (waf_lock == NULL)
@@ -181,6 +188,7 @@ int lock_destroy(struct waf_lock *waf_lock) {
     /* Locks destroy doesn't support on Windows */
     return WAF_ERROR_LOCK_WIN_DESTROY_NOT_SUPPORT;
 }
+// Windows
 #endif
 
 /**
@@ -190,13 +198,16 @@ int lock_destroy(struct waf_lock *waf_lock) {
 **         WAF_LOCK_ERROR if failed.
 */
 #ifndef _WIN32
+// Linux
 int lock_close(struct waf_lock *waf_lock) {
     if (waf_lock == NULL)
         return WAF_LOCK_ERROR_HANDLE_NULL;
     /* Linux doesn't do anything */
     return WAF_LOCK_SUCCESS;
 }
+// Linux
 #else
+// Windows
 int lock_close(struct waf_lock *waf_lock) {
     if (waf_lock == NULL)
         return WAF_LOCK_ERROR_HANDLE_NULL;
@@ -221,6 +232,7 @@ int lock_close(struct waf_lock *waf_lock) {
         return WAF_ERROR_LOCK_WIN_CLOSE_MUTEX_FAIL;
     return WAF_LOCK_SUCCESS;
 }
+// Windows
 #endif
 
 /**
@@ -232,6 +244,7 @@ int lock_close(struct waf_lock *waf_lock) {
 **         or WAF_LOCK_ERROR if failed
 */
 #ifndef _WIN32
+// Linux
 int lock_P(const struct waf_lock *waf_lock, int index, int val) {
     struct sembuf sem_op;
     if (val < 0)
@@ -244,7 +257,9 @@ int lock_P(const struct waf_lock *waf_lock, int index, int val) {
         return WAF_ERROR_LOCK_LINUX_SEM_MODIFY_FAIL;
     return WAF_LOCK_SUCCESS;
 }
+// Linux
 #else
+// Windows
 int lock_P(const struct waf_lock *waf_lock, int index, int val) {
     int rc;
     HANDLE lock_handle;
@@ -264,6 +279,7 @@ int lock_P(const struct waf_lock *waf_lock, int index, int val) {
         return WAF_ERROR_LOCK_WIN_GET_MUTEX_FAIL;
     return WAF_LOCK_SUCCESS;
 }
+// Windows
 #endif
 
 /**
@@ -275,6 +291,7 @@ int lock_P(const struct waf_lock *waf_lock, int index, int val) {
 **         or WAF_LOCK_ERROR if failed
 */
 #ifndef _WIN32
+// Linux
 int lock_V(const struct waf_lock *waf_lock, int index, int val) {
     struct sembuf sem_op;
     if (val < 0)
@@ -287,7 +304,9 @@ int lock_V(const struct waf_lock *waf_lock, int index, int val) {
         return WAF_ERROR_LOCK_LINUX_SEM_MODIFY_FAIL;
     return WAF_LOCK_SUCCESS;
 }
+// Linux
 #else
+// Windows
 int lock_V(const struct waf_lock *waf_lock, int index, int val) {
     int rc;
     HANDLE lock_handle;
@@ -307,6 +326,7 @@ int lock_V(const struct waf_lock *waf_lock, int index, int val) {
         return WAF_ERROR_LOCK_WIN_RELEASE_MUTEX_FAIL;
     return WAF_LOCK_SUCCESS;
 }
+// Windows
 #endif
 
 /**
@@ -346,13 +366,16 @@ bool Waf_lock_isError(int return_code) {
 **          or WAF_LOCK_ERROR if the handle is NULL.
 */
 #ifndef _WIN32
+// Linux
 int Waf_lock_init(struct waf_lock* waf_lock) {
     if (waf_lock == NULL)
         return WAF_LOCK_ERROR_HANDLE_NULL;
     waf_lock->sem_id = -1;
     return WAF_LOCK_SUCCESS;
 }
+// Linux
 #else
+// Windows 
 int Waf_lock_init(struct waf_lock* waf_lock) {
     if (waf_lock == NULL)
         return WAF_LOCK_ERROR_HANDLE_NULL;
@@ -360,6 +383,7 @@ int Waf_lock_init(struct waf_lock* waf_lock) {
     waf_lock->write_lock_handle = INVALID_HANDLE_VALUE;
     return WAF_LOCK_SUCCESS;
 }
+// Windows 
 #endif
 
 /**

--- a/apache2/waf_lock/waf_lock.cpp
+++ b/apache2/waf_lock/waf_lock.cpp
@@ -1,0 +1,512 @@
+#include"waf_lock_external.h"
+#include"waf_lock_internal.h"
+
+
+/**
+**========================================================
+** Waf Lock Internal Function
+**========================================================
+*/
+
+/**
+** Create and initialize a waf_lock, if the lock with given key exists, just link to the lock.
+** The new_lock should have been created before calling this function.
+** @param new_lock:        The pointer to save the information of the lock.
+** @param new_lock_args: the lock properties needed to create lock.
+** return: WAF_SUCCESS_LOCK_CREATE if successfully created a new lock,
+**         WAF_SUCCESS_LOCK_OPEN if successfully link to an existed lock,
+**         WAF_LOCK_ERROR if failed.
+*/
+int lock_create(struct waf_lock *new_lock, struct waf_lock_args *new_lock_args) {
+#ifndef _WIN32
+    union semun sem_union;
+    uid_t uid;
+    gid_t gid;
+#else
+    int read_lock_name_len = 0;
+    int write_lock_name_len = 0;
+    char* read_lock_name = NULL;
+    char* write_lock_name = NULL;
+    bool lock_exists = false;
+#endif
+    if (new_lock == NULL)
+        return WAF_LOCK_ERROR_HANDLE_NULL;
+#ifndef _WIN32
+    new_lock->sem_id = semget(new_lock_args->lock_id, SEM_NUMBERS, IPC_CREAT | IPC_EXCL);
+    if (new_lock->sem_id != -1) {
+        // A new semaphore set is created, need to initialize the semaphore set
+	// Set permssion
+	struct semid_ds buf;
+	if ((GetUserId(new_lock_args->lock_owner, &uid) == WAF_LOCK_ERROR) || (GetGroupId(new_lock_args->lock_owner, &gid) == WAF_LOCK_ERROR)) {
+            lock_destroy(new_lock);
+            return WAF_ERROR_LOCK_LINUX_SEM_GET_USER_FAIL;
+	}
+
+	buf.sem_perm.uid = uid; 
+	buf.sem_perm.gid = gid; 
+	buf.sem_perm.mode = 0600;
+	sem_union.buf = &buf;
+        if (semctl(new_lock->sem_id, 0, IPC_SET, sem_union) == -1) {
+            lock_destroy(new_lock);
+            return WAF_ERROR_LOCK_LINUX_SEM_SET_PERMISSION_FAIL;
+        }
+	
+        sem_union.val = SEM_READ_INITVAL;
+        if (semctl(new_lock->sem_id, SEM_ID_READ, SETVAL, sem_union) == -1) {
+            lock_destroy(new_lock);
+            return WAF_ERROR_LOCK_LINUX_SEM_CREATE_FAIL;
+        }
+
+        sem_union.val = SEM_WRITE_INITVAL;
+        if (semctl(new_lock->sem_id, SEM_ID_WRITE, SETVAL, sem_union) == -1) {
+            // If failed, destroy the lock
+            lock_destroy(new_lock);
+            return WAF_ERROR_LOCK_LINUX_SEM_INIT_FAIL;
+        }
+        return WAF_SUCCESS_LOCK_CREATE;
+    }
+    else {
+        new_lock->sem_id = semget(new_lock_args->lock_id, SEM_NUMBERS, IPC_CREAT);
+        if (new_lock->sem_id == -1) {
+            return WAF_ERROR_LOCK_LINUX_SEM_OPEN_FAIL;
+        }
+        return WAF_SUCCESS_LOCK_OPEN;
+    }
+#else
+    read_lock_name_len = (strlen(READ_LOCK_SUFFIX) + strlen(new_lock_args->lock_name) + 1) * sizeof(char);
+    write_lock_name_len = (strlen(WRITE_LOCK_SUFFIX) + strlen(new_lock_args->lock_name) + 1) * sizeof(char);
+
+    if (Waf_lock_isstring(new_lock_args->lock_name, new_lock_args->lock_name_length) != WAF_LOCK_SUCCESS)
+        return WAF_ERROR_LOCK_WIN_NAME_INVALID_STRING;
+
+    read_lock_name = (char *)malloc(read_lock_name_len * sizeof(char));
+    sprintf_s(read_lock_name, read_lock_name_len, "%s%s", new_lock_args->lock_name, READ_LOCK_SUFFIX);
+    new_lock->read_lock_handle = CreateMutex(
+        NULL,               // Default security settings.
+        FALSE,              // Do not take the lock after created.
+        read_lock_name);    // The name of read lock.
+    free(read_lock_name);
+
+    if (new_lock->read_lock_handle == NULL) {
+        new_lock->read_lock_handle = INVALID_HANDLE_VALUE;
+        return WAF_ERROR_LOCK_WIN_MUTEX_CREATE_FAIL;
+    }
+
+    if (GetLastError() == ERROR_ALREADY_EXISTS)
+        lock_exists = true;
+
+    write_lock_name = (char *)malloc(write_lock_name_len * sizeof(char));
+    sprintf_s(write_lock_name, write_lock_name_len, "%s%s", new_lock_args->lock_name, WRITE_LOCK_SUFFIX);
+    new_lock->write_lock_handle = CreateMutex(
+        NULL,               // Default security settings.
+        FALSE,              // Do not take the lock after created.
+        write_lock_name);   // The name of write lock.
+    free(write_lock_name);
+
+    if (new_lock->write_lock_handle == NULL) {
+        CloseHandle(new_lock->read_lock_handle);
+        new_lock->read_lock_handle = INVALID_HANDLE_VALUE;
+        new_lock->write_lock_handle = INVALID_HANDLE_VALUE;
+        return WAF_ERROR_LOCK_WIN_MUTEX_CREATE_FAIL;
+    }
+
+    if ((GetLastError() == ERROR_ALREADY_EXISTS) != lock_exists) {
+        // One lock exists, another not.
+        CloseHandle(new_lock->read_lock_handle);
+        new_lock->read_lock_handle = INVALID_HANDLE_VALUE;
+        CloseHandle(new_lock->write_lock_handle);
+        new_lock->write_lock_handle = INVALID_HANDLE_VALUE;
+        return WAF_ERROR_LOCK_WIN_ONLY_ONE_LOCK_EXISTS;
+    }
+
+    if (lock_exists == true)
+        return WAF_SUCCESS_LOCK_OPEN;
+    else
+        return WAF_SUCCESS_LOCK_CREATE;
+#endif
+    // Should never get here
+    return WAF_SUCCESS_LOCK_CREATE;
+}
+
+/**
+** Destroy the lock
+** @param waf_lock: The waf_lock sturcture
+** return: WAF_LOCK_SUCCESS if successfully destroy the lock,
+**         WAF_LOCK_ERROR if failed.
+*/
+int lock_destroy(struct waf_lock *waf_lock) {
+    int rc = WAF_LOCK_SUCCESS;
+    if (waf_lock == NULL)
+        return WAF_LOCK_ERROR_HANDLE_NULL;
+    rc = lock_close(waf_lock);
+    if (Waf_lock_isError(rc))
+        return rc;
+#ifndef _WIN32
+    if (waf_lock->sem_id == -1)
+        return WAF_LOCK_SUCCESS;
+    rc = semctl(waf_lock->sem_id, 0, IPC_RMID);
+    if (rc == -1)
+        return WAF_ERROR_LOCK_LINUX_SEM_DESTROY_FAIL;
+    else
+        waf_lock->sem_id = -1;
+    return WAF_LOCK_SUCCESS;
+#else
+    /* Locks destroy doesn't support on Windows */
+    return WAF_ERROR_LOCK_WIN_DESTROY_NOT_SUPPORT;
+#endif
+}
+
+/**
+** Close the lock
+** @param waf_lock: The waf_lock sturcture
+** return: WAF_LOCK_SUCCESS if successfully close the lock,
+**         WAF_LOCK_ERROR if failed.
+*/
+int lock_close(struct waf_lock *waf_lock) {
+    if (waf_lock == NULL)
+        return WAF_LOCK_ERROR_HANDLE_NULL;
+    /* Linux doesn't do anything */
+#ifdef _WIN32
+    BOOL rc_read = 1;
+    BOOL rc_write = 1;
+    if (waf_lock->read_lock_handle != INVALID_HANDLE_VALUE)
+    {
+        rc_read = CloseHandle(waf_lock->read_lock_handle);
+        if (rc_read != 0)
+            waf_lock->read_lock_handle = INVALID_HANDLE_VALUE;
+    }
+
+    if (waf_lock->write_lock_handle != INVALID_HANDLE_VALUE)
+    {
+        rc_write = CloseHandle(waf_lock->write_lock_handle);
+        if (rc_write != 0)
+            waf_lock->write_lock_handle = INVALID_HANDLE_VALUE;
+    }
+
+    if (rc_read == 0 || rc_write == 0)
+        return WAF_ERROR_LOCK_WIN_CLOSE_MUTEX_FAIL;
+#endif
+    return WAF_LOCK_SUCCESS;
+}
+
+/**
+** Decrease a lock's value by a given number.
+** @param waf_lock: The waf_lock sturcture
+** @param index:   The index of atom lock (read or write) .
+** @param val:     The value you want to decrease from the lock.
+** return: WAF_LOCK_SUCCESS if success;
+**         or WAF_LOCK_ERROR if failed
+*/
+int lock_P(const struct waf_lock *waf_lock, int index, int val) {
+#ifndef _WIN32
+    struct sembuf sem_op;
+    if (val < 0)
+        return WAF_ERROR_LOCK_OP_NEGATIVE_VAL;
+
+    sem_op.sem_num = index;
+    sem_op.sem_op = -val;
+    sem_op.sem_flg = SEM_UNDO;
+    if (semop(waf_lock->sem_id, &sem_op, 1) == -1)
+        return WAF_ERROR_LOCK_LINUX_SEM_MODIFY_FAIL;
+    return WAF_LOCK_SUCCESS;
+#else
+    int rc;
+    HANDLE lock_handle;
+    if (val < 0)
+        return WAF_ERROR_LOCK_OP_NEGATIVE_VAL;
+
+    if (index == SEM_ID_READ)
+        lock_handle = waf_lock->read_lock_handle;
+    else
+        lock_handle = waf_lock->write_lock_handle;
+
+    if (lock_handle == INVALID_HANDLE_VALUE)
+        return WAF_ERROR_LOCK_WIN_GET_MUTEX_FAIL;
+
+    rc = WaitForSingleObject(lock_handle, INFINITE);
+    if (rc != WAIT_OBJECT_0)
+        return WAF_ERROR_LOCK_WIN_GET_MUTEX_FAIL;
+    return WAF_LOCK_SUCCESS;
+#endif
+}
+
+/**
+** Increase a lock's value by a given number.
+** @param waf_lock: The waf_lock sturcture
+** @param index:   The index of atom lock (read or write) .
+** @param val:     The value you want to add to the lock.
+** return: WAF_LOCK_SUCCESS if success;
+**         or WAF_LOCK_ERROR if failed
+*/
+int lock_V(const struct waf_lock *waf_lock, int index, int val) {
+#ifndef _WIN32
+    struct sembuf sem_op;
+    if (val < 0)
+        return WAF_ERROR_LOCK_OP_NEGATIVE_VAL;
+
+    sem_op.sem_num = index;
+    sem_op.sem_op = val;
+    sem_op.sem_flg = SEM_UNDO;
+    if (semop(waf_lock->sem_id, &sem_op, 1) == -1)
+        return WAF_ERROR_LOCK_LINUX_SEM_MODIFY_FAIL;
+    return WAF_LOCK_SUCCESS;
+#else
+    int rc;
+    HANDLE lock_handle;
+    if (val < 0)
+        return WAF_ERROR_LOCK_OP_NEGATIVE_VAL;
+
+    if (index == SEM_ID_READ)
+        lock_handle = waf_lock->read_lock_handle;
+    else
+        lock_handle = waf_lock->write_lock_handle;
+
+    if (lock_handle == INVALID_HANDLE_VALUE)
+        return WAF_ERROR_LOCK_WIN_RELEASE_MUTEX_FAIL;
+
+    rc = ReleaseMutex(lock_handle);
+    if (rc == 0)
+        return WAF_ERROR_LOCK_WIN_RELEASE_MUTEX_FAIL;
+    return WAF_LOCK_SUCCESS;
+#endif
+}
+
+/**
+** Check the string format.
+** @param str: the string you want to check.
+** @param str_len: given string length (not include '\0').
+** return: WAF_LOCK_SUCCESS if the string length equals str_len;
+**             WAF_LOCK_ERROR if not
+*/
+int Waf_lock_isstring(const char* str, int str_len) {
+    int i;
+    for (i = 0;i < str_len;i++)
+        if (str[i] == '\0')
+            return WAF_LOCK_ERROR;
+    if (str[i] != '\0')
+        return WAF_LOCK_ERROR;
+    return WAF_LOCK_SUCCESS;
+}
+
+/**
+** Check whether a return_code is an error.
+** @param return_code: the code returned by a Waf Lock function.
+** return: True if there is an error;
+False if not.
+*/
+bool Waf_lock_isError(int return_code) {
+    if (return_code < WAF_LOCK_ERROR)
+        return false;
+    else
+        return true;
+}
+
+/**
+** Initialize the handle of Waf Lock.
+** @param waf_lock: the handle of Waf Lock.
+** return:  if WAF_LOCK_SUCCESS if success
+**          or WAF_LOCK_ERROR if the handle is NULL.
+*/
+int Waf_lock_init(struct waf_lock* waf_lock) {
+    if (waf_lock == NULL)
+        return WAF_LOCK_ERROR_HANDLE_NULL;
+#ifndef _WIN32
+    waf_lock->sem_id = -1;
+#else
+    waf_lock->read_lock_handle = INVALID_HANDLE_VALUE;
+    waf_lock->write_lock_handle = INVALID_HANDLE_VALUE;
+#endif
+    return WAF_LOCK_SUCCESS;
+}
+
+/**
+**========================================================
+** Waf Lock External Function
+**========================================================
+*/
+
+/**
+** Get a shared lock for read only.
+** @param waf_lock: lock handler you want to lock.
+** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+*/
+int Waf_getSharedLock(struct waf_lock *waf_lock) {
+    int rc;
+    if (waf_lock == NULL)
+        return WAF_LOCK_ERROR_HANDLE_NULL;
+
+    rc = lock_P(waf_lock, SEM_ID_WRITE, 1);
+    if (rc != WAF_LOCK_SUCCESS)
+        return rc;
+
+    rc = lock_P(waf_lock, SEM_ID_READ, 1);
+    if (rc != WAF_LOCK_SUCCESS) {
+        lock_V(waf_lock, SEM_ID_WRITE, 1);
+        return rc;
+    }
+
+    rc = lock_V(waf_lock, SEM_ID_WRITE, 1);
+    if (rc != WAF_LOCK_SUCCESS) {
+        lock_V(waf_lock, SEM_ID_READ, 1);
+        return rc;
+    }
+
+    return WAF_LOCK_SUCCESS;
+}
+
+/**
+** Get a exclusive lock for read and write.
+** @param waf_lock: the lock handler you want to return the lock.
+** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+*/
+int Waf_getExclusiveLock(struct waf_lock *waf_lock) {
+    int rc;
+    if (waf_lock == NULL)
+        return WAF_LOCK_ERROR_HANDLE_NULL;
+
+    rc = lock_P(waf_lock, SEM_ID_WRITE, 1);
+    if (rc != WAF_LOCK_SUCCESS)
+        return rc;
+
+    rc = lock_P(waf_lock, SEM_ID_READ, SEM_READ_INITVAL);
+    if (rc != WAF_LOCK_SUCCESS) {
+        lock_V(waf_lock, SEM_ID_WRITE, 1);
+        return rc;
+    }
+
+    return WAF_LOCK_SUCCESS;
+}
+
+/**
+** Free a shared lock that you have got before.
+** @param waf_lock: the lock handler you want to return the lock.
+** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+*/
+int Waf_freeSharedLock(struct waf_lock *waf_lock) {
+    int rc;
+    if (waf_lock == NULL)
+        return WAF_LOCK_ERROR_HANDLE_NULL;
+
+    rc = lock_V(waf_lock, SEM_ID_READ, 1);
+    if (rc != WAF_LOCK_SUCCESS)
+        return rc;
+
+    return WAF_LOCK_SUCCESS;
+}
+
+/**
+** Free a exclusive lock that you have got before.
+** @param waf_lock: the lock handler you want to return the lock.
+** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+*/
+int Waf_freeExclusiveLock(struct waf_lock *waf_lock) {
+    int rc;
+    if (waf_lock == NULL)
+        return WAF_LOCK_ERROR_HANDLE_NULL;
+
+    rc = lock_V(waf_lock, SEM_ID_READ, SEM_READ_INITVAL);
+    if (rc != WAF_LOCK_SUCCESS)
+        return rc;
+    rc = lock_V(waf_lock, SEM_ID_WRITE, 1);
+    if (rc != WAF_LOCK_SUCCESS)
+        return rc;
+
+    return WAF_LOCK_SUCCESS;
+}
+/**
+** Open a Lock with given name, and intialize the lock handler for further operation.
+** If the lock doesn't exist, a new lock will be created.
+** @param lock: a created sturcture to save the lock information.
+** @param lock_args: the lock properties needed to create lock.
+** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+*/
+int Waf_createLock(struct waf_lock* waf_lock, struct waf_lock_args* waf_lock_args) {
+    int rc = WAF_LOCK_SUCCESS;
+
+    rc = Waf_lock_init(waf_lock);
+    if (rc != WAF_LOCK_SUCCESS) {
+        return rc;
+    }
+
+    /* Check the format of db_name */
+    if (waf_lock_name == NULL) {
+        return WAF_LOCK_ERROR_NAME_NULL;
+    }
+    else if (waf_lock_name_length <= 0) {
+        return WAF_LOCK_ERROR_NAME_INVALID_STRING;
+    }
+    else if (Waf_lock_isstring(waf_lock_name, waf_lock_name_length) == WAF_LOCK_ERROR) {
+        return WAF_LOCK_ERROR_NAME_INVALID_STRING;
+    }
+
+    /* Create or open the lock */
+    rc = lock_create(waf_lock, waf_lock_args);
+    if (Waf_lock_isError(rc))
+    {
+        return rc;
+    }
+    else if (rc != WAF_SUCCESS_LOCK_CREATE && rc != WAF_SUCCESS_LOCK_OPEN) {
+        return WAF_LOCK_ERROR_UNEXPECTED;
+    }
+
+    return rc;
+}
+
+/**
+** Close and destroy a lock.
+** @param waf_lock: the waf_lock you want to destroy.
+** return: WAF_LOCK_SUCCESS if successfully destroyed or WAF_LOCK_ERROR if failed.
+*/
+int Waf_destroyLock(struct waf_lock *waf_lock) {
+    int rc_lock = WAF_LOCK_SUCCESS;
+
+    if (waf_lock == NULL)
+        return WAF_LOCK_ERROR_HANDLE_NULL;
+
+    rc_lock = lock_destroy(waf_lock);
+
+    if (Waf_lock_isError(rc_lock))
+        return rc_lock;
+    else
+        return WAF_LOCK_SUCCESS;
+}
+
+/**
+** Close a Lock, but does not destroy it.
+** @param lock: the lock you want to close.
+** return: WAF_LOCK_SUCCESS if successfully closed or WAF_LOCK_ERROR if failed.
+*/
+int Waf_closeLock(struct waf_lock *waf_lock) {
+    int rc_lock = WAF_LOCK_SUCCESS;
+
+    if (waf_lock == NULL)
+        return WAF_LOCK_ERROR_HANDLE_NULL;
+
+    rc_lock = lock_close(waf_lock);
+    if (Waf_lock_isError(rc_lock))
+        return rc_lock;
+    else
+        return WAF_LOCK_SUCCESS;
+}
+
+int GetGroupId(const char *name, gid_t *id)
+{
+    struct group *grp = getgrnam(name); /* don't free, see getgrnam() for details */
+    if(grp == NULL) {
+        return WAF_LOCK_ERROR;
+    } 
+
+    *id = grp->gr_gid;
+    return WAF_LOCK_SUCCESS;
+}
+
+int GetUserId(const char *name, uid_t *id)
+{
+    struct passwd *pwd = getpwnam(name); /* don't free, see getpwnam() for details */
+    if(pwd == NULL) {
+        return WAF_LOCK_ERROR;
+    } 
+
+    *id = pwd->pw_uid;
+    return WAF_LOCK_SUCCESS;
+}

--- a/apache2/waf_lock/waf_lock_external.h
+++ b/apache2/waf_lock/waf_lock_external.h
@@ -1,0 +1,173 @@
+#ifndef _WAF_LOCK_EXTERNAL_HEADER
+#define _WAF_LOCK_EXTERNAL_HEADER
+
+#include "stdbool.h"
+#ifdef _WIN32
+#ifdef inline
+#undef inline
+#endif
+#include <windows.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ **========================================================
+ ** Lock Status Definition
+ **========================================================
+ */
+/**
+ ** First Digit: equals 1 if it is an error code.
+ ** Second Digit: the platform where the error happens.
+ **              0 means general, 1 means LINUX, 2 means WINDOWS.
+ ** 3th & 4th Digit: the detailed error number.
+ */
+
+#define WAF_LOCK_SUCCESS                                        0000
+#define WAF_SUCCESS_LOCK_CREATE                                 0001
+#define WAF_SUCCESS_LOCK_OPEN                                   0002
+
+#define WAF_LOCK_ERROR                                          1000
+#define WAF_ERROR_LOCK_LINUX_SEM_CREATE_FAIL                    1100
+#define WAF_ERROR_LOCK_LINUX_SEM_OPEN_FAIL                      1101
+#define WAF_ERROR_LOCK_LINUX_SEM_INIT_FAIL                      1102
+#define WAF_ERROR_LOCK_LINUX_SEM_MODIFY_FAIL                    1103
+#define WAF_ERROR_LOCK_LINUX_SEM_DESTROY_FAIL                   1104
+#define	WAF_ERROR_LOCK_LINUX_SEM_SET_PERMISSION_FAIL            1105
+#define	WAF_ERROR_LOCK_LINUX_SEM_GET_USER_FAIL                  1106
+
+#define WAF_ERROR_LOCK_WIN_NAME_INVALID_STRING                  1200
+#define WAF_ERROR_LOCK_WIN_MUTEX_CREATE_FAIL                    1201
+#define WAF_ERROR_LOCK_WIN_ONLY_ONE_LOCK_EXISTS                 1202
+#define WAF_ERROR_LOCK_WIN_GET_MUTEX_FAIL                       1203
+#define WAF_ERROR_LOCK_WIN_RELEASE_MUTEX_FAIL                   1204
+#define WAF_ERROR_LOCK_WIN_CLOSE_MUTEX_FAIL                     1205
+#define WAF_ERROR_LOCK_WIN_DESTROY_NOT_SUPPORT                  1206
+
+#define WAF_LOCK_ERROR_NAME_NULL                                1001
+#define WAF_LOCK_ERROR_NAME_INVALID_STRING                      1002
+#define WAF_ERROR_LOCK_OP_NEGATIVE_VAL                          1003
+#define WAF_LOCK_ERROR_HANDLE_NULL                              1004
+#define WAF_LOCK_ERROR_UNEXPECTED                               1005
+
+
+/**
+ **========================================================
+ ** Waf Lock Handler Definition
+ **========================================================
+ */
+
+/**
+ ** The structure stores the Read/Write locks information.
+ ** In Linux, a set of semaphores is used to implement the Read/Write locks.
+ ** In Windows, The Windows Mutex is used to implement the Read/Write locks.
+ ** @param sem_id: The identifier of semaphore set in Linux.
+ ** @param read_lock_handle: The handler of the read locks in Windows.
+ ** @param write_lock_handle: The handler of the write lock in Windows.
+ */
+struct waf_lock {
+#ifndef _WIN32
+    int sem_id;
+#else
+    HANDLE read_lock_handle;
+    HANDLE write_lock_handle;
+#endif
+};
+
+
+/**
+ ** The structure stores arguments to create the lock.
+ ** In Linux, An id and owner are needed to create the semaphore.
+ ** In Windows, The name is needed to create locks.
+ ** @param lock_id: The lock id in Linux.
+ ** @param lock_owner: The owner of the lock in Linux.
+ ** @param lock_name: the name of lock in Windows.
+ ** @param lock_name_length: The handler of the write lock in Windows.
+ */
+struct waf_lock_args {
+#ifndef _WIN32
+    int   lock_id;
+    char *lock_owner; 
+#else
+    char *lock_name;
+    int   lock_name_length;
+#endif
+};
+
+/**
+ **========================================================
+ ** Waf Lock API
+ **========================================================
+ */
+
+/**
+ ** Create a lock.
+ ** @param lock: lock handler.
+ ** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+ */
+int Waf_createLock(struct waf_lock *lock, struct waf_lock_args *lock_args);
+
+/**
+ ** Destroy a lock.
+ ** @param lock: lock handler.
+ ** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+ */
+int Waf_destroyLock(struct waf_lock *lock);
+
+/**
+ ** Close a lock.
+ ** @param lock: lock handler.
+ ** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+ */
+int Waf_cLoseLock(struct waf_lock *lock);
+
+/**
+ ** Get a shared lock for read only.
+ ** @param lock: lock handler.
+ ** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+ */
+
+int Waf_getSharedLock(struct waf_lock *lock);
+
+/**
+ ** Get a exclusive lock for read and write.
+ ** @param lock: lock handler.
+ ** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+ */
+int Waf_getExclusiveLock(struct waf_lock *lock);
+
+/**
+ ** Free a shared lock that you have got before.
+ ** @param lock: lock handler.
+ ** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+ */
+int Waf_freeSharedLock(struct waf_lock *lock);
+
+/**
+ ** Free a exclusive lock that you have got before.
+ ** @param lock: lock handler.
+ ** return: WAF_LOCK_SUCCESS if successfully created or WAF_LOCK_ERROR if failed.
+ */
+int Waf_freeExclusiveLock(struct waf_lock *lock);
+
+/**
+ **========================================================
+ ** Lock Debug API
+ **========================================================
+ */
+/**
+ ** Check whether a return_code is an error.
+ ** @param return_code: the code returned by a Lock function.
+ ** return: True if there is an error;
+            False if not.
+ */
+bool Waf_lock_isError(int return_code);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/apache2/waf_lock/waf_lock_external.h
+++ b/apache2/waf_lock/waf_lock_external.h
@@ -35,7 +35,7 @@ extern "C" {
 #define WAF_ERROR_LOCK_LINUX_SEM_INIT_FAIL                      1102
 #define WAF_ERROR_LOCK_LINUX_SEM_MODIFY_FAIL                    1103
 #define WAF_ERROR_LOCK_LINUX_SEM_DESTROY_FAIL                   1104
-#define	WAF_ERROR_LOCK_LINUX_SEM_SET_PERMISSION_FAIL            1105
+#define WAF_ERROR_LOCK_LINUX_SEM_SET_PERMISSION_FAIL            1105
 #define	WAF_ERROR_LOCK_LINUX_SEM_GET_USER_FAIL                  1106
 
 #define WAF_ERROR_LOCK_WIN_NAME_INVALID_STRING                  1200

--- a/apache2/waf_lock/waf_lock_internal.h
+++ b/apache2/waf_lock/waf_lock_internal.h
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#ifndef _WAF_LOCK_INTERNAL_HEADER
+#define _WAF_LOCK_INTERNAL_HEADER
+
+#ifdef _WIN32
+#ifdef inline
+#undef inline
+#endif
+#include <windows.h>
+#include<Synchapi.h>
+#else
+#include<sys/shm.h>
+#include<sys/sem.h>
+#include<sys/ipc.h>
+#include <errno.h>
+#endif
+#include<cstring>
+#include<stdlib.h>
+#include<time.h>
+#include<stdio.h>
+#include<pwd.h>
+#include<grp.h>
+#include"waf_lock_external.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ **========================================================
+ ** Semaphore Operator Structure and Function
+ **========================================================
+ */
+
+#define DEFAULT_WAF_LOCK_ID_RANGE  0x8fffffff  // the default range of lock ID mapped by lock's name
+
+/**
+ **========================================================
+ ** Defaut Setting of Semaphore Set
+ **========================================================
+ */
+
+#define SEM_NUMBERS             2  // the number of semaphores in a semaphore set
+#define SEM_READ_INITVAL        10 // the initial value of read semaphore
+#define SEM_WRITE_INITVAL       1  // the initial value of write semaphore
+
+#define SEM_ID_READ             0  // the index of read semaphore in a semaphore set
+#define SEM_ID_WRITE            1  // the index of write semaphore in a semaphore set
+
+/**
+ ** Define the name suffix of Read/Write lock on Windows
+ */
+#ifdef _WIN32
+#define READ_LOCK_SUFFIX "_DB_LOCK_READ"
+#define WRITE_LOCK_SUFFIX "_DB_LOCK_WRITE"
+#endif
+
+/**
+ ** Required by Linux.
+ ** @param val:
+ ** @param buf:
+ ** @param array:
+ */
+union semun {
+    int val;
+    struct semid_ds *buf;
+    unsigned short *array;
+};
+
+/**
+ ** Create and initialize a waf_lock, if the lock with given key exists, just link to the lock.
+ ** The new_lock should have been created before calling this function.
+ ** @param new_lock:        The pointer to save the information of the lock.
+ ** @param new_lock_args:   The pointer to lock properties needed to create the lock .
+ ** return: WAF_SUCCESS_LOCK_CREATE if successfully created a new lock,
+ **         WAF_SUCCESS_LOCK_OPEN if successfully link to an existed lock,
+ **         WAF_LOCK_ERROR if failed.
+ */
+int lock_create(struct waf_lock *new_lock, struct waf_lock_args *new_lock_args);
+
+/**
+ ** Destroy the lock
+ ** @param waf_lock: The waf_lock sturcture
+ ** return: WAF_LOCK_SUCCESS if successfully destroy the lock,
+ **         WAF_LOCK_ERROR if failed.
+ */
+int lock_destroy(struct waf_lock *waf_lock);
+
+/**
+ ** Close the lock
+ ** @param waf_lock: The waf_lock sturcture
+ ** return: WAF_LOCK_SUCCESS if successfully close the lock,
+ **         WAF_LOCK_ERROR if failed.
+ */
+int lock_close(struct waf_lock *waf_lock);
+
+/**
+ ** Decrease a lock's value by a given number.
+ ** @param waf_lock: The waf_lock sturcture
+ ** @param index:   The index of atom lock (read or write) .
+ ** @param val:     The value you want to decrease from the lock.
+ ** return: WAF_LOCK_SUCCESS if success;
+ **         or WAF_LOCK_ERROR if failed
+ */
+int lock_P(const struct waf_lock *waf_lock, int index, int val);
+
+/**
+ ** Increase a lock's value by a given number.
+ ** @param waf_lock: The waf_lock sturcture
+ ** @param index:   The index of atom lock (read or write) .
+ ** @param val:     The value you want to add to the lock.
+ ** return: WAF_LOCK_SUCCESS if success;
+ **         or WAF_LOCK_ERROR if failed
+ */
+int lock_V(const struct waf_lock *waf_lock, int index, int val);
+
+/**
+ **========================================================
+ ** Other Function
+ **========================================================
+ */
+
+/**
+ ** Check the string format.
+ ** @param str: the string you want to check.
+ ** @param str_len: given string length (not include '\0').
+ ** return: WAF_LOCK_SUCCESS if the string length equals str_len;
+ **             WAF_LOCK_ERROR if not
+ */
+int Waf_lock_isstring(const char* str, int str_len);
+
+/**
+** Initialize the handle of lock.
+** @param waf_lock: the handle of Lock.
+** return:  if WAF_LOCK_SUCCESS if success
+**          or WAF_LOCK_ERROR if the handle is NULL.
+*/
+int Waf_lock_init(struct waf_lock* waf_lock);
+
+/**
+** Get user id by name.
+** @param name: name.
+** return:  if WAF_LOCK_SUCCESS if success
+**          or WAF_LOCK_ERROR if the handle is NULL.
+*/
+int GetUserId(const char* name, uid_t* id);
+
+/**
+** Get group id by name.
+** @param name: name.
+** return:  if WAF_LOCK_SUCCESS if success
+**          or WAF_LOCK_ERROR if the handle is NULL.
+*/
+int GetGroupId(const char* name, gid_t* id);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/standalone/Makefile.am
+++ b/standalone/Makefile.am
@@ -7,6 +7,7 @@ standalone_la_SOURCES = ../apache2/acmp.c \
     ../apache2/ag_mdb/ag_mdb.cpp \
     ../apache2/waf_logging/waf_format.pb.cc \
     ../apache2/waf_logging/waf_log_util.cc \
+    ../apache2/waf_lock/waf_lock.cpp \
     ../apache2/apache2_config.c \
     ../apache2/apache2_io.c \
     ../apache2/apache2_util.c \


### PR DESCRIPTION
first version of persistent lock utility for modsec
In Nginx, modsecurity_init will be called whenever there is config update and never released, so it will cause semaphore leak, and apr run time library doesn't have persistent lock api, so we implement this utility.

Have tested on the multiple work process and works fine. Also you need SecWafLockOwner to set permission of the lock if you want to use in non-root process