### PR TITLE
fix lock permission, let people set user and group

### DIFF
--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -1228,7 +1228,7 @@ static const char *cmd_waf_lock_group(cmd_parms *cmd,
 
     return NULL;
 }
-#endif
+#endif // _WIN32
 
 static const char *cmd_action(cmd_parms *cmd, void *_dcfg, const char *p1)
 {
@@ -4076,6 +4076,6 @@ const command_rec module_directives[] = {
         CMD_SCOPE_ANY,
         "Set waf lock group"
     ),
-#endif
+#endif // __WIN32
     { NULL }
 };

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -1202,6 +1202,7 @@ static const char *cmd_waf_instanceId(cmd_parms *cmd,
 }
 #endif
 
+#ifndef _WIN32
 static const char *cmd_waf_lock_user(cmd_parms *cmd,
         void *_dcfg, const char *p1)
 {
@@ -1227,6 +1228,7 @@ static const char *cmd_waf_lock_group(cmd_parms *cmd,
 
     return NULL;
 }
+#endif
 
 static const char *cmd_action(cmd_parms *cmd, void *_dcfg, const char *p1)
 {
@@ -4059,19 +4061,21 @@ const command_rec module_directives[] = {
         "Set waf instanceId"
     ),
 #endif
+#ifndef _WIN32
     AP_INIT_TAKE1 (
         "SecWafLockUser",
         cmd_waf_lock_user,
         NULL,
         CMD_SCOPE_ANY,
-        "Set waf lock owner"
+        "Set waf lock user"
     ),
     AP_INIT_TAKE1 (
         "SecWafLockGroup",
         cmd_waf_lock_group,
         NULL,
         CMD_SCOPE_ANY,
-        "Set waf lock owner"
+        "Set waf lock group"
     ),
+#endif
     { NULL }
 };

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -1200,20 +1200,33 @@ static const char *cmd_waf_instanceId(cmd_parms *cmd,
 
     return NULL;
 }
+#endif
 
-static const char *cmd_waf_lock_owner(cmd_parms *cmd,
+static const char *cmd_waf_lock_user(cmd_parms *cmd,
         void *_dcfg, const char *p1)
 {
 
     if (cmd->server->is_virtual) {
-        return "ModSecurity: SecWafLockOwner not allowed in VirtualHost";
+        return "ModSecurity: SecWafLockUser not allowed in VirtualHost";
     }
 
-    msc_waf_lock_owner = (char *)p1;
+    msc_waf_lock_user = (char *)p1;
 
     return NULL;
 }
-#endif
+
+static const char *cmd_waf_lock_group(cmd_parms *cmd,
+        void *_dcfg, const char *p1)
+{
+
+    if (cmd->server->is_virtual) {
+        return "ModSecurity: SecWafLockGroup not allowed in VirtualHost";
+    }
+
+    msc_waf_lock_group = (char *)p1;
+
+    return NULL;
+}
 
 static const char *cmd_action(cmd_parms *cmd, void *_dcfg, const char *p1)
 {
@@ -4045,13 +4058,20 @@ const command_rec module_directives[] = {
         CMD_SCOPE_ANY,
         "Set waf instanceId"
     ),
+#endif
     AP_INIT_TAKE1 (
-        "SecWafLockOwner",
-        cmd_waf_lock_owner,
+        "SecWafLockUser",
+        cmd_waf_lock_user,
         NULL,
         CMD_SCOPE_ANY,
         "Set waf lock owner"
     ),
-#endif
+    AP_INIT_TAKE1 (
+        "SecWafLockGroup",
+        cmd_waf_lock_group,
+        NULL,
+        CMD_SCOPE_ANY,
+        "Set waf lock owner"
+    ),
     { NULL }
 };

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -93,8 +93,8 @@ TreeRoot DSOLOCAL *conn_write_state_whitelist = 0;
 TreeRoot DSOLOCAL *conn_write_state_suspicious_list = 0;
 
 #ifdef WAF_JSON_LOGGING_ENABLE
-char DSOLOCAL *msc_waf_resourceId = "";
-char DSOLOCAL *msc_waf_instanceId = "";
+char DSOLOCAL *msc_waf_resourceId = NULL;
+char DSOLOCAL *msc_waf_instanceId = NULL;
 #endif
 
 char DSOLOCAL *msc_waf_lock_user;

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -97,8 +97,10 @@ char DSOLOCAL *msc_waf_resourceId = NULL;
 char DSOLOCAL *msc_waf_instanceId = NULL;
 #endif
 
+#ifndef _WIN32
 char DSOLOCAL *msc_waf_lock_user;
 char DSOLOCAL *msc_waf_lock_group;
+#endif
 
 #if defined(WIN32) || defined(VERSION_NGINX)
 int (*modsecDropAction)(request_rec *r) = NULL;

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -95,8 +95,10 @@ TreeRoot DSOLOCAL *conn_write_state_suspicious_list = 0;
 #ifdef WAF_JSON_LOGGING_ENABLE
 char DSOLOCAL *msc_waf_resourceId = "";
 char DSOLOCAL *msc_waf_instanceId = "";
-char DSOLOCAL *msc_waf_lock_owner = "root";
 #endif
+
+char DSOLOCAL *msc_waf_lock_user;
+char DSOLOCAL *msc_waf_lock_group;
 
 #if defined(WIN32) || defined(VERSION_NGINX)
 int (*modsecDropAction)(request_rec *r) = NULL;
@@ -834,6 +836,10 @@ static int hook_post_config(apr_pool_t *mp, apr_pool_t *mp_log, apr_pool_t *mp_t
  */
 static void hook_child_init(apr_pool_t *mp, server_rec *s) {
     modsecurity_child_init(modsecurity);
+}
+
+static void hook_set_lock_owner(const char *user, const char *group) {
+    modsecurity_set_lock_owner(user, group);
 }
 
 /**
@@ -1710,6 +1716,7 @@ static void register_hooks(apr_pool_t *mp) {
     ap_hook_post_config(hook_post_config, postconfig_beforeme_list,
         postconfig_afterme_list, APR_HOOK_REALLY_LAST);
     ap_hook_child_init(hook_child_init, NULL, NULL, APR_HOOK_MIDDLE);
+    ap_hook_set_lock_owner(hook_set_lock_owner, NULL, NULL, APR_HOOK_MIDDLE);
 
     /* Our own hook to handle RPC transactions (not used at the moment).
      * // ap_hook_handler(hook_handler, NULL, NULL, APR_HOOK_MIDDLE);

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -838,9 +838,11 @@ static void hook_child_init(apr_pool_t *mp, server_rec *s) {
     modsecurity_child_init(modsecurity);
 }
 
+#ifndef _WIN32
 static void hook_set_lock_owner(const char *user, const char *group) {
     modsecurity_set_lock_owner(user, group);
 }
+#endif
 
 /**
  * Initial request processing, executed immediatelly after
@@ -1716,8 +1718,10 @@ static void register_hooks(apr_pool_t *mp) {
     ap_hook_post_config(hook_post_config, postconfig_beforeme_list,
         postconfig_afterme_list, APR_HOOK_REALLY_LAST);
     ap_hook_child_init(hook_child_init, NULL, NULL, APR_HOOK_MIDDLE);
+    
+#ifndef _WIN32
     ap_hook_set_lock_owner(hook_set_lock_owner, NULL, NULL, APR_HOOK_MIDDLE);
-
+#endif
     /* Our own hook to handle RPC transactions (not used at the moment).
      * // ap_hook_handler(hook_handler, NULL, NULL, APR_HOOK_MIDDLE);
      */

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -164,6 +164,8 @@ static void set_lock_args(struct waf_lock_args *lock_args, int lock_id) {
 
 #else
     lock_args->lock_id = lock_id;
+    lock_args->user = msc_waf_lock_user;
+    lock_args->group = msc_waf_lock_group;
 #endif
 }
 
@@ -285,6 +287,11 @@ void modsecurity_child_init(msc_engine *msce) {
     waf_create_lock(msce->dbm_lock, lock_args);    
 #endif
 
+}
+
+void modsecurity_set_lock_owner(const char *user, const char *group) {
+    msc_waf_lock_user = user;
+    msc_waf_lock_group = group;
 }
 
 /**

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -289,10 +289,12 @@ void modsecurity_child_init(msc_engine *msce) {
 
 }
 
+#ifndef _WIN32
 void modsecurity_set_lock_owner(const char *user, const char *group) {
     msc_waf_lock_user = user;
     msc_waf_lock_group = group;
 }
+#endif
 
 /**
  * Releases resources held by engine instance.

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -738,7 +738,9 @@ int DSOLOCAL modsecurity_init(msc_engine *msce, apr_pool_t *mp);
 
 void DSOLOCAL modsecurity_child_init(msc_engine *msce);
 
+#ifndef _WIN32
 void DSOLOCAL modsecurity_set_lock_owner(const char* user, const char* group);
+#endif
 
 void DSOLOCAL modsecurity_shutdown(msc_engine *msce);
 

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -171,8 +171,10 @@ extern DSOLOCAL int *unicode_map_table;
 #ifdef WAF_JSON_LOGGING_ENABLE
 extern DSOLOCAL char *msc_waf_resourceId;
 extern DSOLOCAL char *msc_waf_instanceId;
-extern DSOLOCAL char *msc_waf_lock_owner;
 #endif
+
+extern DSOLOCAL char *msc_waf_lock_user;
+extern DSOLOCAL char *msc_waf_lock_group;
 
 #define AUDITLOG_LOCK_ID                1
 #define WAFJSONLOG_LOCK_ID              2
@@ -735,6 +737,8 @@ msc_engine DSOLOCAL *modsecurity_create(apr_pool_t *mp, int processing_mode);
 int DSOLOCAL modsecurity_init(msc_engine *msce, apr_pool_t *mp);
 
 void DSOLOCAL modsecurity_child_init(msc_engine *msce);
+
+void DSOLOCAL modsecurity_set_lock_owner(const char* user, const char* group);
 
 void DSOLOCAL modsecurity_shutdown(msc_engine *msce);
 

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -173,8 +173,10 @@ extern DSOLOCAL char *msc_waf_resourceId;
 extern DSOLOCAL char *msc_waf_instanceId;
 #endif
 
+#ifndef _WIN32
 extern DSOLOCAL char *msc_waf_lock_user;
 extern DSOLOCAL char *msc_waf_lock_group;
+#endif
 
 #define AUDITLOG_LOCK_ID                1
 #define WAFJSONLOG_LOCK_ID              2

--- a/apache2/waf_lock/waf_lock.cpp
+++ b/apache2/waf_lock/waf_lock.cpp
@@ -21,6 +21,8 @@
 // Linux
 int lock_create(struct waf_lock *new_lock, struct waf_lock_args *new_lock_args) {
     union semun sem_union;
+    uid_t uid;
+    gid_t gid;
 
     if (new_lock == NULL)
         return WAF_LOCK_ERROR_HANDLE_NULL;
@@ -30,7 +32,22 @@ int lock_create(struct waf_lock *new_lock, struct waf_lock_args *new_lock_args) 
         // Set permssion
 	struct semid_ds buf;
 
-	buf.sem_perm.mode = 0666;
+    if (new_lock_args->user != NULL && new_lock_args->group != NULL)
+    {
+        if ((GetUserId(new_lock_args->user, &uid) == WAF_LOCK_ERROR) || (GetGroupId(new_lock_args->group, &gid) == WAF_LOCK_ERROR)) {
+            lock_destroy(new_lock);
+            return WAF_ERROR_LOCK_LINUX_SEM_GET_USER_FAIL;
+	    }
+
+ 	    buf.sem_perm.uid = uid; 
+	    buf.sem_perm.gid = gid; 
+	    buf.sem_perm.mode = 0600;
+    }
+    else
+    {
+	    buf.sem_perm.mode = 0666;
+    }
+
 	sem_union.buf = &buf;
 	// Set the permission for the new lock
         if (semctl(new_lock->sem_id, 0, IPC_SET, sem_union) == -1) {
@@ -536,4 +553,23 @@ int waf_close_lock(struct waf_lock *waf_lock) {
         return rc_lock;
     else
         return WAF_LOCK_SUCCESS;
+}
+
+int GetGroupId(const char *name, gid_t *id)
+{
+    struct group *grp = getgrnam(name); /* don't free, see getgrnam() for details */
+    if(grp == NULL) {
+        return WAF_LOCK_ERROR;
+    } 
+     *id = grp->gr_gid;
+    return WAF_LOCK_SUCCESS;
+}
+ int GetUserId(const char *name, uid_t *id)
+{
+    struct passwd *pwd = getpwnam(name); /* don't free, see getpwnam() for details */
+    if(pwd == NULL) {
+        return WAF_LOCK_ERROR;
+    } 
+     *id = pwd->pw_uid;
+    return WAF_LOCK_SUCCESS;
 }

--- a/apache2/waf_lock/waf_lock.cpp
+++ b/apache2/waf_lock/waf_lock.cpp
@@ -34,7 +34,8 @@ int lock_create(struct waf_lock *new_lock, struct waf_lock_args *new_lock_args) 
 
     if (new_lock_args->user != NULL && new_lock_args->group != NULL)
     {
-        if ((GetUserId(new_lock_args->user, &uid) == WAF_LOCK_ERROR) || (GetGroupId(new_lock_args->group, &gid) == WAF_LOCK_ERROR)) {
+        if ((GetUserId(new_lock_args->user, &uid) == WAF_LOCK_ERROR) || (GetGroupId(new_lock_args->group, &gid) == WAF_LOCK_ERROR)) 
+        {
             lock_destroy(new_lock);
             return WAF_ERROR_LOCK_LINUX_SEM_GET_USER_FAIL;
 	    }
@@ -559,19 +560,21 @@ int waf_close_lock(struct waf_lock *waf_lock) {
 int GetGroupId(const char *name, gid_t *id)
 {
     struct group *grp = getgrnam(name); /* don't free, see getgrnam() for details */
-    if(grp == NULL) {
+    if(grp == NULL) 
+    {
         return WAF_LOCK_ERROR;
     } 
-     *id = grp->gr_gid;
+    *id = grp->gr_gid;
     return WAF_LOCK_SUCCESS;
 }
  int GetUserId(const char *name, uid_t *id)
 {
     struct passwd *pwd = getpwnam(name); /* don't free, see getpwnam() for details */
-    if(pwd == NULL) {
+    if(pwd == NULL) 
+    {
         return WAF_LOCK_ERROR;
     } 
-     *id = pwd->pw_uid;
+    *id = pwd->pw_uid;
     return WAF_LOCK_SUCCESS;
 }
 #endif

--- a/apache2/waf_lock/waf_lock.cpp
+++ b/apache2/waf_lock/waf_lock.cpp
@@ -555,6 +555,7 @@ int waf_close_lock(struct waf_lock *waf_lock) {
         return WAF_LOCK_SUCCESS;
 }
 
+#ifndef _WIN32
 int GetGroupId(const char *name, gid_t *id)
 {
     struct group *grp = getgrnam(name); /* don't free, see getgrnam() for details */
@@ -573,3 +574,4 @@ int GetGroupId(const char *name, gid_t *id)
      *id = pwd->pw_uid;
     return WAF_LOCK_SUCCESS;
 }
+#endif

--- a/apache2/waf_lock/waf_lock_external.h
+++ b/apache2/waf_lock/waf_lock_external.h
@@ -36,6 +36,7 @@ extern "C" {
 #define WAF_ERROR_LOCK_LINUX_SEM_MODIFY_FAIL                    1103
 #define WAF_ERROR_LOCK_LINUX_SEM_DESTROY_FAIL                   1104
 #define WAF_ERROR_LOCK_LINUX_SEM_SET_PERMISSION_FAIL            1105
+#define WAF_ERROR_LOCK_LINUX_SEM_GET_USER_FAIL                  1106
 
 #define WAF_ERROR_LOCK_WIN_NAME_INVALID_STRING                  1200
 #define WAF_ERROR_LOCK_WIN_MUTEX_CREATE_FAIL                    1201
@@ -88,6 +89,8 @@ struct waf_lock {
 struct waf_lock_args {
 #ifndef _WIN32
     int   lock_id;
+    char *user;
+    char *group;
 #else
     char *lock_name;
     int   lock_name_length;

--- a/apache2/waf_lock/waf_lock_internal.h
+++ b/apache2/waf_lock/waf_lock_internal.h
@@ -138,6 +138,21 @@ int Waf_lock_isstring(const char* str, int str_len);
 */
 int Waf_lock_init(struct waf_lock* waf_lock);
 
+/**
+** Get user id by name.
+** @param name: name.
+** return:  if WAF_LOCK_SUCCESS if success
+**          or WAF_LOCK_ERROR if the handle is NULL.
+*/
+int GetUserId(const char* name, uid_t* id);
+ /**
+** Get group id by name.
+** @param name: name.
+** return:  if WAF_LOCK_SUCCESS if success
+**          or WAF_LOCK_ERROR if the handle is NULL.
+*/
+int GetGroupId(const char* name, gid_t* id);
+
 #ifdef __cplusplus
 }
 #endif

--- a/apache2/waf_lock/waf_lock_internal.h
+++ b/apache2/waf_lock/waf_lock_internal.h
@@ -153,7 +153,7 @@ int GetUserId(const char* name, uid_t* id);
 **          or WAF_LOCK_ERROR if the handle is NULL.
 */
 int GetGroupId(const char* name, gid_t* id);
-#endif
+#endif // _WIN32
 
 #ifdef __cplusplus
 }

--- a/apache2/waf_lock/waf_lock_internal.h
+++ b/apache2/waf_lock/waf_lock_internal.h
@@ -138,6 +138,7 @@ int Waf_lock_isstring(const char* str, int str_len);
 */
 int Waf_lock_init(struct waf_lock* waf_lock);
 
+#ifndef _WIN32
 /**
 ** Get user id by name.
 ** @param name: name.
@@ -152,6 +153,7 @@ int GetUserId(const char* name, uid_t* id);
 **          or WAF_LOCK_ERROR if the handle is NULL.
 */
 int GetGroupId(const char* name, gid_t* id);
+#endif
 
 #ifdef __cplusplus
 }

--- a/standalone/api.c
+++ b/standalone/api.c
@@ -79,7 +79,10 @@ DECLARE_HOOK(void, error_log, (const char *file, int line, int level,
 DECLARE_HOOK(int,log_transaction,(request_rec *r))
 DECLARE_HOOK(void,insert_filter,(request_rec *r))
 DECLARE_HOOK(void,insert_error_filter,(request_rec *r))
+
+#ifndef _WIN32
 DECLARE_HOOK(void,set_lock_owner,(const char *user, const char *group))
+#endif
 
 char *sa_name = "standalone";
 const char *sa_name_argv[] = { "standalone", NULL };
@@ -325,9 +328,11 @@ void modsecInitProcess()    {
     hookfn_child_init(pool, server);
 }
 
+#ifndef _WIN32
 void modsecSetLockOwner(const char *user, const char *group)    {
     hookfn_set_lock_owner(user, group);
 }
+#endif
 
 conn_rec *modsecNewConnection() {
     conn_rec *c;

--- a/standalone/api.c
+++ b/standalone/api.c
@@ -64,6 +64,10 @@ extern ns##_HOOK_##name##_t *hookfn_##name;
 #define DECLARE_HOOK(ret,name,args) \
     DECLARE_EXTERNAL_HOOK(ap,AP,ret,name,args)
 
+#define AP_DECLARE_HOOK(ret,name,args) \
+        APR_DECLARE_EXTERNAL_HOOK(ap,AP,ret,name,args)
+AP_DECLARE_HOOK(void,set_lock_owner,(const char *user, const char *group))
+
 DECLARE_HOOK(int,pre_config,(apr_pool_t *pconf,apr_pool_t *plog, apr_pool_t *ptemp))
 DECLARE_HOOK(int,post_config,(apr_pool_t *pconf,apr_pool_t *plog, apr_pool_t *ptemp,server_rec *s))
 DECLARE_HOOK(void,child_init,(apr_pool_t *pchild, server_rec *s))
@@ -77,6 +81,7 @@ DECLARE_HOOK(void, error_log, (const char *file, int line, int level,
 DECLARE_HOOK(int,log_transaction,(request_rec *r))
 DECLARE_HOOK(void,insert_filter,(request_rec *r))
 DECLARE_HOOK(void,insert_error_filter,(request_rec *r))
+DECLARE_HOOK(void,set_lock_owner,(const char *user, const char *group))
 
 char *sa_name = "standalone";
 const char *sa_name_argv[] = { "standalone", NULL };
@@ -320,6 +325,10 @@ void modsecFinalizeConfig() {
 
 void modsecInitProcess()    {
     hookfn_child_init(pool, server);
+}
+
+void modsecSetLockOwner(const char *user, const char *group)    {
+    hookfn_set_lock_owner(user, group);
 }
 
 conn_rec *modsecNewConnection() {

--- a/standalone/api.c
+++ b/standalone/api.c
@@ -39,6 +39,7 @@
 #include "http_config.h"
 
 #include "api.h"
+#include "hooks.h"
 
 #ifdef WIN32
 #include "msc_status_engine.h"
@@ -64,9 +65,6 @@ extern ns##_HOOK_##name##_t *hookfn_##name;
 #define DECLARE_HOOK(ret,name,args) \
     DECLARE_EXTERNAL_HOOK(ap,AP,ret,name,args)
 
-#define AP_DECLARE_HOOK(ret,name,args) \
-        APR_DECLARE_EXTERNAL_HOOK(ap,AP,ret,name,args)
-AP_DECLARE_HOOK(void,set_lock_owner,(const char *user, const char *group))
 
 DECLARE_HOOK(int,pre_config,(apr_pool_t *pconf,apr_pool_t *plog, apr_pool_t *ptemp))
 DECLARE_HOOK(int,post_config,(apr_pool_t *pconf,apr_pool_t *plog, apr_pool_t *ptemp,server_rec *s))

--- a/standalone/hooks.c
+++ b/standalone/hooks.c
@@ -50,6 +50,10 @@ link##_DECLARE(void) ns##_hook_##name(ns##_HOOK_##name##_t *pf, \
 #define DECLARE_HOOK(ret,name,args) \
 	DECLARE_EXTERNAL_HOOK(ap,AP,ret,name,args)
 
+#define AP_DECLARE_HOOK(ret,name,args) \
+        APR_DECLARE_EXTERNAL_HOOK(ap,AP,ret,name,args)
+AP_DECLARE_HOOK(void,set_lock_owner,(const char *user, const char *group))
+
 DECLARE_HOOK(int,pre_config,(apr_pool_t *pconf,apr_pool_t *plog, apr_pool_t *ptemp))
 DECLARE_HOOK(int,post_config,(apr_pool_t *pconf,apr_pool_t *plog, apr_pool_t *ptemp,server_rec *s))
 DECLARE_HOOK(void,child_init,(apr_pool_t *pchild, server_rec *s))
@@ -63,3 +67,4 @@ DECLARE_HOOK(void, error_log, (const char *file, int line, int level,
 DECLARE_HOOK(int,log_transaction,(request_rec *r))
 DECLARE_HOOK(void,insert_filter,(request_rec *r))
 DECLARE_HOOK(void,insert_error_filter,(request_rec *r))
+DECLARE_HOOK(void,set_lock_owner,(const char *user, const char *group))

--- a/standalone/hooks.c
+++ b/standalone/hooks.c
@@ -36,7 +36,7 @@
 #include "apr_lib.h"
 #include "ap_config.h"
 #include "http_config.h"
-
+#include "hooks.h"
 
 #define DECLARE_EXTERNAL_HOOK(ns,link,ret,name,args) \
 ns##_HOOK_##name##_t *hookfn_##name = NULL; \
@@ -50,9 +50,6 @@ link##_DECLARE(void) ns##_hook_##name(ns##_HOOK_##name##_t *pf, \
 #define DECLARE_HOOK(ret,name,args) \
 	DECLARE_EXTERNAL_HOOK(ap,AP,ret,name,args)
 
-#define AP_DECLARE_HOOK(ret,name,args) \
-        APR_DECLARE_EXTERNAL_HOOK(ap,AP,ret,name,args)
-AP_DECLARE_HOOK(void,set_lock_owner,(const char *user, const char *group))
 
 DECLARE_HOOK(int,pre_config,(apr_pool_t *pconf,apr_pool_t *plog, apr_pool_t *ptemp))
 DECLARE_HOOK(int,post_config,(apr_pool_t *pconf,apr_pool_t *plog, apr_pool_t *ptemp,server_rec *s))

--- a/standalone/hooks.c
+++ b/standalone/hooks.c
@@ -64,4 +64,7 @@ DECLARE_HOOK(void, error_log, (const char *file, int line, int level,
 DECLARE_HOOK(int,log_transaction,(request_rec *r))
 DECLARE_HOOK(void,insert_filter,(request_rec *r))
 DECLARE_HOOK(void,insert_error_filter,(request_rec *r))
+
+#ifndef _WIN32
 DECLARE_HOOK(void,set_lock_owner,(const char *user, const char *group))
+#endif

--- a/standalone/hooks.h
+++ b/standalone/hooks.h
@@ -1,0 +1,20 @@
+/*
+* ModSecurity for Apache 2.x, http://www.modsecurity.org/
+* Copyright (c) 2004-2013 Trustwave Holdings, Inc. (http://www.trustwave.com/)
+*
+* You may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* If any of the files related to licensing are missing or if you have any
+* other questions related to licensing please contact Trustwave Holdings, Inc.
+* directly using the email address security@modsecurity.org.
+*/
+
+#ifndef _HOOKS_HEADER
+#define _HOOKS_HEADER
+
+AP_DECLARE_HOOK(void,set_lock_owner,(const char *user, const char *group))
+
+#endif

--- a/standalone/hooks.h
+++ b/standalone/hooks.h
@@ -15,6 +15,10 @@
 #ifndef _HOOKS_HEADER
 #define _HOOKS_HEADER
 
+#include "http_config.h"
+
+#ifndef _WIN32
 AP_DECLARE_HOOK(void,set_lock_owner,(const char *user, const char *group))
+#endif
 
 #endif


### PR DESCRIPTION
For Linux, add API for set lock user and group permission, so it's more safe.  No other process with different user and group could get the lock, so in this case, only worker process is able to get the lock.