### PR TITLE
IIS, use PCRE_NO_RECURSE option to avoid stack overflow

### DIFF
--- a/iis/dependencies/build_pcre.bat
+++ b/iis/dependencies/build_pcre.bat
@@ -15,7 +15,7 @@ move "%PCRE_DIR%" "pcre"
 )
 
 cd "pcre"
-cat CMakeLists.txt | sed "s/PCRE_STATIC_RUNTIME OFF CACHE BOOL/PCRE_STATIC_RUNTIME/g" > CMakeLists.txt.ops
+cat CMakeLists.txt | sed "s/PCRE_STATIC_RUNTIME OFF CACHE BOOL/PCRE_STATIC_RUNTIME/g" | sed "s/PCRE_NO_RECURSE OFF/PCRE_NO_RECURSE ON/g" > CMakeLists.txt.ops
 move CMakeLists.txt CMakeLists.txt.old
 move CMakeLists.txt.ops CMakeLists.txt
 CMAKE -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=True


### PR DESCRIPTION
IIS only. Use PCRE_NO_RECURSE option to avoid stack overflow in PCRE.
Will later look into whether this is a problem on nginx too.