### PR TITLE
Fixed the handling of "filename" and "filename*" attribute in Content…

### DIFF
--- a/apache2/msc_multipart.c
+++ b/apache2/msc_multipart.c
@@ -94,8 +94,9 @@ static int multipart_parse_content_disposition(modsec_rec *msr, char *c_d_value)
     if (*p != ';') return -2;
     p++;
 
-    /* parse the appended parts */
+    int filenamePresent = 0;
 
+    /* parse the appended parts */
     while(*p != '\0') {
         char *name = NULL, *value = NULL, *start = NULL;
 
@@ -205,6 +206,9 @@ static int multipart_parse_content_disposition(modsec_rec *msr, char *c_d_value)
 
             if (strcmp(name, "filename*") == 0)
             {
+                 // Make sure to turn of INVALID quoting since RFC 5987 expects quotes in the filename format.
+                msr->mpd->flag_invalid_quoting = 0;
+
                 decoded_filename = rfc5987_decode(msr->mp, value);
                 if (!decoded_filename)
                 {
@@ -226,25 +230,27 @@ static int multipart_parse_content_disposition(modsec_rec *msr, char *c_d_value)
                 // The `filename*` RCF 5987 encoded filename always overrides the `filename` parameter in content-disposition header.
                 msr->mpd->mpp->filename = msr->mpd->mpp->filenameext;
 
-                // Make sure to turn of INVALID quoting since RFC 5987 expects quotes in the filename format.
-                msr->mpd->flag_invalid_quoting = 0;
+                // Re-run the validation check on the filename. We shouldn't be seeing quotes in the UTF-8 formatted filename either.
+                validate_quotes(msr, msr->mpd->mpp->filename);
             }
             else
             {
                 // Process the `filename` attribute in the content-disposition header only if `filename*` does not exist.
+                filenamePresent++;
+                if (filenamePresent > 1)
+                {
+                    // Duplicate `filename` attributes are not allowed.
+                    msr_log(msr, 4, "Multipart: Warning: Duplicate Content-Disposition filename: %s",
+                            log_escape_nq(msr->mp, decoded_filename));
+                    return -15;
+                }
+
                 if (msr->mpd->mpp->filenameext == NULL)
                 {
                     // "name == 'filename'"
                     decoded_filename = value;
                     validate_quotes(msr, value);
                     msr->multipart_filename = apr_pstrdup(msr->mp, decoded_filename);
-
-                    if (msr->mpd->mpp->filename != NULL)
-                    {
-                        msr_log(msr, 4, "Multipart: Warning: Duplicate Content-Disposition filename: %s",
-                                log_escape_nq(msr->mp, decoded_filename));
-                        return -15;
-                    }
                     msr->mpd->mpp->filename = decoded_filename;
                 }
             }

--- a/apache2/msc_multipart.h
+++ b/apache2/msc_multipart.h
@@ -53,6 +53,9 @@ struct multipart_part {
     /* files only, filename as supplied by the browser */
     char                    *filename;
 
+    /* files only, filename as supplied by the browser in RFC 5987 format */
+    char                    *filenameext;
+
     char                    *last_header_name;
     apr_table_t             *headers;
 


### PR DESCRIPTION
This fix allows "filename" and "filename*" to be part of the same Content-Disposition header. When both attributes are present "filename*" always takes precedence.
```
POST /?a=1 HTTP/1.1
Content-Type: multipart/form-data; boundary=------------------------1aa6ce6559102
Accept: */*
Host: example.net
Max-Forwards: 10
User-Agent: myuseragent
Cookie: test123=123; test456=123
Content-Length: {{bodylength}}

--------------------------1aa6ce6559102
content-disposition: form-data; name="b"; filename="03CB16644685216C1E818D1369BB5D4B.png"; filename*="utf-8''03CB16644685216C1E818D1369BB5D4B.png"

Hello world.
--------------------------1aa6ce6559102--
```
Tested the fix against the above payload. We were able to reproduce the problem against the specific payload and were able to run the test successfully against the payload and get a 200 OK.

* Tested validation with quotes:
```
POST /?a=1 HTTP/1.1
Content-Type: multipart/form-data; boundary=------------------------1aa6ce6559102
Accept: */*
Host: example.net
Max-Forwards: 10
User-Agent: myuseragent
Cookie: test123=123; test456=123
Content-Length: {{bodylength}}

--------------------------1aa6ce6559102
content-disposition: form-data; name="b"; filename*="utf-8''Hello%A9%B5C'razy.png"

Hello world.
--------------------------1aa6ce6559102--
```
* Tested validation with duplicate filenames:
```
POST /?a=1 HTTP/1.1
Content-Type: multipart/form-data; boundary=------------------------1aa6ce6559102
Accept: */*
Host: example.net
Max-Forwards: 10
User-Agent: myuseragent
Cookie: test123=123; test456=123
Content-Length: {{bodylength}}

--------------------------1aa6ce6559102
content-disposition: form-data; name="b"; filename*="utf-8''03CB16644685216C1E818D1369BB5D4B.png"; filename="03CB16644685216C1E818D1369BB5D4B.png"; filename="03CB16644685216C1E818D1369BB5D4B.png"

Hello world.
--------------------------1aa6ce6559102--
```