### PR TITLE
Added support for RFC 5987 formatted HTTP headers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 ﻿.vscode
+*.swp
+*.stackdump
 *.obj
 *.tlog
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-﻿*.obj
+﻿.vscode
+*.obj
 *.tlog
 *.log
 *.pdb

--- a/apache2/msc_multipart.c
+++ b/apache2/msc_multipart.c
@@ -214,7 +214,7 @@ static int multipart_parse_content_disposition(modsec_rec *msr, char *c_d_value)
                 }
                 msr->multipart_filename = decoded_filename;
 
-                // Make sure to turn of INVALID quoting since RFC 5987 expects quotes in the filename format it expects.
+                // Make sure to turn of INVALID quoting since RFC 5987 expects quotes in the filename format.
                 msr->mpd->flag_invalid_quoting = 0;
             }
             else

--- a/apache2/msc_multipart.c
+++ b/apache2/msc_multipart.c
@@ -198,23 +198,38 @@ static int multipart_parse_content_disposition(modsec_rec *msr, char *c_d_value)
                     log_escape_nq(msr->mp, value));
             }
         }
-        else
-        if (strcmp(name, "filename") == 0) {
+        else if ((strcmp(name, "filename") == 0) || (strcmp(name, "filename*") == 0))
+        {
 
-            validate_quotes(msr, value);
+            char *decoded_filename = NULL;
 
-            msr->multipart_filename = apr_pstrdup(msr->mp, value);
+            if (strcmp(name, "filename*") == 0)
+            {
+                decoded_filename = rfc5987_decode(msr->mp, value);
+                msr->multipart_filename = decoded_filename;
 
-            if (msr->mpd->mpp->filename != NULL) {
+                // Make sure to turn of INVALID quoting since RFC 5987 supports it.
+                msr->mpd->flag_invalid_quoting = 0;
+            }
+            else
+            {
+                decoded_filename = value;
+                validate_quotes(msr, value);
+                msr->multipart_filename = apr_pstrdup(msr->mp, value);
+            }
+
+            if (msr->mpd->mpp->filename != NULL)
+            {
                 msr_log(msr, 4, "Multipart: Warning: Duplicate Content-Disposition filename: %s",
-                    log_escape_nq(msr->mp, value));
+                        log_escape_nq(msr->mp, decoded_filename));
                 return -15;
             }
-            msr->mpd->mpp->filename = value;
+            msr->mpd->mpp->filename = decoded_filename;
 
-            if (msr->txcfg->debuglog_level >= 9) {
+            if (msr->txcfg->debuglog_level >= 9)
+            {
                 msr_log(msr, 9, "Multipart: Content-Disposition filename: %s",
-                    log_escape_nq(msr->mp, value));
+                        log_escape_nq(msr->mp, decoded_filename));
             }
         }
         else return -11;
@@ -307,7 +322,7 @@ static int multipart_process_part_header(modsec_rec *msr, char **error_msg) {
              * values from the C-D header. We need to check for the case where they
              * didn't understand C-D but we did.
              */
-            if (strstr(header_value, "filename=") == NULL) {
+            if ((strstr(header_value, "filename=") == NULL) && (strstr(header_value, "filename*=") == NULL)) {
                 *error_msg = apr_psprintf(msr->mp, "Multipart: Invalid Content-Disposition header (filename).");
                 return -1;
             }

--- a/apache2/msc_util.c
+++ b/apache2/msc_util.c
@@ -1779,6 +1779,98 @@ int urldecode_nonstrict_inplace_ex(unsigned char *input, long int input_len, int
     return count;
 }
 
+// RFC 5987 allows HTTP values to be non-ASCII characters.
+// As per RFC 5987 the value can be encoded as UTF-8 or ISO-8859-1. Since HTTP doesn't support non-ASCII characters, 
+// when using the extended value format specified by RFC 5987 the value is double encoded.
+// The value is first encoded into an octet stream in the format specified in the extended format (UTF-8 or ISO-8859-1)
+// and then the octet stream itself is encoded using URL encoding.
+// RFC 5987 specifies the extended value format to be as follows:
+//  `value = <utf-8|iso-8859-1>'<language>'<URL encoded octect stream>.
+// The function, takes in a RFC 5987 encoded value and decodes it to a UTF-8 encoded string (even if the RFC 5987 was encoded using ISO-8859-1).
+char *rfc5987_decode(apr_pool_t *mptmp, char *value)
+{
+    const char utf8[] = "utf-8";
+    const char iso88591[] = "iso-8859-1";
+    int len = strlen(value);
+    char *urlEncodedValue = strstr(value, "'");
+
+    if (!urlEncodedValue)
+    {
+        return NULL;
+    }
+
+    // Find the URL encoded string. 'URLEncodedValue' is already set to the first occurence of the quote, the format of the extended value as per RFC 5987 is
+    // `value = <utf-8|iso-8859-1>'<language>'<URL encoded octect stream>
+    if (strlen(urlEncodedValue) > 0)
+    {
+        // Remove the leading single quotes.
+        urlEncodedValue++;
+        urlEncodedValue = strstr(urlEncodedValue, "'");
+
+        if (!urlEncodedValue)
+        {
+            return NULL;
+        }
+
+        // Remove the terminating single quotes.
+        urlEncodedValue++;
+    }
+
+    // The decode that we perform will be in place, hence lets allocate a new buffer for URL encoded value that we are processing.
+    urlEncodedValue = apr_pstrdup(mptmp, urlEncodedValue);
+
+    if (strncmp(value, utf8, strlen(utf8)) == 0)
+    {
+        // The value is an extended value with UTF-8 encoding.
+        int invalid_count;
+        int changed;
+        if (urldecode_nonstrict_inplace_ex(urlEncodedValue, strlen(urlEncodedValue), &invalid_count, &changed) > 0)
+        {
+            return urlEncodedValue;
+        }
+        else
+        {
+            return NULL;
+        }
+    }
+    else if (strncmp(value, iso88591, strlen(iso88591)) == 0)
+    {
+        // The value is an extended value with ISO-8859-1 encoding.
+        int invalid_count;
+        int changed;
+        int isoCount = 0;
+        char *utf8EncodedValue = NULL;
+        int outLen = 0;
+        if ((isoCount = urldecode_nonstrict_inplace_ex(urlEncodedValue, strlen(urlEncodedValue), &invalid_count, &changed)) > 0)
+        {
+            // The URLdecoded string is in ISO-8859-1 format, convert it to UTF-8.
+            outLen = 2 * isoCount;
+            utf8EncodedValue = apr_palloc(mptmp, outLen);
+
+            if (isolat1ToUTF8(utf8EncodedValue, &outLen, (const unsigned char *)urlEncodedValue, &isoCount) > 0)
+            {
+                // We want a null-terminated UTF-8 string.
+                utf8EncodedValue[outLen + 1] = '\0';
+                return utf8EncodedValue;
+            }
+            else
+            {
+                return NULL;
+            }
+        }
+        else
+        {
+            return NULL;
+        }
+    }
+    else
+    {
+        return NULL;
+    }
+
+    return NULL;
+}
+
 /**
  *
  * IMP1 Assumes NUL-terminated

--- a/apache2/msc_util.c
+++ b/apache2/msc_util.c
@@ -1791,8 +1791,9 @@ char *rfc5987_decode(apr_pool_t *mptmp, char *value)
 {
     const char utf8[] = "utf-8";
     const char iso88591[] = "iso-8859-1";
+    const char rfc5987Delimiter[] = "'";
     int len = strlen(value);
-    char *urlEncodedValue = strstr(value, "'");
+    char *urlEncodedValue = strstr(value, rfc5987Delimiter);
 
     if (!urlEncodedValue)
     {
@@ -1805,7 +1806,7 @@ char *rfc5987_decode(apr_pool_t *mptmp, char *value)
     {
         // Remove the leading single quotes.
         urlEncodedValue++;
-        urlEncodedValue = strstr(urlEncodedValue, "'");
+        urlEncodedValue = strstr(urlEncodedValue, rfc5987Delimiter);
 
         if (!urlEncodedValue)
         {
@@ -1828,10 +1829,6 @@ char *rfc5987_decode(apr_pool_t *mptmp, char *value)
         {
             return urlEncodedValue;
         }
-        else
-        {
-            return NULL;
-        }
     }
     else if (strncmp(value, iso88591, strlen(iso88591)) == 0)
     {
@@ -1853,21 +1850,10 @@ char *rfc5987_decode(apr_pool_t *mptmp, char *value)
                 utf8EncodedValue[outLen + 1] = '\0';
                 return utf8EncodedValue;
             }
-            else
-            {
-                return NULL;
-            }
         }
-        else
-        {
-            return NULL;
-        }
-    }
-    else
-    {
-        return NULL;
     }
 
+    // Error
     return NULL;
 }
 

--- a/apache2/msc_util.h
+++ b/apache2/msc_util.h
@@ -126,6 +126,8 @@ int DSOLOCAL urldecode_uni_nonstrict_inplace_ex(unsigned char *input, long int i
 
 int DSOLOCAL urldecode_nonstrict_inplace_ex(unsigned char *input, long int input_length, int *invalid_count, int *changed);
 
+char* DSOLOCAL rfc5987_decode(apr_pool_t *mptmp, char* value);
+
 int DSOLOCAL html_entities_decode_inplace(apr_pool_t *mp, unsigned char *input, int len);
 
 int DSOLOCAL ansi_c_sequences_decode_inplace(unsigned char *input, int len);


### PR DESCRIPTION
RFC 5987 allows HTTP headers to be encoded in non-ASCII strings. It currently supports UTF-8 and ISO-8859-1. This commit adds infrastructure for decoding HTTP headers that are sent using the RFC 5987 format. It also uses this infrastructure to allow parsing of the `filename` attribute in the "Content-Disposition" headers in multi-part form data, when the `filename` attribute is being send in RFC 5987 format.

Tests performed:
* Used the RawRequest generated by @allanbomsft  to send The following HTTP request to test ISO-8859-1 support:
```
POST /?a=1 HTTP/1.1
Content-Type: multipart/form-data; boundary=------------------------1aa6ce6559102
Accept: */*
Host: example.net
Max-Forwards: 10
User-Agent: myuseragent
Cookie: test123=123; test456=123
Content-Length: {{bodylength}}

--------------------------1aa6ce6559102
content-disposition: form-data; name="b"; filename*="iso-8859-1''%A2Crazy%D6Hello.png"

Hello world.
--------------------------1aa6ce6559102--
```
* Used the RawRequest generated by @allanbomsft  to send The following HTTP request to test UTF-8 support:
```
POST /?a=1 HTTP/1.1
Content-Type: multipart/form-data; boundary=------------------------1aa6ce6559102
Accept: */*
Host: example.net
Max-Forwards: 10
User-Agent: myuseragent
Cookie: test123=123; test456=123
Content-Length: {{bodylength}}

--------------------------1aa6ce6559102
content-disposition: form-data; name="b"; filename*="utf-8'en'%A2Crazy%D6Hello.png"

Hello world.
--------------------------1aa6ce6559102--
```

For both of the above tests was able to observe the correct decoding for the UTF-8 and ISO-8859-1 encodings in the debug logs.


* Also tested the behavior of the Modsecurity with errorneously formatted strings for `filename*` attribute. 

* Tested the setup with the regular `filename` attribute as well.



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/modsecurity/37)
<!-- Reviewable:end -->
