### PR TITLE
Re-factored the code for supporting RFC 5987.

### DIFF
--- a/apache2/msc_multipart.h
+++ b/apache2/msc_multipart.h
@@ -53,9 +53,6 @@ struct multipart_part {
     /* files only, filename as supplied by the browser */
     char                    *filename;
 
-    /* files only, filename as supplied by the browser in RFC 5987 format */
-    char                    *filenameext;
-
     char                    *last_header_name;
     apr_table_t             *headers;
 


### PR DESCRIPTION
Re-wrote the logic to detect duplication `filename` and `filename*` attributes in Content-Disposition headers.