### PR TITLE
Nginx, scan all request bodies

### DIFF
--- a/nginx/modsecurity/ngx_http_modsecurity.c
+++ b/nginx/modsecurity/ngx_http_modsecurity.c
@@ -1038,10 +1038,8 @@ ngx_http_modsecurity_handler(ngx_http_request_t *r)
         return NGX_DECLINED;
     }
 
-    if (r->method == NGX_HTTP_POST 
-            && modsecIsRequestBodyAccessEnabled(ctx->req) ) {
 
-        /* read POST request body, should we process PUT? */
+    if (modsecIsRequestBodyAccessEnabled(ctx->req) && (r->headers_in.content_length || r->headers_in.chunked)) {
         rc = ngx_http_read_client_request_body(r, ngx_http_modsecurity_body_handler);
         if (rc >= NGX_HTTP_SPECIAL_RESPONSE) {
             return rc;
@@ -1049,8 +1047,7 @@ ngx_http_modsecurity_handler(ngx_http_request_t *r)
 
         return NGX_DONE;
     }
-    
-    /* other method */
+
     return ngx_http_modsecurity_status(r, modsecProcessRequestBody(ctx->req));
 }
 


### PR DESCRIPTION
This is to let Nginx scan not only POST requests bodies, but all request bodies.

I was hoping to find an indicator in Nginx's structs that tell a bit more definitive whether there was a body, but couldn't find such a variable. Checking whether there was either a length or chunked was the best I could find.

Tested manually by issuing the following requests which I believe covers the edge cases:
 - A simple GET with no req body
 - A GET with a req body (this is strange yes, but I believe valid)
 - A GET with a chunked req body
 - A GET with a 0 length chunked body
 - A GET with some trailing data after the headers where there would normally be a body
 - A GET with a body, and some trailing data after that
 - A POST with a body of type multipart/form-data
 - A POST with a chunked body of type multipart/form-data
 - A POST with a chunked body of type XML
 - A request with a non-standard made up verb rather than POST/GET/PUT/etc.
 - A request with a non-standard verb that was several kilobytes long
