### PR TITLE
Fixing Linux build breakage

### DIFF
--- a/apache2/msc_util.h
+++ b/apache2/msc_util.h
@@ -126,7 +126,7 @@ int DSOLOCAL urldecode_uni_nonstrict_inplace_ex(unsigned char *input, long int i
 
 int DSOLOCAL urldecode_nonstrict_inplace_ex(unsigned char *input, long int input_length, int *invalid_count, int *changed);
 
-char* DSOLOCAL rfc5987_decode(apr_pool_t *mptmp, char* value);
+char DSOLOCAL *rfc5987_decode(apr_pool_t *mptmp, char* value);
 
 int DSOLOCAL html_entities_decode_inplace(apr_pool_t *mp, unsigned char *input, int len);
 


### PR DESCRIPTION
* Linux build was broken due to the declaration of rfc5987_decode(). Revise the rfc5987_decode()declaration and fix this bug.