### PR TITLE
Regex Integrator

### DIFF
--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -3270,6 +3270,8 @@ static const char *cmd_cache_transformations(cmd_parms *cmd, void *_dcfg,
     return NULL;
 }
 
+#ifdef REGEX_INTEGRATOR
+
 /* Enable regex integrator */
 static const char *cmd_regex_integrator(cmd_parms *cmd, void *_dcfg, const char *p1) {
     extern unsigned int g_use_regex_integrator;
@@ -3282,6 +3284,8 @@ static const char *cmd_regex_integrator(cmd_parms *cmd, void *_dcfg, const char 
     }
     return NULL;
 }
+
+#endif
 
 /* -- Configuration directives definitions -- */
 
@@ -4065,6 +4069,9 @@ const command_rec module_directives[] = {
         "Set waf lock owner"
     ),
 #endif
+
+#ifdef REGEX_INTEGRATOR
+
     AP_INIT_TAKE1 (
         "SecRegexIntegrator",
         cmd_regex_integrator,
@@ -4072,5 +4079,8 @@ const command_rec module_directives[] = {
         CMD_SCOPE_ANY,
         "On or Off"
     ),
+
+#endif
+
     { NULL }
 };

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -4121,7 +4121,7 @@ const command_rec module_directives[] = {
         cmd_regex_integrator,
         NULL,
         CMD_SCOPE_ANY,
-        "On or Off"
+        "The priority sequence of engine"
     ),
 
 #endif

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -214,7 +214,7 @@ static void copy_rules_phase(apr_pool_t *mp,
                         if ((rule->actionset != NULL)&&(rule->actionset->msg != NULL)) {
                             char *my_error_msg = NULL;
 
-                            int rc = msc_regexec(exceptions[j]->param_data,
+                            int rc = msc_regex_regexec(exceptions[j]->param_data,
                                     rule->actionset->msg, strlen(rule->actionset->msg),
                                     &my_error_msg);
                             if (rc >= 0) copy--;
@@ -234,7 +234,7 @@ static void copy_rules_phase(apr_pool_t *mp,
                                 msre_action *action = (msre_action *)telts[c].val;
                                 if(strcmp("tag", action->metadata->name) == 0)  {
 
-                                    int rc = msc_regexec(exceptions[j]->param_data,
+                                    int rc = msc_regex_regexec(exceptions[j]->param_data,
                                             action->param, strlen(action->param),
                                             &my_error_msg);
                                     if (rc >= 0) copy--;
@@ -1367,7 +1367,7 @@ static const char *cmd_audit_log_relevant_status(cmd_parms *cmd, void *_dcfg,
 {
     directory_config *dcfg = _dcfg;
 
-    dcfg->auditlog_relevant_regex = msc_pregcomp(cmd->pool, p1, PCRE_DOTALL, NULL, NULL);
+    dcfg->auditlog_relevant_regex = msc_regex_pregcomp(cmd->pool, p1, PCRE_DOTALL, NULL, NULL);
     if (dcfg->auditlog_relevant_regex == NULL) {
         return apr_psprintf(cmd->pool, "ModSecurity: Invalid regular expression: %s", p1);
     }
@@ -2247,7 +2247,7 @@ static const char *cmd_rule_update_target_by_tag(cmd_parms *cmd, void *_dcfg,
 
     re->type = RULE_EXCEPTION_REMOVE_TAG;
     re->param = p1;
-    re->param_data = msc_pregcomp(cmd->pool, p1, 0, NULL, NULL);
+    re->param_data = msc_regex_pregcomp(cmd->pool, p1, 0, NULL, NULL);
     if (re->param_data == NULL) {
         return apr_psprintf(cmd->pool, "ModSecurity: Invalid regular expression: %s", p1);
     }
@@ -2282,7 +2282,7 @@ static const char *cmd_rule_update_target_by_msg(cmd_parms *cmd, void *_dcfg,
 
     re->type = RULE_EXCEPTION_REMOVE_MSG;
     re->param = p1;
-    re->param_data = msc_pregcomp(cmd->pool, p1, 0, NULL, NULL);
+    re->param_data = msc_regex_pregcomp(cmd->pool, p1, 0, NULL, NULL);
     if (re->param_data == NULL) {
         return apr_psprintf(cmd->pool, "ModSecurity: Invalid regular expression: %s", p1);
     }
@@ -2521,7 +2521,7 @@ static const char *cmd_rule_remove_by_tag(cmd_parms *cmd, void *_dcfg,
 
     re->type = RULE_EXCEPTION_REMOVE_TAG;
     re->param = p1;
-    re->param_data = msc_pregcomp(cmd->pool, p1, 0, NULL, NULL);
+    re->param_data = msc_regex_pregcomp(cmd->pool, p1, 0, NULL, NULL);
     if (re->param_data == NULL) {
         return apr_psprintf(cmd->pool, "ModSecurity: Invalid regular expression: %s", p1);
     }
@@ -2546,7 +2546,7 @@ static const char *cmd_rule_remove_by_msg(cmd_parms *cmd, void *_dcfg,
 
     re->type = RULE_EXCEPTION_REMOVE_MSG;
     re->param = p1;
-    re->param_data = msc_pregcomp(cmd->pool, p1, 0, NULL, NULL);
+    re->param_data = msc_regex_pregcomp(cmd->pool, p1, 0, NULL, NULL);
     if (re->param_data == NULL) {
         return apr_psprintf(cmd->pool, "ModSecurity: Invalid regular expression: %s", p1);
     }
@@ -2953,7 +2953,7 @@ static const char *cmd_hash_method_rx(cmd_parms *cmd, void *_dcfg,
     if (strcasecmp(p1, "HashHref") == 0) {
         re->type = HASH_URL_HREF_HASH_RX;
         re->param = _p2;
-        re->param_data = msc_pregcomp(cmd->pool, p2, 0, NULL, NULL);
+        re->param_data = msc_regex_pregcomp(cmd->pool, p2, 0, NULL, NULL);
         if (re->param_data == NULL) {
             return apr_psprintf(cmd->pool, "ModSecurity: Invalid regular expression: %s", p2);
         }
@@ -2962,7 +2962,7 @@ static const char *cmd_hash_method_rx(cmd_parms *cmd, void *_dcfg,
     else if (strcasecmp(p1, "HashFormAction") == 0) {
         re->type = HASH_URL_FACTION_HASH_RX;
         re->param = _p2;
-        re->param_data = msc_pregcomp(cmd->pool, p2, 0, NULL, NULL);
+        re->param_data = msc_regex_pregcomp(cmd->pool, p2, 0, NULL, NULL);
         if (re->param_data == NULL) {
             return apr_psprintf(cmd->pool, "ModSecurity: Invalid regular expression: %s", p2);
         }
@@ -2971,7 +2971,7 @@ static const char *cmd_hash_method_rx(cmd_parms *cmd, void *_dcfg,
     else if (strcasecmp(p1, "HashLocation") == 0) {
         re->type = HASH_URL_LOCATION_HASH_RX;
         re->param = _p2;
-        re->param_data = msc_pregcomp(cmd->pool, p2, 0, NULL, NULL);
+        re->param_data = msc_regex_pregcomp(cmd->pool, p2, 0, NULL, NULL);
         if (re->param_data == NULL) {
             return apr_psprintf(cmd->pool, "ModSecurity: Invalid regular expression: %s", p2);
         }
@@ -2980,7 +2980,7 @@ static const char *cmd_hash_method_rx(cmd_parms *cmd, void *_dcfg,
     else if (strcasecmp(p1, "HashIframeSrc") == 0) {
         re->type = HASH_URL_IFRAMESRC_HASH_RX;
         re->param = _p2;
-        re->param_data = msc_pregcomp(cmd->pool, p2, 0, NULL, NULL);
+        re->param_data = msc_regex_pregcomp(cmd->pool, p2, 0, NULL, NULL);
         if (re->param_data == NULL) {
             return apr_psprintf(cmd->pool, "ModSecurity: Invalid regular expression: %s", p2);
         }
@@ -2989,7 +2989,7 @@ static const char *cmd_hash_method_rx(cmd_parms *cmd, void *_dcfg,
     else if (strcasecmp(p1, "HashFrameSrc") == 0) {
         re->type = HASH_URL_FRAMESRC_HASH_RX;
         re->param = _p2;
-        re->param_data = msc_pregcomp(cmd->pool, p2, 0, NULL, NULL);
+        re->param_data = msc_regex_pregcomp(cmd->pool, p2, 0, NULL, NULL);
         if (re->param_data == NULL) {
             return apr_psprintf(cmd->pool, "ModSecurity: Invalid regular expression: %s", p2);
         }
@@ -3270,6 +3270,18 @@ static const char *cmd_cache_transformations(cmd_parms *cmd, void *_dcfg,
     return NULL;
 }
 
+/* Enable regex integrator */
+static const char *cmd_regex_integrator(cmd_parms *cmd, void *_dcfg, const char *p1) {
+    extern unsigned int g_use_regex_integrator;
+    if (strncasecmp(p1, "on", 2) == 0) {
+        g_use_regex_integrator = 1;
+    } else if (strncasecmp(p1, "off", 3) == 0) {
+        g_use_regex_integrator = 0;
+    } else {
+        return "Error paramenter to SecRegexIntegrator.";
+    }
+    return NULL;
+}
 
 /* -- Configuration directives definitions -- */
 
@@ -4053,5 +4065,12 @@ const command_rec module_directives[] = {
         "Set waf lock owner"
     ),
 #endif
+    AP_INIT_TAKE1 (
+        "SecRegexIntegrator",
+        cmd_regex_integrator,
+        NULL,
+        CMD_SCOPE_ANY,
+        "On or Off"
+    ),
     { NULL }
 };

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -604,7 +604,7 @@ static int is_response_status_relevant(modsec_rec *msr, int status) {
 
     apr_snprintf(buf, sizeof(buf), "%d", status);
 
-    rc = msc_regexec(msr->txcfg->auditlog_relevant_regex, buf, strlen(buf), &my_error_msg);
+    rc = msc_regex_regexec(msr->txcfg->auditlog_relevant_regex, buf, strlen(buf), &my_error_msg);
     if (rc >= 0) return 1;
     if (rc == PCRE_ERROR_NOMATCH) return 0;
 

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -37,6 +37,7 @@ typedef struct msc_parm msc_parm;
 #include "msc_logging.h"
 #include "msc_multipart.h"
 #include "msc_pcre.h"
+#include "msc_regex.h"
 #include "msc_util.h"
 #include "msc_json.h"
 #include "msc_xml.h"
@@ -575,7 +576,7 @@ struct directory_config {
     /* A regular expression that determines if a response
      * status is treated as relevant.
      */
-    msc_regex_t         *auditlog_relevant_regex;
+    void         *auditlog_relevant_regex;
 
     /* Upload */
     const char          *tmp_dir;

--- a/apache2/modules.mk
+++ b/apache2/modules.mk
@@ -1,11 +1,13 @@
 MOD_SECURITY2 = mod_security2 apache2_config apache2_io apache2_util \
     re re_operators re_actions re_tfns re_variables msc_json \
     msc_logging msc_xml msc_multipart modsecurity msc_parsers msc_util msc_pcre \
-    persist_dbm msc_reqbody pdf_protect msc_geo msc_gsb msc_crypt msc_tree msc_unicode acmp msc_lua
+    persist_dbm msc_reqbody pdf_protect msc_geo msc_gsb msc_crypt msc_tree msc_unicode acmp msc_lua \
+    msc_ri msc_regex
 
 H = re.h modsecurity.h msc_logging.h msc_multipart.h msc_parsers.h msc_json.h \
     msc_pcre.h msc_util.h msc_xml.h persist_dbm.h apache2.h pdf_protect.h \
-    msc_geo.h msc_gsb.h msc_crypt.h msc_tree.h msc_unicode.h acmp.h utf8tables.h msc_lua.h
+    msc_geo.h msc_gsb.h msc_crypt.h msc_tree.h msc_unicode.h acmp.h utf8tables.h msc_lua.h \
+    msc_ri.h msc_regex.h
 
 ${MOD_SECURITY2:=.slo}: ${H}
 ${MOD_SECURITY2:=.lo}: ${H}

--- a/apache2/msc_crypt.c
+++ b/apache2/msc_crypt.c
@@ -380,7 +380,7 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                     break;
                 case HASH_URL_HREF_HASH_RX:
                     if(em[i]->type == HASH_URL_HREF_HASH_RX)   {
-                        rc = msc_regexec_capture(em[i]->param_data, link, strlen(link), ovector, 30, &my_error_msg);
+                        rc = msc_regex_regexec_capture(em[i]->param_data, link, strlen(link), ovector, 30, &my_error_msg);
                         if ((rc == PCRE_ERROR_MATCHLIMIT) || (rc == PCRE_ERROR_RECURSIONLIMIT)) {
                             msc_string *s = (msc_string *)apr_pcalloc(msr->mp, sizeof(msc_string));
 
@@ -435,7 +435,7 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                     break;
                 case HASH_URL_FACTION_HASH_RX:
                     if(em[i]->type == HASH_URL_FACTION_HASH_RX)   {
-                        rc = msc_regexec_capture(em[i]->param_data, link, strlen(link), ovector, 30, &my_error_msg);
+                        rc = msc_regex_regexec_capture(em[i]->param_data, link, strlen(link), ovector, 30, &my_error_msg);
                         if ((rc == PCRE_ERROR_MATCHLIMIT) || (rc == PCRE_ERROR_RECURSIONLIMIT)) {
                             msc_string *s = (msc_string *)apr_pcalloc(msr->mp, sizeof(msc_string));
 
@@ -490,7 +490,7 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                     break;
                 case HASH_URL_LOCATION_HASH_RX:
                     if(em[i]->type == HASH_URL_LOCATION_HASH_RX)   {
-                        rc = msc_regexec_capture(em[i]->param_data, link, strlen(link), ovector, 30, &my_error_msg);
+                        rc = msc_regex_regexec_capture(em[i]->param_data, link, strlen(link), ovector, 30, &my_error_msg);
                         if ((rc == PCRE_ERROR_MATCHLIMIT) || (rc == PCRE_ERROR_RECURSIONLIMIT)) {
                             msc_string *s = (msc_string *)apr_pcalloc(msr->mp, sizeof(msc_string));
 
@@ -545,7 +545,7 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                     break;
                 case HASH_URL_IFRAMESRC_HASH_RX:
                     if(em[i]->type == HASH_URL_IFRAMESRC_HASH_RX)   {
-                        rc = msc_regexec_capture(em[i]->param_data, link, strlen(link), ovector, 30, &my_error_msg);
+                        rc = msc_regex_regexec_capture(em[i]->param_data, link, strlen(link), ovector, 30, &my_error_msg);
                         if ((rc == PCRE_ERROR_MATCHLIMIT) || (rc == PCRE_ERROR_RECURSIONLIMIT)) {
                             msc_string *s = (msc_string *)apr_pcalloc(msr->mp, sizeof(msc_string));
 
@@ -600,7 +600,7 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                     break;
                 case HASH_URL_FRAMESRC_HASH_RX:
                     if(em[i]->type == HASH_URL_FRAMESRC_HASH_RX)   {
-                        rc = msc_regexec_capture(em[i]->param_data, link, strlen(link), ovector, 30, &my_error_msg);
+                        rc = msc_regex_regexec_capture(em[i]->param_data, link, strlen(link), ovector, 30, &my_error_msg);
                         if ((rc == PCRE_ERROR_MATCHLIMIT) || (rc == PCRE_ERROR_RECURSIONLIMIT)) {
                             msc_string *s = (msc_string *)apr_pcalloc(msr->mp, sizeof(msc_string));
 

--- a/apache2/msc_regex.c
+++ b/apache2/msc_regex.c
@@ -25,7 +25,7 @@ void * msc_regex_pregcomp_ex(apr_pool_t *pool, const char *pattern, int options,
 }
 
 /**
- * Compiles the provided regular expression pattern.  Calls msc_pregcomp_ex()
+ * Compiles the provided regular expression pattern.  Calls msc_regex_pregcomp_ex()
  * with default limits.
  */
 void * msc_regex_pregcomp(apr_pool_t *pool, const char *pattern, int options,

--- a/apache2/msc_regex.c
+++ b/apache2/msc_regex.c
@@ -3,7 +3,11 @@
 
 #include "msc_regex.h"
 
+#ifdef REGEX_INTEGRATOR
+
 unsigned int g_use_regex_integrator = 0;
+
+#endif
 
 /**
  * Compiles the provided regular expression pattern. The _err*
@@ -17,9 +21,13 @@ void * msc_regex_pregcomp_ex(apr_pool_t *pool, const char *pattern, int options,
                       const char **_errptr, int *_erroffset,
                       int match_limit, int match_limit_recursion)
 {
+#ifdef REGEX_INTEGRATOR
     if (g_use_regex_integrator) {
         return msc_ri_pregcomp_ex(pool, pattern, options, _errptr, match_limit, match_limit_recursion);
-    } else {
+    } else 
+#endif
+    {
+
         return msc_pregcomp_ex(pool, pattern, options, _errptr, _erroffset, match_limit, match_limit_recursion);
     }
 }
@@ -31,9 +39,12 @@ void * msc_regex_pregcomp_ex(apr_pool_t *pool, const char *pattern, int options,
 void * msc_regex_pregcomp(apr_pool_t *pool, const char *pattern, int options,
                    const char **_errptr, int *_erroffset)
 {
+#ifdef REGEX_INTEGRATOR
     if (g_use_regex_integrator) {
         return msc_ri_pregcomp(pool, pattern, options, _errptr);
-    } else {
+    } else 
+#endif
+    {
         return msc_pregcomp(pool, pattern, options, _errptr, _erroffset);
     }
 }
@@ -46,9 +57,12 @@ void * msc_regex_pregcomp(apr_pool_t *pool, const char *pattern, int options,
 int msc_regex_regexec_ex(const void * regex, const char *s, unsigned int slen,
     int startoffset, int options, int *ovector, int ovecsize, char **error_msg)
 {
+#ifdef REGEX_INTEGRATOR
     if (g_use_regex_integrator) {
         return msc_ri_regexec_ex((msc_ri_regex_t *)regex, s, slen, startoffset, options, ovector, ovecsize, error_msg);
-    } else {
+    } else 
+#endif
+    {
         return msc_regexec_ex((msc_regex_t *)regex, s, slen, startoffset, options, ovector, ovecsize, error_msg);
     }
 }
@@ -61,9 +75,12 @@ int msc_regex_regexec_ex(const void * regex, const char *s, unsigned int slen,
 int msc_regex_regexec_capture(const void * regex, const char *s, unsigned int slen,
     int *ovector, int ovecsize, char **error_msg)
 {
+#ifdef REGEX_INTEGRATOR
     if (g_use_regex_integrator) {
         return msc_ri_regexec_capture((msc_ri_regex_t *)regex, s, slen, ovector, ovecsize, error_msg);
-    } else {
+    } else 
+#endif
+    {
         return msc_regexec_capture((msc_regex_t *)regex, s, slen, ovector, ovecsize, error_msg);
     }
 }
@@ -75,9 +92,12 @@ int msc_regex_regexec_capture(const void * regex, const char *s, unsigned int sl
 int msc_regex_regexec(const void * regex, const char *s, unsigned int slen,
     char **error_msg)
 {
+#ifdef REGEX_INTEGRATOR
     if (g_use_regex_integrator) {
         return msc_ri_regexec((msc_ri_regex_t *)regex, s, slen, error_msg);
-    } else {
+    } else 
+#endif
+    {
         return msc_regexec((msc_regex_t *)regex, s, slen, error_msg);
     }
 }
@@ -87,17 +107,23 @@ int msc_regex_regexec(const void * regex, const char *s, unsigned int slen,
  */
 int msc_regex_fullinfo(const void * regex, int what, void *where)
 {
+#ifdef REGEX_INTEGRATOR
     if (g_use_regex_integrator) {
         return -1000;   /* To differentiate from PCRE as it already uses -1. */
-    } else {
+    } else 
+#endif
+    {
         return msc_fullinfo((msc_regex_t *)regex, what, where);
     }
 }
 
 const char * msc_regex_pattern(const void * regex) {
+#ifdef REGEX_INTEGRATOR
     if (g_use_regex_integrator) {
         return ((msc_ri_regex_t * )regex)->pattern;
-    } else {
+    } else 
+#endif
+    {
         return ((msc_regex_t *)regex)->pattern;
     }
 }

--- a/apache2/msc_regex.c
+++ b/apache2/msc_regex.c
@@ -1,16 +1,5 @@
-/*
-* ModSecurity for Apache 2.x, http://www.modsecurity.org/
-* Copyright (c) 2004-2013 Trustwave Holdings, Inc. (http://www.trustwave.com/)
-*
-* You may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* If any of the files related to licensing are missing or if you have any
-* other questions related to licensing please contact Trustwave Holdings, Inc.
-* directly using the email address security@modsecurity.org.
-*/
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
 
 #include "msc_regex.h"
 

--- a/apache2/msc_regex.c
+++ b/apache2/msc_regex.c
@@ -1,0 +1,114 @@
+/*
+* ModSecurity for Apache 2.x, http://www.modsecurity.org/
+* Copyright (c) 2004-2013 Trustwave Holdings, Inc. (http://www.trustwave.com/)
+*
+* You may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* If any of the files related to licensing are missing or if you have any
+* other questions related to licensing please contact Trustwave Holdings, Inc.
+* directly using the email address security@modsecurity.org.
+*/
+
+#include "msc_regex.h"
+
+unsigned int g_use_regex_integrator = 0;
+
+/**
+ * Compiles the provided regular expression pattern. The _err*
+ * parameters are optional, but if they are provided and an error
+ * occurs they will contain the error message and the offset in
+ * the pattern where the offending part of the pattern begins. The
+ * match_limit* parameters are optional and if >0, then will set
+ * match limits.
+ */
+void * msc_regex_pregcomp_ex(apr_pool_t *pool, const char *pattern, int options,
+                      const char **_errptr, int *_erroffset,
+                      int match_limit, int match_limit_recursion)
+{
+    if (g_use_regex_integrator) {
+        return msc_ri_pregcomp_ex(pool, pattern, options, _errptr, match_limit, match_limit_recursion);
+    } else {
+        return msc_pregcomp_ex(pool, pattern, options, _errptr, _erroffset, match_limit, match_limit_recursion);
+    }
+}
+
+/**
+ * Compiles the provided regular expression pattern.  Calls msc_pregcomp_ex()
+ * with default limits.
+ */
+void * msc_regex_pregcomp(apr_pool_t *pool, const char *pattern, int options,
+                   const char **_errptr, int *_erroffset)
+{
+    if (g_use_regex_integrator) {
+        return msc_ri_pregcomp(pool, pattern, options, _errptr);
+    } else {
+        return msc_pregcomp(pool, pattern, options, _errptr, _erroffset);
+    }
+}
+
+/**
+ * Executes regular expression with extended options.
+ * Returns PCRE_ERROR_NOMATCH when there is no match, error code < -1
+ * on errors, and a value > 0 when there is a match.
+ */
+int msc_regex_regexec_ex(const void * regex, const char *s, unsigned int slen,
+    int startoffset, int options, int *ovector, int ovecsize, char **error_msg)
+{
+    if (g_use_regex_integrator) {
+        return msc_ri_regexec_ex((msc_ri_regex_t *)regex, s, slen, startoffset, options, ovector, ovecsize, error_msg);
+    } else {
+        return msc_regexec_ex((msc_regex_t *)regex, s, slen, startoffset, options, ovector, ovecsize, error_msg);
+    }
+}
+
+/**
+ * Executes regular expression, capturing subexpressions in the given
+ * vector. Returns PCRE_ERROR_NOMATCH when there is no match, error code < -1
+ * on errors, and a value > 0 when there is a match.
+ */
+int msc_regex_regexec_capture(const void * regex, const char *s, unsigned int slen,
+    int *ovector, int ovecsize, char **error_msg)
+{
+    if (g_use_regex_integrator) {
+        return msc_ri_regexec_capture((msc_ri_regex_t *)regex, s, slen, ovector, ovecsize, error_msg);
+    } else {
+        return msc_regexec_capture((msc_regex_t *)regex, s, slen, ovector, ovecsize, error_msg);
+    }
+}
+
+/**
+ * Executes regular expression but ignores any of the subexpression
+ * captures. See above for the return codes.
+ */
+int msc_regex_regexec(const void * regex, const char *s, unsigned int slen,
+    char **error_msg)
+{
+    if (g_use_regex_integrator) {
+        return msc_ri_regexec((msc_ri_regex_t *)regex, s, slen, error_msg);
+    } else {
+        return msc_regexec((msc_regex_t *)regex, s, slen, error_msg);
+    }
+}
+
+/**
+ * Gets info on a compiled regex.
+ */
+int msc_regex_fullinfo(const void * regex, int what, void *where)
+{
+    if (g_use_regex_integrator) {
+        return -1000;   /* To differentiate from PCRE as it already uses -1. */
+    } else {
+        return msc_fullinfo((msc_regex_t *)regex, what, where);
+    }
+}
+
+const char * msc_regex_pattern(const void * regex) {
+    if (g_use_regex_integrator) {
+        return ((msc_ri_regex_t * )regex)->pattern;
+    } else {
+        return ((msc_regex_t *)regex)->pattern;
+    }
+}

--- a/apache2/msc_regex.c
+++ b/apache2/msc_regex.c
@@ -5,7 +5,8 @@
 
 #ifdef REGEX_INTEGRATOR
 
-unsigned int g_use_regex_integrator = 0;
+regex_mode_t g_regex_mode = REGEX_ORIGINAL_MODE;
+regex_status_t g_start_regex = REGEX_UNSTART;
 
 #endif
 
@@ -22,7 +23,8 @@ void * msc_regex_pregcomp_ex(apr_pool_t *pool, const char *pattern, int options,
                       int match_limit, int match_limit_recursion)
 {
 #ifdef REGEX_INTEGRATOR
-    if (g_use_regex_integrator) {
+    g_start_regex = REGEX_START;
+    if (g_regex_mode == REGEX_INTEGRATED_MODE) {
         return msc_ri_pregcomp_ex(pool, pattern, options, _errptr, match_limit, match_limit_recursion);
     } else 
 #endif
@@ -40,7 +42,8 @@ void * msc_regex_pregcomp(apr_pool_t *pool, const char *pattern, int options,
                    const char **_errptr, int *_erroffset)
 {
 #ifdef REGEX_INTEGRATOR
-    if (g_use_regex_integrator) {
+    g_start_regex = REGEX_START;
+    if (g_regex_mode == REGEX_INTEGRATED_MODE) {
         return msc_ri_pregcomp(pool, pattern, options, _errptr);
     } else 
 #endif
@@ -48,6 +51,7 @@ void * msc_regex_pregcomp(apr_pool_t *pool, const char *pattern, int options,
         return msc_pregcomp(pool, pattern, options, _errptr, _erroffset);
     }
 }
+
 
 /**
  * Executes regular expression with extended options.
@@ -58,7 +62,7 @@ int msc_regex_regexec_ex(const void * regex, const char *s, unsigned int slen,
     int startoffset, int options, int *ovector, int ovecsize, char **error_msg)
 {
 #ifdef REGEX_INTEGRATOR
-    if (g_use_regex_integrator) {
+    if (g_regex_mode == REGEX_INTEGRATED_MODE) {
         return msc_ri_regexec_ex((msc_ri_regex_t *)regex, s, slen, startoffset, options, ovector, ovecsize, error_msg);
     } else 
 #endif
@@ -76,7 +80,7 @@ int msc_regex_regexec_capture(const void * regex, const char *s, unsigned int sl
     int *ovector, int ovecsize, char **error_msg)
 {
 #ifdef REGEX_INTEGRATOR
-    if (g_use_regex_integrator) {
+    if (g_regex_mode == REGEX_INTEGRATED_MODE) {
         return msc_ri_regexec_capture((msc_ri_regex_t *)regex, s, slen, ovector, ovecsize, error_msg);
     } else 
 #endif
@@ -93,7 +97,7 @@ int msc_regex_regexec(const void * regex, const char *s, unsigned int slen,
     char **error_msg)
 {
 #ifdef REGEX_INTEGRATOR
-    if (g_use_regex_integrator) {
+    if (g_regex_mode == REGEX_INTEGRATED_MODE) {
         return msc_ri_regexec((msc_ri_regex_t *)regex, s, slen, error_msg);
     } else 
 #endif
@@ -108,7 +112,7 @@ int msc_regex_regexec(const void * regex, const char *s, unsigned int slen,
 int msc_regex_fullinfo(const void * regex, int what, void *where)
 {
 #ifdef REGEX_INTEGRATOR
-    if (g_use_regex_integrator) {
+    if (g_regex_mode == REGEX_INTEGRATED_MODE) {
         return -1000;   /* To differentiate from PCRE as it already uses -1. */
     } else 
 #endif
@@ -119,7 +123,7 @@ int msc_regex_fullinfo(const void * regex, int what, void *where)
 
 const char * msc_regex_pattern(const void * regex) {
 #ifdef REGEX_INTEGRATOR
-    if (g_use_regex_integrator) {
+    if (g_regex_mode == REGEX_INTEGRATED_MODE) {
         return ((msc_ri_regex_t * )regex)->pattern;
     } else 
 #endif

--- a/apache2/msc_regex.h
+++ b/apache2/msc_regex.h
@@ -10,8 +10,18 @@
 
 #include "msc_ri.h"
 
-extern unsigned int g_use_regex_integrator;
-extern struct ri_priority g_default_ri_priority;
+typedef enum {
+    REGEX_ORIGINAL_MODE,
+    REGEX_INTEGRATED_MODE,
+} regex_mode_t;
+
+extern regex_mode_t g_regex_mode;
+
+typedef enum {
+    REGEX_UNSTART,
+    REGEX_START,
+} regex_status_t;
+extern regex_status_t g_start_regex;
 
 #endif
 

--- a/apache2/msc_regex.h
+++ b/apache2/msc_regex.h
@@ -14,7 +14,7 @@ void * msc_regex_pregcomp_ex(apr_pool_t *pool, const char *pattern, int options,
         const char **_errptr, int *_erroffset,
         int match_limit, int match_limit_recursion);
 
-/* Compiles the provided regular expression pattern.  Calls msc_pregcomp_ex()
+/* Compiles the provided regular expression pattern.  Calls msc_regex_pregcomp_ex()
  * with default limits. */
 void * msc_regex_pregcomp(apr_pool_t *pool, const char *pattern, int options,
         const char **_errptr, int *_erroffset);

--- a/apache2/msc_regex.h
+++ b/apache2/msc_regex.h
@@ -1,16 +1,5 @@
-/*
-* ModSecurity for Apache 2.x, http://www.modsecurity.org/
-* Copyright (c) 2004-2013 Trustwave Holdings, Inc. (http://www.trustwave.com/)
-*
-* You may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* If any of the files related to licensing are missing or if you have any
-* other questions related to licensing please contact Trustwave Holdings, Inc.
-* directly using the email address security@modsecurity.org.
-*/
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
 
 #ifndef _MSC_REGEX_H_
 #define _MSC_REGEX_H_

--- a/apache2/msc_regex.h
+++ b/apache2/msc_regex.h
@@ -1,0 +1,53 @@
+/*
+* ModSecurity for Apache 2.x, http://www.modsecurity.org/
+* Copyright (c) 2004-2013 Trustwave Holdings, Inc. (http://www.trustwave.com/)
+*
+* You may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* If any of the files related to licensing are missing or if you have any
+* other questions related to licensing please contact Trustwave Holdings, Inc.
+* directly using the email address security@modsecurity.org.
+*/
+
+#ifndef _MSC_REGEX_H_
+#define _MSC_REGEX_H_
+
+#include "msc_pcre.h"
+#include "msc_ri.h"
+
+extern unsigned int g_use_regex_integrator;
+
+/* Compiles the provided regular expression pattern. */
+void * msc_regex_pregcomp_ex(apr_pool_t *pool, const char *pattern, int options,
+        const char **_errptr, int *_erroffset,
+        int match_limit, int match_limit_recursion);
+
+/* Compiles the provided regular expression pattern.  Calls msc_pregcomp_ex()
+ * with default limits. */
+void * msc_regex_pregcomp(apr_pool_t *pool, const char *pattern, int options,
+        const char **_errptr, int *_erroffset);
+
+/* Executes regular expression with extended options. */
+int msc_regex_regexec_ex(const void * regex, const char *s,
+        unsigned int slen, int startoffset, int options,
+        int *ovector, int ovecsize, char **error_msg);
+
+/* Executes regular expression, capturing subexpressions in the given vector. */
+int msc_regex_regexec_capture(const void * regex, const char *s,
+        unsigned int slen, int *ovector,
+        int ovecsize, char **error_msg);
+
+/* Executes regular expression but ignores any of the subexpression captures. */
+int msc_regex_regexec(const void * regex, const char *s,
+        unsigned int slen, char **error_msg);
+
+/* Gets info on a compiled regex. */
+int msc_regex_fullinfo(const void * regex, int what, void *where);
+
+/* Gets pattern on a compiled regex. */
+const char * msc_regex_pattern(const void * regex);
+
+#endif

--- a/apache2/msc_regex.h
+++ b/apache2/msc_regex.h
@@ -11,6 +11,7 @@
 #include "msc_ri.h"
 
 extern unsigned int g_use_regex_integrator;
+extern struct ri_priority g_default_ri_priority;
 
 #endif
 

--- a/apache2/msc_regex.h
+++ b/apache2/msc_regex.h
@@ -5,9 +5,14 @@
 #define _MSC_REGEX_H_
 
 #include "msc_pcre.h"
+
+#ifdef REGEX_INTEGRATOR
+
 #include "msc_ri.h"
 
 extern unsigned int g_use_regex_integrator;
+
+#endif
 
 /* Compiles the provided regular expression pattern. */
 void * msc_regex_pregcomp_ex(apr_pool_t *pool, const char *pattern, int options,

--- a/apache2/msc_ri.c
+++ b/apache2/msc_ri.c
@@ -1,6 +1,8 @@
 /* Copyright (c) Microsoft Corporation. All rights reserved.
    Licensed under the MIT License. */
 
+#ifdef REGEX_INTEGRATOR
+
 #include "msc_ri.h"
 
 
@@ -129,3 +131,4 @@ int msc_ri_regexec(msc_ri_regex_t * regex, const char *s, unsigned int slen,
     return msc_ri_regexec_ex(regex, s, slen, 0, 0, NULL, 0, error_msg);
 }
 
+#endif

--- a/apache2/msc_ri.c
+++ b/apache2/msc_ri.c
@@ -1,0 +1,142 @@
+/*
+* ModSecurity for Apache 2.x, http://www.modsecurity.org/
+* Copyright (c) 2004-2013 Trustwave Holdings, Inc. (http://www.trustwave.com/)
+*
+* You may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* If any of the files related to licensing are missing or if you have any
+* other questions related to licensing please contact Trustwave Holdings, Inc.
+* directly using the email address security@modsecurity.org.
+*/
+
+#include "msc_ri.h"
+
+
+/**
+ * Releases the resources used by a single regular expression pattern.
+ */
+static apr_status_t msc_ri_cleanup(msc_ri_regex_t * regex) {
+    if (regex != NULL) {
+        if (regex->re) {
+            ri_free(regex->re);
+        }
+    }
+    return APR_SUCCESS;
+}
+
+/**
+ * Compiles the provided regular expression pattern. The _err*
+ * parameters are optional, but if they are provided and an error
+ * occurs they will contain the error message and the offset in
+ * the pattern where the offending part of the pattern begins. The
+ * match_limit* parameters are optional and if >0, then will set
+ * match limits.
+ */
+msc_ri_regex_t * msc_ri_pregcomp_ex(apr_pool_t *pool, const char *pattern, int options,
+                      const char **_errptr,
+                      int match_limit, int match_limit_recursion)
+{
+    int error_code = 0;
+    int ri_options = RI_COMP_DEFAULT;
+    const static struct ri_priority priority = {
+        {RI_RE2, RI_PCRE_JIT, RI_PCRE},
+        3,
+    };
+    const struct ri_params params = {
+        // Set PCRE params
+        {
+            match_limit, match_limit_recursion,
+        },
+        //SET PCRE-JIT params
+        {    match_limit, match_limit_recursion,},
+    };
+    msc_ri_regex_t * regex = NULL;
+    regex = apr_pcalloc(pool, sizeof(msc_ri_regex_t));
+    regex->pattern = pattern;
+    // Set options
+    if (options & PCRE_CASELESS)
+        ri_options |= RI_COMP_CASELESS;
+
+    if (options & PCRE_MULTILINE)
+        ri_options |= RI_COMP_MULTILINE;
+
+    if (options & PCRE_DOTALL)
+        ri_options |= RI_COMP_DOTALL;
+
+    if (options & PCRE_DOLLAR_ENDONLY)
+        ri_options |= RI_COMP_DOLLAR_ENDONLY;
+
+    error_code = ri_create(&(regex->re), pattern, ri_options, 
+            &priority, &params, _errptr);
+
+    if (error_code != RI_SUCCESS)
+        return NULL;
+        
+    apr_pool_cleanup_register(pool, (void *)regex,
+        (apr_status_t (*)(void *))msc_ri_cleanup, apr_pool_cleanup_null);
+
+    return regex;
+}
+
+/**
+ * Compiles the provided regular expression pattern.  Calls msc_pregcomp_ex()
+ * with default limits.
+ */
+msc_ri_regex_t * msc_ri_pregcomp(apr_pool_t *pool, const char *pattern, int options,
+                   const char **_errptr)
+{
+    return msc_ri_pregcomp_ex(pool, pattern, options, _errptr, 0, 0);
+}
+
+/**
+ * Executes regular expression with extended options.
+ * Returns PCRE_ERROR_NOMATCH when there is no match, error code < -1
+ * on errors, and a value > 0 when there is a match.
+ */
+int msc_ri_regexec_ex(msc_ri_regex_t * regex, const char *s, unsigned int slen,
+    int startoffset, int options, int *ovector, int ovecsize, char **error_msg)
+{
+    int ri_options = RI_EXEC_DEFAULT;
+    int rv = 0;
+
+    if (error_msg == NULL)
+         return -1000; /* To differentiate from PCRE as it already uses -1. */
+    *error_msg = NULL;
+
+    if (options & PCRE_NOTEMPTY)
+        ri_options |= RI_EXEC_NOTEMPTY;
+
+    return ri_exec(regex->re, s, slen, startoffset, ri_options,
+            NULL, ovector, ovecsize, (const char **)error_msg);
+}
+
+/**
+ * Executes regular expression, capturing subexpressions in the given
+ * vector. Returns PCRE_ERROR_NOMATCH when there is no match, error code < -1
+ * on errors, and a value > 0 when there is a match.
+ */
+int msc_ri_regexec_capture(msc_ri_regex_t * regex, const char *s, unsigned int slen,
+    int *ovector, int ovecsize, char **error_msg)
+{
+    if (error_msg == NULL) return -1000; /* To differentiate from PCRE as it already uses -1. */
+    *error_msg = NULL;
+
+    return msc_ri_regexec_ex(regex, s, slen, 0, 0, ovector, ovecsize, error_msg);
+}
+
+/**
+ * Executes regular expression but ignores any of the subexpression
+ * captures. See above for the return codes.
+ */
+int msc_ri_regexec(msc_ri_regex_t * regex, const char *s, unsigned int slen,
+    char **error_msg)
+{
+    if (error_msg == NULL) return -1000; /* To differentiate from PCRE as it already uses -1. */
+    *error_msg = NULL;
+
+    return msc_ri_regexec_ex(regex, s, slen, 0, 0, NULL, 0, error_msg);
+}
+

--- a/apache2/msc_ri.c
+++ b/apache2/msc_ri.c
@@ -1,16 +1,5 @@
-/*
-* ModSecurity for Apache 2.x, http://www.modsecurity.org/
-* Copyright (c) 2004-2013 Trustwave Holdings, Inc. (http://www.trustwave.com/)
-*
-* You may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* If any of the files related to licensing are missing or if you have any
-* other questions related to licensing please contact Trustwave Holdings, Inc.
-* directly using the email address security@modsecurity.org.
-*/
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
 
 #include "msc_ri.h"
 

--- a/apache2/msc_ri.c
+++ b/apache2/msc_ri.c
@@ -5,6 +5,10 @@
 
 #include "msc_ri.h"
 
+struct ri_priority g_default_ri_priority = {
+    {RI_RE2, RI_PCRE_JIT, RI_PCRE},
+    3,
+};
 
 /**
  * Releases the resources used by a single regular expression pattern.
@@ -32,10 +36,8 @@ msc_ri_regex_t * msc_ri_pregcomp_ex(apr_pool_t *pool, const char *pattern, int o
 {
     int error_code = 0;
     int ri_options = RI_COMP_DEFAULT;
-    const static struct ri_priority priority = {
-        {RI_RE2, RI_PCRE_JIT, RI_PCRE},
-        3,
-    };
+    const struct ri_priority priority = g_default_ri_priority;
+
     const struct ri_params params = {
         // Set PCRE params
         {
@@ -91,7 +93,6 @@ int msc_ri_regexec_ex(msc_ri_regex_t * regex, const char *s, unsigned int slen,
     int startoffset, int options, int *ovector, int ovecsize, char **error_msg)
 {
     int ri_options = RI_EXEC_DEFAULT;
-    int rv = 0;
 
     if (error_msg == NULL)
          return -1000; /* To differentiate from PCRE as it already uses -1. */

--- a/apache2/msc_ri.c
+++ b/apache2/msc_ri.c
@@ -71,7 +71,7 @@ msc_ri_regex_t * msc_ri_pregcomp_ex(apr_pool_t *pool, const char *pattern, int o
 }
 
 /**
- * Compiles the provided regular expression pattern.  Calls msc_pregcomp_ex()
+ * Compiles the provided regular expression pattern.  Calls msc_ri_pregcomp_ex()
  * with default limits.
  */
 msc_ri_regex_t * msc_ri_pregcomp(apr_pool_t *pool, const char *pattern, int options,

--- a/apache2/msc_ri.h
+++ b/apache2/msc_ri.h
@@ -23,7 +23,7 @@ extern unsigned int g_use_regex_integrator;
 msc_ri_regex_t * msc_ri_pregcomp_ex(apr_pool_t *pool, const char *pattern, int options,
         const char **_errptr, int match_limit, int match_limit_recursion);
 
-/* Compiles the provided regular expression pattern.  Calls msc_pregcomp_ex()
+/* Compiles the provided regular expression pattern.  Calls msc_ri_pregcomp_ex()
  * with default limits. */
 msc_ri_regex_t * msc_ri_pregcomp(apr_pool_t *pool, const char *pattern, int options,
         const char **_errptr);

--- a/apache2/msc_ri.h
+++ b/apache2/msc_ri.h
@@ -1,0 +1,56 @@
+/*
+* ModSecurity for Apache 2.x, http://www.modsecurity.org/
+* Copyright (c) 2004-2013 Trustwave Holdings, Inc. (http://www.trustwave.com/)
+*
+* You may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* If any of the files related to licensing are missing or if you have any
+* other questions related to licensing please contact Trustwave Holdings, Inc.
+* directly using the email address security@modsecurity.org.
+*/
+
+#ifndef _MSC_RI_H_
+#define _MSC_RI_H_
+
+typedef struct msc_ri_regex_t msc_ri_regex_t;
+
+#include "apr_general.h"
+#include "modsecurity.h"
+
+
+#include <regex_integrator/ri_api.h>
+
+struct msc_ri_regex_t {
+    ri_regex_t       re;
+    const char      *pattern;
+};
+
+extern unsigned int g_use_regex_integrator;
+
+/* Compiles the provided regular expression pattern. */
+msc_ri_regex_t * msc_ri_pregcomp_ex(apr_pool_t *pool, const char *pattern, int options,
+        const char **_errptr, int match_limit, int match_limit_recursion);
+
+/* Compiles the provided regular expression pattern.  Calls msc_pregcomp_ex()
+ * with default limits. */
+msc_ri_regex_t * msc_ri_pregcomp(apr_pool_t *pool, const char *pattern, int options,
+        const char **_errptr);
+
+/* Executes regular expression with extended options. */
+int msc_ri_regexec_ex(msc_ri_regex_t * regex, const char *s,
+        unsigned int slen, int startoffset, int options,
+        int *ovector, int ovecsize, char **error_msg);
+
+/* Executes regular expression, capturing subexpressions in the given vector. */
+int msc_ri_regexec_capture(msc_ri_regex_t * regex, const char *s,
+        unsigned int slen, int *ovector,
+        int ovecsize, char **error_msg);
+
+/* Executes regular expression but ignores any of the subexpression captures. */
+int msc_ri_regexec(msc_ri_regex_t * regex, const char *s,
+        unsigned int slen, char **error_msg);
+
+#endif

--- a/apache2/msc_ri.h
+++ b/apache2/msc_ri.h
@@ -4,11 +4,12 @@
 #ifndef _MSC_RI_H_
 #define _MSC_RI_H_
 
+#ifdef REGEX_INTEGRATOR
+
 typedef struct msc_ri_regex_t msc_ri_regex_t;
 
 #include "apr_general.h"
 #include "modsecurity.h"
-
 
 #include <regex_integrator/ri_api.h>
 
@@ -41,5 +42,7 @@ int msc_ri_regexec_capture(msc_ri_regex_t * regex, const char *s,
 /* Executes regular expression but ignores any of the subexpression captures. */
 int msc_ri_regexec(msc_ri_regex_t * regex, const char *s,
         unsigned int slen, char **error_msg);
+
+#endif
 
 #endif

--- a/apache2/msc_ri.h
+++ b/apache2/msc_ri.h
@@ -18,7 +18,7 @@ struct msc_ri_regex_t {
     const char      *pattern;
 };
 
-extern unsigned int g_use_regex_integrator;
+extern struct ri_priority g_default_ri_priority;
 
 /* Compiles the provided regular expression pattern. */
 msc_ri_regex_t * msc_ri_pregcomp_ex(apr_pool_t *pool, const char *pattern, int options,

--- a/apache2/msc_ri.h
+++ b/apache2/msc_ri.h
@@ -1,16 +1,5 @@
-/*
-* ModSecurity for Apache 2.x, http://www.modsecurity.org/
-* Copyright (c) 2004-2013 Trustwave Holdings, Inc. (http://www.trustwave.com/)
-*
-* You may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* If any of the files related to licensing are missing or if you have any
-* other questions related to licensing please contact Trustwave Holdings, Inc.
-* directly using the email address security@modsecurity.org.
-*/
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
 
 #ifndef _MSC_RI_H_
 #define _MSC_RI_H_

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -543,7 +543,7 @@ int msre_ruleset_rule_matches_exception(msre_rule *rule, rule_exception *re)   {
                 if ((rule->actionset != NULL)&&(rule->actionset->msg != NULL)) {
                     char *my_error_msg = NULL;
 
-                    int rc = msc_regexec(re->param_data,
+                    int rc = msc_regex_regexec(re->param_data,
                             rule->actionset->msg, strlen(rule->actionset->msg),
                             &my_error_msg);
                     if (rc >= 0) {
@@ -566,7 +566,7 @@ int msre_ruleset_rule_matches_exception(msre_rule *rule, rule_exception *re)   {
                         msre_action *action = (msre_action *)telts[act].val;
                         if((action != NULL) && (action->metadata != NULL) && (strcmp("tag", action->metadata->name) == 0))  {
 
-                            int rc = msc_regexec(re->param_data,
+                            int rc = msc_regex_regexec(re->param_data,
                                     action->param, strlen(action->param),
                                     &my_error_msg);
                             if (rc >= 0)    {
@@ -1650,7 +1650,7 @@ static apr_status_t msre_ruleset_process_phase_(msre_ruleset *ruleset, modsec_re
                         msr_log(msr, 9, "Checking removal of rule msg=\"%s\" against: %s", rule->actionset->msg, re->param);
                     }
 
-                    rc = msc_regexec(re->param_data,
+                    rc = msc_regex_regexec(re->param_data,
                             rule->actionset->msg, strlen(rule->actionset->msg),
                             &my_error_msg);
                     if (rc >= 0)    {
@@ -1700,7 +1700,7 @@ static apr_status_t msre_ruleset_process_phase_(msre_ruleset *ruleset, modsec_re
                                 msr_log(msr, 9, "Checking removal of rule tag=\"%s\" against: %s", var->value, re->param);
                             }
 
-                            rc = msc_regexec(re->param_data,
+                            rc = msc_regex_regexec(re->param_data,
                                     var->value, strlen(var->value),
                                     &my_error_msg);
                             if (rc >= 0)    {
@@ -2099,7 +2099,7 @@ static int msre_ruleset_phase_rule_remove_with_exception(msre_ruleset *ruleset, 
                         if ((rule->actionset != NULL)&&(rule->actionset->msg != NULL)) {
                             char *my_error_msg = NULL;
 
-                            int rc = msc_regexec(re->param_data,
+                            int rc = msc_regex_regexec(re->param_data,
                                     rule->actionset->msg, strlen(rule->actionset->msg),
                                     &my_error_msg);
                             if (rc >= 0) {
@@ -2122,7 +2122,7 @@ static int msre_ruleset_phase_rule_remove_with_exception(msre_ruleset *ruleset, 
                                 msre_action *action = (msre_action *)telts[act].val;
                                 if((action != NULL) && (action->metadata != NULL) && (strcmp("tag", action->metadata->name) == 0))  {
 
-                                    int rc = msc_regexec(re->param_data,
+                                    int rc = msc_regex_regexec(re->param_data,
                                             action->param, strlen(action->param),
                                             &my_error_msg);
                                     if (rc >= 0)    {

--- a/apache2/re.h
+++ b/apache2/re.h
@@ -269,7 +269,7 @@ struct msre_var {
     char                    *param;
     const void              *param_data;
     msre_var_metadata       *metadata;
-    msc_regex_t             *param_regex;
+    void             *param_regex;
     unsigned int             is_negated;
     unsigned int             is_counting;
 };

--- a/apache2/re_actions.c
+++ b/apache2/re_actions.c
@@ -818,12 +818,12 @@ static char *msre_action_ctl_validate(msre_engine *engine, apr_pool_t *mp, msre_
         return NULL;
     } else
     if (strcasecmp(name, "ruleRemoveByTag") == 0) {
-        if (!msc_pregcomp(mp, value, 0, NULL, NULL))
+        if (!msc_regex_pregcomp(mp, value, 0, NULL, NULL))
            return apr_psprintf(mp, "ModSecurity: Invalid regular expression \"%s\"", value);
         return NULL;
     } else
     if (strcasecmp(name, "ruleRemoveByMsg") == 0) {
-       if (!msc_pregcomp(mp, value, 0, NULL, NULL))
+       if (!msc_regex_pregcomp(mp, value, 0, NULL, NULL))
            return apr_psprintf(mp, "ModSecurity: Invalid regular expression \"%s\"", value);
         return NULL;
     } else
@@ -927,7 +927,7 @@ static char *msre_action_ctl_validate(msre_engine *engine, apr_pool_t *mp, msre_
                 parm = apr_strtok(value,";",&savedptr);
                 if(parm == NULL && savedptr == NULL)
                     return apr_psprintf(mp, "ruleRemoveTargetByTag must has at least tag;VARIABLE");
-            if (!msc_pregcomp(mp, parm, 0, NULL, NULL)) {
+            if (!msc_regex_pregcomp(mp, parm, 0, NULL, NULL)) {
                 return apr_psprintf(mp, "ModSecurity: Invalid regular expression \"%s\"", parm);
             }
         return NULL;
@@ -939,7 +939,7 @@ static char *msre_action_ctl_validate(msre_engine *engine, apr_pool_t *mp, msre_
                 parm = apr_strtok(value,";",&savedptr);
                 if(parm == NULL && savedptr == NULL)
                     return apr_psprintf(mp, "ruleRemoveTargetByMsg must has at least msg;VARIABLE");
-            if (!msc_pregcomp(mp, parm, 0, NULL, NULL)) {
+            if (!msc_regex_pregcomp(mp, parm, 0, NULL, NULL)) {
                 return apr_psprintf(mp, "ModSecurity: Invalid regular expression \"%s\"", parm);
             }
         return NULL;
@@ -1042,7 +1042,7 @@ static apr_status_t msre_action_ctl_execute(modsec_rec *msr, apr_pool_t *mptmp,
         rule_exception *re = apr_pcalloc(msr->mp, sizeof(rule_exception));
         re->type = RULE_EXCEPTION_REMOVE_TAG;
         re->param = (const char *)apr_pstrdup(msr->mp, value);
-        re->param_data = msc_pregcomp(msr->mp, re->param, 0, NULL, NULL);
+        re->param_data = msc_regex_pregcomp(msr->mp, re->param, 0, NULL, NULL);
         if (re->param_data == NULL) {
             msr_log(msr, 1, "ModSecurity: Invalid regular expression \"%s\"", re->param);
             return -1;
@@ -1060,7 +1060,7 @@ static apr_status_t msre_action_ctl_execute(modsec_rec *msr, apr_pool_t *mptmp,
         rule_exception *re = apr_pcalloc(msr->mp, sizeof(rule_exception));
         re->type = RULE_EXCEPTION_REMOVE_MSG;
         re->param = (const char *)apr_pstrdup(msr->mp, value);
-        re->param_data = msc_pregcomp(msr->mp, re->param, 0, NULL, NULL);
+        re->param_data = msc_regex_pregcomp(msr->mp, re->param, 0, NULL, NULL);
         if (re->param_data == NULL) {
             msr_log(msr, 1, "ModSecurity: Invalid regular expression \"%s\"", re->param);
             return -1;
@@ -1261,7 +1261,7 @@ static apr_status_t msre_action_ctl_execute(modsec_rec *msr, apr_pool_t *mptmp,
     re = apr_pcalloc(msr->mp, sizeof(rule_exception));
     re->type = RULE_EXCEPTION_REMOVE_TAG;
     re->param = (const char *)apr_pstrdup(msr->mp, p1);
-    re->param_data = msc_pregcomp(msr->mp, p1, 0, NULL, NULL);
+    re->param_data = msc_regex_pregcomp(msr->mp, p1, 0, NULL, NULL);
     if (re->param_data == NULL) {
         msr_log(msr, 1, "ModSecurity: Invalid regular expression \"%s\"", p1);
         return -1;
@@ -1285,7 +1285,7 @@ static apr_status_t msre_action_ctl_execute(modsec_rec *msr, apr_pool_t *mptmp,
     re = apr_pcalloc(msr->mp, sizeof(rule_exception));
     re->type = RULE_EXCEPTION_REMOVE_MSG;
     re->param = apr_pstrdup(msr->mp, p1);
-    re->param_data = msc_pregcomp(msr->mp, p1, 0, NULL, NULL);
+    re->param_data = msc_regex_pregcomp(msr->mp, p1, 0, NULL, NULL);
     if (re->param_data == NULL) {
         msr_log(msr, 1, "ModSecurity: Invalid regular expression \"%s\"", p1);
         return -1;

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -699,7 +699,7 @@ static int msre_op_validateHash_param_init(msre_rule *rule, char **error_msg) {
         regex = msc_regex_pregcomp_ex(rule->ruleset->mp, pattern,0, &errptr, &erroffset, msc_pcre_match_limit, msc_pcre_match_limit_recursion) ;
         if (regex == NULL) {
 #ifdef REGEX_INTEGRATOR
-            if (g_use_regex_integrator) {
+            if ((g_regex_mode == REGEX_INTEGRATED_MODE)) {
                 *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern: %s", errptr);
             } else 
 #endif
@@ -713,7 +713,7 @@ static int msre_op_validateHash_param_init(msre_rule *rule, char **error_msg) {
         #ifdef WITH_PCRE_STUDY
             #ifdef WITH_PCRE_JIT
 #ifdef REGEX_INTEGRATOR
-        if (!g_use_regex_integrator) 
+        if (!(g_regex_mode == REGEX_INTEGRATED_MODE)) 
 #endif
         {
 
@@ -802,7 +802,7 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
                     &erroffset, msc_pcre_match_limit, msc_pcre_match_limit_recursion);
             if (regex == NULL) {
 #ifdef REGEX_INTEGRATOR
-                if (g_use_regex_integrator) {
+                if ((g_regex_mode == REGEX_INTEGRATED_MODE)) {
                     *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern : %s", errptr);
                 } else 
 #endif
@@ -817,7 +817,7 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
                 #ifdef WITH_PCRE_JIT
             if (msr->txcfg->debuglog_level >= 4) {
 #ifdef REGEX_INTEGRATOR
-                if (!g_use_regex_integrator) 
+                if (!(g_regex_mode == REGEX_INTEGRATED_MODE)) 
 #endif
                 {
                     rc = msc_regex_fullinfo(regex, PCRE_INFO_JIT, &jit);
@@ -969,7 +969,7 @@ static int msre_op_rx_param_init(msre_rule *rule, char **error_msg) {
         regex = msc_regex_pregcomp_ex(rule->ruleset->mp, pattern, PCRE_DOTALL | PCRE_DOLLAR_ENDONLY, &errptr, &erroffset, msc_pcre_match_limit, msc_pcre_match_limit_recursion);
         if (regex == NULL) {
 #ifdef REGEX_INTEGRATOR
-            if (g_use_regex_integrator) 
+            if ((g_regex_mode == REGEX_INTEGRATED_MODE)) 
             {
                 *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern : %s", errptr);
             } else 
@@ -984,7 +984,7 @@ static int msre_op_rx_param_init(msre_rule *rule, char **error_msg) {
         #ifdef WITH_PCRE_STUDY
             #ifdef WITH_PCRE_JIT
 #ifdef REGEX_INTEGRATOR
-        if (!g_use_regex_integrator) 
+        if (!(g_regex_mode == REGEX_INTEGRATED_MODE)) 
 #endif
         {
             rc = msc_regex_fullinfo(regex, PCRE_INFO_JIT, &jit);
@@ -1063,7 +1063,7 @@ static int msre_op_rx_execute(modsec_rec *msr, msre_rule *rule, msre_var *var, c
 
             if (regex == NULL) {
 #ifdef REGEX_INTEGRATOR
-                if (g_use_regex_integrator) {
+                if ((g_regex_mode == REGEX_INTEGRATED_MODE)) {
                     *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern : %s", errptr);
                 } else 
 #endif
@@ -1078,7 +1078,7 @@ static int msre_op_rx_execute(modsec_rec *msr, msre_rule *rule, msre_var *var, c
                 #ifdef WITH_PCRE_JIT
             if (msr->txcfg->debuglog_level >= 4) {
 #ifdef REGEX_INTEGRATOR
-                if (!g_use_regex_integrator) 
+                if (!(g_regex_mode == REGEX_INTEGRATED_MODE)) 
 #endif
                 {
                     rc = msc_regex_fullinfo(regex, PCRE_INFO_JIT, &jit);
@@ -1127,7 +1127,7 @@ static int msre_op_rx_execute(modsec_rec *msr, msre_rule *rule, msre_var *var, c
     /* Show when the regex captures but "capture" is not set */
     if (msr->txcfg->debuglog_level >= 6) {
 #ifdef REGEX_INTEGRATOR
-        if (! g_use_regex_integrator) 
+        if (! (g_regex_mode == REGEX_INTEGRATED_MODE)) 
 #endif
         {
             int capcount = 0;
@@ -2797,7 +2797,7 @@ static int msre_op_verifyCC_init(msre_rule *rule, char **error_msg) {
     regex = msc_regex_pregcomp_ex(rule->ruleset->mp, rule->op_param, PCRE_DOTALL | PCRE_MULTILINE, &errptr, &erroffset, msc_pcre_match_limit, msc_pcre_match_limit_recursion);
     if (regex == NULL) {
 #ifdef REGEX_INTEGRATOR
-        if (g_use_regex_integrator) {
+        if ((g_regex_mode == REGEX_INTEGRATED_MODE)) {
             *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern : %s",errptr);
         } else 
 #endif
@@ -2846,7 +2846,7 @@ static int msre_op_verifyCC_execute(modsec_rec *msr, msre_rule *rule, msre_var *
         #ifdef WITH_PCRE_JIT
     if (msr->txcfg->debuglog_level >= 4) {
 #ifdef REGEX_INTEGRATOR
-        if (!g_use_regex_integrator) 
+        if (!(g_regex_mode == REGEX_INTEGRATED_MODE)) 
 #endif
         {
             rc = msc_regex_fullinfo(regex, PCRE_INFO_JIT, &jit);
@@ -3105,7 +3105,7 @@ static int msre_op_verifyCPF_init(msre_rule *rule, char **error_msg) {
     regex = msc_regex_pregcomp_ex(rule->ruleset->mp, rule->op_param, PCRE_DOTALL | PCRE_MULTILINE, &errptr, &erroffset, msc_pcre_match_limit, msc_pcre_match_limit_recursion);
     if (regex == NULL) {
 #ifdef REGEX_INTEGRATOR
-        if (g_use_regex_integrator) {
+        if ((g_regex_mode == REGEX_INTEGRATED_MODE)) {
             *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern : %s", errptr);    
         } else 
 #endif
@@ -3167,7 +3167,7 @@ static int msre_op_verifyCPF_execute(modsec_rec *msr, msre_rule *rule, msre_var 
         #ifdef WITH_PCRE_JIT
     if (msr->txcfg->debuglog_level >= 4) {
 #ifdef REGEX_INTEGRATOR
-        if (!g_use_regex_integrator) 
+        if (!(g_regex_mode == REGEX_INTEGRATED_MODE)) 
 #endif
         {
             rc = msc_regex_fullinfo(regex, PCRE_INFO_JIT, &jit);
@@ -3409,7 +3409,7 @@ static int msre_op_verifySSN_init(msre_rule *rule, char **error_msg) {
     regex = msc_regex_pregcomp_ex(rule->ruleset->mp, rule->op_param, PCRE_DOTALL | PCRE_MULTILINE, &errptr, &erroffset, msc_pcre_match_limit, msc_pcre_match_limit_recursion);
     if (regex == NULL) {
 #ifdef REGEX_INTEGRATOR
-        if (g_use_regex_integrator) {
+        if ((g_regex_mode == REGEX_INTEGRATED_MODE)) {
             *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern : %s", errptr);
         } else 
 #endif
@@ -3471,7 +3471,7 @@ static int msre_op_verifySSN_execute(modsec_rec *msr, msre_rule *rule, msre_var 
         #ifdef WITH_PCRE_JIT
     if (msr->txcfg->debuglog_level >= 4) {
 #ifdef REGEX_INTEGRATOR
-        if (g_use_regex_integrator) 
+        if ((g_regex_mode == REGEX_INTEGRATED_MODE)) 
 #endif
         {
             rc = msc_regex_fullinfo(regex, PCRE_INFO_JIT, &jit);

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -698,9 +698,12 @@ static int msre_op_validateHash_param_init(msre_rule *rule, char **error_msg) {
     if(strstr(pattern,"%{") == NULL) {
         regex = msc_regex_pregcomp_ex(rule->ruleset->mp, pattern,0, &errptr, &erroffset, msc_pcre_match_limit, msc_pcre_match_limit_recursion) ;
         if (regex == NULL) {
+#ifdef REGEX_INTEGRATOR
             if (g_use_regex_integrator) {
                 *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern: %s", errptr);
-            } else {
+            } else 
+#endif
+            {
                 *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern (offset %d): %s",
                     erroffset, errptr);
             }
@@ -709,7 +712,11 @@ static int msre_op_validateHash_param_init(msre_rule *rule, char **error_msg) {
 
         #ifdef WITH_PCRE_STUDY
             #ifdef WITH_PCRE_JIT
-        if (!g_use_regex_integrator) {
+#ifdef REGEX_INTEGRATOR
+        if (!g_use_regex_integrator) 
+#endif
+        {
+
             rc = msc_regex_fullinfo(regex, PCRE_INFO_JIT, &jit);
             if ((rc != 0) || (jit != 1)) {
                 *error_msg = apr_psprintf(rule->ruleset->mp,
@@ -794,9 +801,12 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
             regex = msc_regex_pregcomp_ex(rule->ruleset->mp, pattern, PCRE_DOTALL | PCRE_DOLLAR_ENDONLY, &errptr, 
                     &erroffset, msc_pcre_match_limit, msc_pcre_match_limit_recursion);
             if (regex == NULL) {
+#ifdef REGEX_INTEGRATOR
                 if (g_use_regex_integrator) {
                     *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern : %s", errptr);
-                } else {
+                } else 
+#endif
+                {
                     *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern (offset %d): %s",
                         erroffset, errptr);
                 }
@@ -806,7 +816,10 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
             #ifdef WITH_PCRE_STUDY
                 #ifdef WITH_PCRE_JIT
             if (msr->txcfg->debuglog_level >= 4) {
-                if (!g_use_regex_integrator) {
+#ifdef REGEX_INTEGRATOR
+                if (!g_use_regex_integrator) 
+#endif
+                {
                     rc = msc_regex_fullinfo(regex, PCRE_INFO_JIT, &jit);
                     if ((rc != 0) || (jit != 1)) {
                         *error_msg = apr_psprintf(rule->ruleset->mp,
@@ -842,7 +855,7 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
      * and no memory has to be allocated for any backreferences.
      */
     
-    rc = msc_regex_regexec_capture((msc_ri_regex_t *)regex, target, target_length, ovector, 30, &my_error_msg);
+    rc = msc_regex_regexec_capture(regex, target, target_length, ovector, 30, &my_error_msg);
     if ((rc == PCRE_ERROR_MATCHLIMIT) || (rc == PCRE_ERROR_RECURSIONLIMIT)) {
         msc_string *s = (msc_string *)apr_pcalloc(msr->mp, sizeof(msc_string));
 
@@ -955,9 +968,13 @@ static int msre_op_rx_param_init(msre_rule *rule, char **error_msg) {
     if(strstr(pattern,"%{") == NULL)    {
         regex = msc_regex_pregcomp_ex(rule->ruleset->mp, pattern, PCRE_DOTALL | PCRE_DOLLAR_ENDONLY, &errptr, &erroffset, msc_pcre_match_limit, msc_pcre_match_limit_recursion);
         if (regex == NULL) {
-            if (g_use_regex_integrator) {
+#ifdef REGEX_INTEGRATOR
+            if (g_use_regex_integrator) 
+            {
                 *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern : %s", errptr);
-            } else {
+            } else 
+#endif
+            {
                 *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern (offset %d): %s",
                     erroffset, errptr);
             }
@@ -966,7 +983,10 @@ static int msre_op_rx_param_init(msre_rule *rule, char **error_msg) {
 
         #ifdef WITH_PCRE_STUDY
             #ifdef WITH_PCRE_JIT
-        if (!g_use_regex_integrator) {
+#ifdef REGEX_INTEGRATOR
+        if (!g_use_regex_integrator) 
+#endif
+        {
             rc = msc_regex_fullinfo(regex, PCRE_INFO_JIT, &jit);
             if ((rc != 0) || (jit != 1)) {
                 *error_msg = apr_psprintf(rule->ruleset->mp,
@@ -1042,9 +1062,12 @@ static int msre_op_rx_execute(modsec_rec *msr, msre_rule *rule, msre_var *var, c
             regex = msc_regex_pregcomp_ex(rule->ruleset->mp, pattern, PCRE_DOTALL | PCRE_DOLLAR_ENDONLY, &errptr, &erroffset, msc_pcre_match_limit, msc_pcre_match_limit_recursion);
 
             if (regex == NULL) {
+#ifdef REGEX_INTEGRATOR
                 if (g_use_regex_integrator) {
                     *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern : %s", errptr);
-                } else {
+                } else 
+#endif
+                {
                     *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern (offset %d): %s",
                         erroffset, errptr);
                 }
@@ -1054,7 +1077,10 @@ static int msre_op_rx_execute(modsec_rec *msr, msre_rule *rule, msre_var *var, c
             #ifdef WITH_PCRE_STUDY
                 #ifdef WITH_PCRE_JIT
             if (msr->txcfg->debuglog_level >= 4) {
-                if (!g_use_regex_integrator) {
+#ifdef REGEX_INTEGRATOR
+                if (!g_use_regex_integrator) 
+#endif
+                {
                     rc = msc_regex_fullinfo(regex, PCRE_INFO_JIT, &jit);
                     if ((rc != 0) || (jit != 1)) {
                         *error_msg = apr_psprintf(rule->ruleset->mp,
@@ -1100,7 +1126,10 @@ static int msre_op_rx_execute(modsec_rec *msr, msre_rule *rule, msre_var *var, c
 
     /* Show when the regex captures but "capture" is not set */
     if (msr->txcfg->debuglog_level >= 6) {
-        if (! g_use_regex_integrator) {
+#ifdef REGEX_INTEGRATOR
+        if (! g_use_regex_integrator) 
+#endif
+        {
             int capcount = 0;
             rc = msc_regex_fullinfo(regex, PCRE_INFO_CAPTURECOUNT, &capcount);
             if (msr->txcfg->debuglog_level >= 6) {
@@ -2767,9 +2796,12 @@ static int msre_op_verifyCC_init(msre_rule *rule, char **error_msg) {
     /* Compile rule->op_param */
     regex = msc_regex_pregcomp_ex(rule->ruleset->mp, rule->op_param, PCRE_DOTALL | PCRE_MULTILINE, &errptr, &erroffset, msc_pcre_match_limit, msc_pcre_match_limit_recursion);
     if (regex == NULL) {
+#ifdef REGEX_INTEGRATOR
         if (g_use_regex_integrator) {
             *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern : %s",errptr);
-        } else {
+        } else 
+#endif
+        {
             *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern (offset %d): %s",
                 erroffset, errptr);
         }
@@ -2813,7 +2845,10 @@ static int msre_op_verifyCC_execute(modsec_rec *msr, msre_rule *rule, msre_var *
     #ifdef WITH_PCRE_STUDY
         #ifdef WITH_PCRE_JIT
     if (msr->txcfg->debuglog_level >= 4) {
-        if (!g_use_regex_integrator) {
+#ifdef REGEX_INTEGRATOR
+        if (!g_use_regex_integrator) 
+#endif
+        {
             rc = msc_regex_fullinfo(regex, PCRE_INFO_JIT, &jit);
             if ((rc != 0) || (jit != 1)) {
                 *error_msg = apr_psprintf(rule->ruleset->mp,
@@ -3069,9 +3104,12 @@ static int msre_op_verifyCPF_init(msre_rule *rule, char **error_msg) {
     /* Compile rule->op_param */
     regex = msc_regex_pregcomp_ex(rule->ruleset->mp, rule->op_param, PCRE_DOTALL | PCRE_MULTILINE, &errptr, &erroffset, msc_pcre_match_limit, msc_pcre_match_limit_recursion);
     if (regex == NULL) {
+#ifdef REGEX_INTEGRATOR
         if (g_use_regex_integrator) {
             *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern : %s", errptr);    
-        } else {
+        } else 
+#endif
+        {
             *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern (offset %d): %s",
                 erroffset, errptr);
         }
@@ -3128,7 +3166,10 @@ static int msre_op_verifyCPF_execute(modsec_rec *msr, msre_rule *rule, msre_var 
     #ifdef WITH_PCRE_STUDY
         #ifdef WITH_PCRE_JIT
     if (msr->txcfg->debuglog_level >= 4) {
-        if (!g_use_regex_integrator) {
+#ifdef REGEX_INTEGRATOR
+        if (!g_use_regex_integrator) 
+#endif
+        {
             rc = msc_regex_fullinfo(regex, PCRE_INFO_JIT, &jit);
             if ((rc != 0) || (jit != 1)) {
                 *error_msg = apr_psprintf(rule->ruleset->mp,
@@ -3367,9 +3408,12 @@ static int msre_op_verifySSN_init(msre_rule *rule, char **error_msg) {
     /* Compile rule->op_param */
     regex = msc_regex_pregcomp_ex(rule->ruleset->mp, rule->op_param, PCRE_DOTALL | PCRE_MULTILINE, &errptr, &erroffset, msc_pcre_match_limit, msc_pcre_match_limit_recursion);
     if (regex == NULL) {
+#ifdef REGEX_INTEGRATOR
         if (g_use_regex_integrator) {
             *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern : %s", errptr);
-        } else {
+        } else 
+#endif
+        {
             *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern (offset %d): %s",
                 erroffset, errptr);
         }
@@ -3426,7 +3470,10 @@ static int msre_op_verifySSN_execute(modsec_rec *msr, msre_rule *rule, msre_var 
     #ifdef WITH_PCRE_STUDY
         #ifdef WITH_PCRE_JIT
     if (msr->txcfg->debuglog_level >= 4) {
-        if (g_use_regex_integrator) {
+#ifdef REGEX_INTEGRATOR
+        if (g_use_regex_integrator) 
+#endif
+        {
             rc = msc_regex_fullinfo(regex, PCRE_INFO_JIT, &jit);
             if ((rc != 0) || (jit != 1)) {
                 *error_msg = apr_psprintf(rule->ruleset->mp,

--- a/apache2/re_variables.c
+++ b/apache2/re_variables.c
@@ -72,7 +72,7 @@ static char *var_generic_list_validate(msre_ruleset *ruleset, msre_var *var) {
         regex = msc_regex_pregcomp(ruleset->mp, pattern, PCRE_DOTALL | PCRE_CASELESS | PCRE_DOLLAR_ENDONLY, &errptr, &erroffset);
         if (regex == NULL) {
 #ifdef REGEX_INTEGRATOR
-            if (g_use_regex_integrator) {
+            if (g_regex_mode == REGEX_INTEGRATED_MODE) {
                 return apr_psprintf(ruleset->mp, "Error compiling pattern : %s", errptr);
             } else
 #endif

--- a/apache2/re_variables.c
+++ b/apache2/re_variables.c
@@ -71,9 +71,12 @@ static char *var_generic_list_validate(msre_ruleset *ruleset, msre_var *var) {
 
         regex = msc_regex_pregcomp(ruleset->mp, pattern, PCRE_DOTALL | PCRE_CASELESS | PCRE_DOLLAR_ENDONLY, &errptr, &erroffset);
         if (regex == NULL) {
+#ifdef REGEX_INTEGRATOR
             if (g_use_regex_integrator) {
                 return apr_psprintf(ruleset->mp, "Error compiling pattern : %s", errptr);
-            } else {
+            } else
+#endif
+            {
                 return apr_psprintf(ruleset->mp, "Error compiling pattern (offset %d): %s",
                     erroffset, errptr);
             }

--- a/apache2/regex_integrator/Makefile
+++ b/apache2/regex_integrator/Makefile
@@ -1,40 +1,56 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-PREFIX = /usr/local
-HEADER_DEST = $(PREFIX)/include/regex_integrator
-LIB_DEST = $(PREFIX)/lib
+BASEPATH=$(shell pwd)
 
-3RD = 3rd
-RE2_SITE = https://github.com/google/re2.git
-RE2_DIR = $(3RD)/re2
-PCRE_VER = pcre-8.42
-PCRE_SITE = https://ftp.pcre.org/pub/pcre/$(PCRE_VER).tar.gz
-PCRE_DIR = $(3RD)/$(PCRE_VER)
+PREFIX?=/usr/local
+HEADER_DEST?=$(PREFIX)/include/regex_integrator
+LIB_DEST?=$(PREFIX)/lib
 
-CC = gcc
-CXX = g++
-CINCLUDES = -I./$(PCRE_DIR)
-CXXINCLUDES = -I./$(RE2_DIR) 
-CFLAGS = -g -O3 -Wall -Werror -std=c99
-CXXFLAGS = -g -O3 -Wall -Werror -std=c++11
-CLIBS = -pthread -L./$(PCRE_DIR)/.libs -lpcre
-CXXLIBS = -L./$(RE2_DIR)/obj -lre2
-TARGET = bin/libregex_integrator.so
-OBJS = objs/ri_pcre.o objs/ri_re2.o objs/ri_api.o
+BIN_DIR?=$(BASEPATH)/bin
+OBJ_DIR=$(BASEPATH)/objs
+
+TARGET?=$(BIN_DIR)/libregex_integrator.a
+HEADER_API?=$(BASEPATH)/ri_api.h
+
+OBJS=$(OBJ_DIR)/ri_pcre.o $(OBJ_DIR)/ri_re2.o $(OBJ_DIR)/ri_api.o
+
+3RD?=$(BASEPATH)/3rd
+
+PCRE_VER?=pcre-8.42
+PCRE_SITE?=https://ftp.pcre.org/pub/pcre/$(PCRE_VER).tar.gz
+PCRE_DIR?=$(3RD)/$(PCRE_VER)
+PCRE_LIB?=$(PCRE_DIR)/.libs/libpcre.a
+PCRE_INCLUDE?=$(PCRE_DIR)
+
+RE2_SITE?=https://github.com/google/re2.git
+RE2_DIR?= $(3RD)/re2
+RE2_LIB?=$(RE2_DIR)/obj/libre2.a
+RE2_INCLUDE?=$(RE2_DIR)
+
+AR?=ar
+CC?=gcc
+CXX?=g++
+CINCLUDES?=-I$(PCRE_DIR)
+CXXINCLUDES=-I$(RE2_DIR) 
+CFLAGS?=-g -O3 -Wall -Werror -std=c99
+CXXFLAGS?=-g -O3 -Wall -Werror -std=c++11
+LIBS?=-pthread
+
+CLEAN_OBJS?=$(BIN_DIR) $(OBJ_DIR)
 
 # initialize enviroment
 $(shell mkdir -p $(3RD))
-$(shell mkdir -p objs)
-$(shell mkdir -p bin)
+$(shell mkdir -p $(OBJ_DIR))
+$(shell mkdir -p $(BIN_DIR))
 
-all: build_pcre build_re2 $(TARGET) test
+all: build_pcre build_re2 $(TARGET)
 
 build_pcre:
 ifeq ($(wildcard $(PCRE_DIR)), )
 	@cd $(3RD) && wget $(PCRE_SITE)
 	@cd $(3RD) && tar -xvzf $(PCRE_VER).tar.gz
-	@cd $(PCRE_DIR) && CFLAGS=-fPIC ./configure --enable-static=true --enable-shared=false
+	@cd $(PCRE_DIR) && ./configure --enable-jit
 endif
 	@cd $(PCRE_DIR) && make -j
 
@@ -45,29 +61,35 @@ ifeq ($(wildcard $(RE2_DIR)), )
 else
 	@cd $(RE2_DIR) && git pull
 endif
-	@cd $(RE2_DIR) && CXXFLAGS=-fPIC make -j;
+	@cd $(RE2_DIR) && make -j;
 
-objs/%.o: %.c
-	$(CC) $(CFLAGS) $(CINCLUDES) -fPIC -c $< -o $@
+$(OBJ_DIR)/%.o: %.c
+	$(CC) $(CFLAGS) $(CINCLUDES) -c $< -o $@
 
-objs/%.o: %.cpp %.h
-	$(CXX) $(CXXFLAGS) $(CXXINCLUDES) -fPIC -c $< -o $@
+$(OBJ_DIR)/%.o: %.cpp %.h
+	$(CXX) $(CXXFLAGS) $(CXXINCLUDES) -c $< -o $@
 
 $(TARGET): $(OBJS)
-	$(CXX) $(CXXFLAGS) -fPIC -shared -o $@ $(OBJS) $(CLIBS) $(CXXLIBS)
+	@cd $(OBJ_DIR) && $(AR) -x $(PCRE_LIB)
+	@cd $(OBJ_DIR) && $(AR) -x $(RE2_LIB)
+	$(AR) rcs -o $@ $(OBJ_DIR)/*.o
 	@echo $(TARGET)" Compile Success"
 
 test: tester.cpp
-	$(CXX) $(CXXFLAGS) $(CINCLUDES) $(CXXINCLUDES) $< $(shell pwd)/$(TARGET) -Wl,-rpath=$(shell pwd)/bin -o bin/$@
+	$(CXX) $(CXXFLAGS) -I$(BASEPATH) $< $(TARGET) $(LIBS) -o $(BIN_DIR)/$@
 	@bin/$@
 	@echo 'Test Success'
 
+bench: bench.cpp
+	$(CXX) $(CXXFLAGS) -I$(BASEPATH) $(CINCLUDES) $(CXXINCLUDES) $< $(TARGET) $(LIBS) -o $(BIN_DIR)/$@
+	@bin/$@
+	@echo 'Bench Success'
+
 install:
 	mkdir -p $(HEADER_DEST)
-	install ri_api.h $(HEADER_DEST)
+	install $(HEADER_API) $(HEADER_DEST)
 	install $(TARGET) $(LIB_DEST)
 	ldconfig
 
 clean:
-	rm -rf objs
-	rm -rf bin
+	rm -rf $(CLEAN_OBJS)

--- a/apache2/regex_integrator/Makefile
+++ b/apache2/regex_integrator/Makefile
@@ -10,7 +10,7 @@ LIB_DEST?=$(PREFIX)/lib
 BIN_DIR?=$(BASEPATH)/bin
 OBJ_DIR=$(BASEPATH)/objs
 
-TARGET?=$(BIN_DIR)/libregex_integrator.a
+TARGET?=$(BIN_DIR)/libregex_integrator.so
 HEADER_API?=$(BASEPATH)/ri_api.h
 
 OBJS=$(OBJ_DIR)/ri_pcre.o $(OBJ_DIR)/ri_re2.o $(OBJ_DIR)/ri_api.o
@@ -33,8 +33,8 @@ CC?=gcc
 CXX?=g++
 CINCLUDES?=-I$(PCRE_DIR)
 CXXINCLUDES=-I$(RE2_DIR) 
-CFLAGS?=-g -O3 -Wall -Werror -std=c99
-CXXFLAGS?=-g -O3 -Wall -Werror -std=c++11
+CFLAGS?= -fPIC -g -O3 -Wall -Werror -std=c99
+CXXFLAGS?= -fPIC -g -O3 -Wall -Werror -std=c++11
 LIBS?=-pthread
 
 CLEAN_OBJS?=$(BIN_DIR) $(OBJ_DIR)
@@ -50,7 +50,7 @@ build_pcre:
 ifeq ($(wildcard $(PCRE_DIR)), )
 	@cd $(3RD) && wget $(PCRE_SITE)
 	@cd $(3RD) && tar -xvzf $(PCRE_VER).tar.gz
-	@cd $(PCRE_DIR) && ./configure --enable-jit
+	@cd $(PCRE_DIR) && CFLAGS="-fPIC -g -O3" ./configure --enable-jit
 endif
 	@cd $(PCRE_DIR) && make -j
 
@@ -61,7 +61,7 @@ ifeq ($(wildcard $(RE2_DIR)), )
 else
 	@cd $(RE2_DIR) && git pull
 endif
-	@cd $(RE2_DIR) && make -j;
+	@cd $(RE2_DIR) && CXXFLAGS="-fPIC -g -O3"  make -j;
 
 $(OBJ_DIR)/%.o: %.c
 	$(CC) $(CFLAGS) $(CINCLUDES) -c $< -o $@
@@ -72,7 +72,7 @@ $(OBJ_DIR)/%.o: %.cpp %.h
 $(TARGET): $(OBJS)
 	@cd $(OBJ_DIR) && $(AR) -x $(PCRE_LIB)
 	@cd $(OBJ_DIR) && $(AR) -x $(RE2_LIB)
-	$(AR) rcs -o $@ $(OBJ_DIR)/*.o
+	$(CXX) -shared $(CXXFLAGS) -o $@ $(OBJ_DIR)/*.o
 	@echo $(TARGET)" Compile Success"
 
 test: tester.cpp

--- a/apache2/regex_integrator/Makefile
+++ b/apache2/regex_integrator/Makefile
@@ -23,9 +23,10 @@ PCRE_DIR?=$(3RD)/$(PCRE_VER)
 PCRE_BUILD?=$(PCRE_DIR)/build
 PCRE_LIB?=$(PCRE_BUILD)/lib/libpcre.a
 PCRE_INCLUDE?=$(PCRE_DIR)
+PCRE_OPT?=
 
 RE2_SITE?=https://github.com/google/re2.git
-RE2_DIR?= $(3RD)/re2
+RE2_DIR?=$(3RD)/re2
 RE2_LIB?=$(RE2_DIR)/obj/libre2.a
 RE2_INCLUDE?=$(RE2_DIR)
 
@@ -34,11 +35,14 @@ CC?=gcc
 CXX?=g++
 CINCLUDES?=-I$(PCRE_DIR)
 CXXINCLUDES=-I$(RE2_DIR) 
-CFLAGS?= -fPIC -g -O3 -Wall -Werror -std=c99
-CXXFLAGS?= -fPIC -g -O3 -Wall -Werror -std=c++11
+WARNING?=-Wall -Werror
+CSTD?=-std=c99
+CXXSTD?=-std=c++11
+CFLAGS?=-fPIC -g -O3
+CXXFLAGS?=-fPIC -g -O3
 LIBS?=-pthread
 
-CLEAN_OBJS?=$(BIN_DIR) $(OBJ_DIR)
+CLEAN_OBJS?=$(BIN_DIR) $(OBJ_DIR) $(3RD)
 
 # initialize enviroment
 $(shell mkdir -p $(3RD))
@@ -51,10 +55,11 @@ build_pcre:
 ifeq ($(wildcard $(PCRE_DIR)), )
 	@cd $(3RD) && wget $(PCRE_SITE)
 	@cd $(3RD) && tar -xvzf $(PCRE_VER).tar.gz
-	@cd $(PCRE_DIR) && CFLAGS="-fPIC -g -O3" ./configure --enable-jit --prefix $(PCRE_BUILD)
+endif
+	@cd $(PCRE_DIR) && autoreconf -f -i
+	@cd $(PCRE_DIR) && CFLAGS="$(CFLAGS)" ./configure --enable-jit --prefix $(PCRE_BUILD) $(PCRE_OPT)
 	@cd $(PCRE_DIR) && make -j
 	@cd $(PCRE_DIR) && make install
-endif
 
 build_re2:
 ifeq ($(wildcard $(RE2_DIR)), )
@@ -62,27 +67,27 @@ ifeq ($(wildcard $(RE2_DIR)), )
 else
 	@cd $(RE2_DIR) && git pull
 endif
-	@cd $(RE2_DIR) && CXXFLAGS="-fPIC -g -O3"  make -j;
+	@cd $(RE2_DIR) && CXXFLAGS="$(CXXFLAGS)"  make -j;
 
 $(OBJ_DIR)/%.o: %.c
-	$(CC) $(CFLAGS) $(CINCLUDES) -c $< -o $@
+	$(CC) $(CFLAGS) $(CSTD) $(WARNING) $(CINCLUDES) -c $< -o $@
 
 $(OBJ_DIR)/%.o: %.cpp %.h
-	$(CXX) $(CXXFLAGS) $(CXXINCLUDES) -c $< -o $@
+	$(CXX) $(CXXFLAGS) $(CXXSTD) $(WARNING) $(CXXINCLUDES) -c $< -o $@
 
 $(TARGET): $(OBJS)
 	@cd $(OBJ_DIR) && $(AR) -x $(PCRE_LIB)
 	@cd $(OBJ_DIR) && $(AR) -x $(RE2_LIB)
-	$(CXX) -shared $(CXXFLAGS) -o $@ $(OBJ_DIR)/*.o
+	$(CXX) -shared $(CXXFLAGS) $(CXXSTD) $(WARNING) -o $@ $(OBJ_DIR)/*.o
 	@echo $(TARGET)" Compile Success"
 
 test: tester.cpp
-	$(CXX) $(CXXFLAGS) -I$(BASEPATH) $< $(TARGET) $(LIBS) -o $(BIN_DIR)/$@
+	$(CXX) $(CXXFLAGS) $(CXXSTD) $(WARNING) -I$(BASEPATH) $< $(TARGET) $(LIBS) -o $(BIN_DIR)/$@
 	@bin/$@
 	@echo 'Test Success'
 
 bench: bench.cpp
-	$(CXX) $(CXXFLAGS) -I$(BASEPATH) $(CINCLUDES) $(CXXINCLUDES) $< $(TARGET) $(LIBS) -o $(BIN_DIR)/$@
+	$(CXX) $(CXXFLAGS) $(CXXSTD) $(WARNING) -I$(BASEPATH) $(CINCLUDES) $(CXXINCLUDES) $< $(TARGET) $(LIBS) -o $(BIN_DIR)/$@
 	@bin/$@
 	@echo 'Bench Success'
 

--- a/apache2/regex_integrator/Makefile
+++ b/apache2/regex_integrator/Makefile
@@ -20,7 +20,8 @@ OBJS=$(OBJ_DIR)/ri_pcre.o $(OBJ_DIR)/ri_re2.o $(OBJ_DIR)/ri_api.o
 PCRE_VER?=pcre-8.42
 PCRE_SITE?=https://ftp.pcre.org/pub/pcre/$(PCRE_VER).tar.gz
 PCRE_DIR?=$(3RD)/$(PCRE_VER)
-PCRE_LIB?=$(PCRE_DIR)/.libs/libpcre.a
+PCRE_BUILD?=$(PCRE_DIR)/build
+PCRE_LIB?=$(PCRE_BUILD)/lib/libpcre.a
 PCRE_INCLUDE?=$(PCRE_DIR)
 
 RE2_SITE?=https://github.com/google/re2.git
@@ -50,14 +51,14 @@ build_pcre:
 ifeq ($(wildcard $(PCRE_DIR)), )
 	@cd $(3RD) && wget $(PCRE_SITE)
 	@cd $(3RD) && tar -xvzf $(PCRE_VER).tar.gz
-	@cd $(PCRE_DIR) && CFLAGS="-fPIC -g -O3" ./configure --enable-jit
-endif
+	@cd $(PCRE_DIR) && CFLAGS="-fPIC -g -O3" ./configure --enable-jit --prefix $(PCRE_BUILD)
 	@cd $(PCRE_DIR) && make -j
+	@cd $(PCRE_DIR) && make install
+endif
 
 build_re2:
 ifeq ($(wildcard $(RE2_DIR)), )
 	@git clone $(RE2_SITE) $(RE2_DIR)
-	@cd $(RE2_DIR)
 else
 	@cd $(RE2_DIR) && git pull
 endif

--- a/apache2/regex_integrator/Makefile
+++ b/apache2/regex_integrator/Makefile
@@ -17,22 +17,26 @@ OBJS=$(OBJ_DIR)/ri_pcre.o $(OBJ_DIR)/ri_re2.o $(OBJ_DIR)/ri_api.o
 
 3RD?=$(BASEPATH)/3rd
 
-PCRE_VER?=pcre-8.42
-PCRE_SITE?=https://ftp.pcre.org/pub/pcre/$(PCRE_VER).tar.gz
-PCRE_DIR?=$(3RD)/$(PCRE_VER)
+PCRE_VER?=8.42
+PCRE_DOWNLOAD_NAME?=pcre-$(PCRE_VER).tar.gz
+PCRE_SITE?=https://ftp.pcre.org/pub/pcre/pcre-$(PCRE_VER).tar.gz
+PCRE_DIR?=$(3RD)/pcre-$(PCRE_VER)
 PCRE_BUILD?=$(PCRE_DIR)/build
 PCRE_LIB?=$(PCRE_BUILD)/lib/libpcre.a
 PCRE_INCLUDE?=$(PCRE_DIR)
 PCRE_OPT?=
 
-RE2_SITE?=https://github.com/google/re2.git
-RE2_DIR?=$(3RD)/re2
+RE2_VER?=2018-10-01
+RE2_DOWNLOAD_NAME?=re-$(RE2_VER).tar.gz
+RE2_SITE?=https://github.com/google/re2/archive/$(RE2_VER).tar.gz
+RE2_DIR?=$(3RD)/re2-$(RE2_VER)
 RE2_LIB?=$(RE2_DIR)/obj/libre2.a
 RE2_INCLUDE?=$(RE2_DIR)
 
 AR?=ar
 CC?=gcc
 CXX?=g++
+MAKE?=make
 CINCLUDES?=-I$(PCRE_DIR)
 CXXINCLUDES=-I$(RE2_DIR) 
 WARNING?=-Wall -Werror
@@ -42,19 +46,21 @@ CFLAGS?=-fPIC -g -O3
 CXXFLAGS?=-fPIC -g -O3
 LIBS?=-pthread
 
-CLEAN_OBJS?=$(BIN_DIR) $(OBJ_DIR) $(3RD)
+CLEAN_OBJS?=$(BIN_DIR) $(OBJ_DIR)
 
 # initialize enviroment
 $(shell mkdir -p $(3RD))
 $(shell mkdir -p $(OBJ_DIR))
 $(shell mkdir -p $(BIN_DIR))
 
-all: build_pcre build_re2 $(TARGET)
+all: build_pcre build_re2
+	$(MAKE) $(TARGET)
 
 build_pcre:
 ifeq ($(wildcard $(PCRE_DIR)), )
-	@cd $(3RD) && wget $(PCRE_SITE)
-	@cd $(3RD) && tar -xvzf $(PCRE_VER).tar.gz
+	@cd $(3RD) && mkdir -p $(PCRE_DIR)
+	@cd $(3RD) && wget $(PCRE_SITE) -O $(PCRE_DOWNLOAD_NAME)
+	@cd $(3RD) && tar -xvzf $(PCRE_DOWNLOAD_NAME) -C $(PCRE_DIR) --strip-components 1
 endif
 	@cd $(PCRE_DIR) && autoreconf -f -i
 	@cd $(PCRE_DIR) && CFLAGS="$(CFLAGS)" ./configure --enable-jit --prefix $(PCRE_BUILD) $(PCRE_OPT)
@@ -63,9 +69,9 @@ endif
 
 build_re2:
 ifeq ($(wildcard $(RE2_DIR)), )
-	@git clone $(RE2_SITE) $(RE2_DIR)
-else
-	@cd $(RE2_DIR) && git pull
+	@cd $(3RD) && mkdir -p $(RE2_DIR)
+	@cd $(3RD) && wget $(RE2_SITE) -O $(RE2_DOWNLOAD_NAME)
+	@cd $(3RD) && tar -xvzf $(RE2_DOWNLOAD_NAME) -C $(RE2_DIR) --strip-components 1
 endif
 	@cd $(RE2_DIR) && CXXFLAGS="$(CXXFLAGS)"  make -j;
 

--- a/apache2/regex_integrator/Makefile
+++ b/apache2/regex_integrator/Makefile
@@ -1,3 +1,8 @@
+
+PREFIX = /usr/local
+HEADER_DEST = $(PREFIX)/include/regex_integrator
+LIB_DEST = $(PREFIX)/lib
+
 3RD = 3rd
 RE2_SITE = https://github.com/google/re2.git
 RE2_DIR = $(3RD)/re2
@@ -17,15 +22,9 @@ TARGET = bin/libregex_integrator.so
 OBJS = objs/ri_pcre.o objs/ri_re2.o objs/ri_api.o
 
 # initialize enviroment
-ifeq ($(wildcard $(3RD)), )
-$(shell mkdir $(3RD))
-endif
-ifeq ($(wildcard objs), )
-$(shell mkdir objs)
-endif
-ifeq ($(wildcard bin), )
-$(shell mkdir bin)
-endif
+$(shell mkdir -p $(3RD))
+$(shell mkdir -p objs)
+$(shell mkdir -p bin)
 
 all: build_pcre build_re2 $(TARGET) test
 
@@ -60,6 +59,12 @@ test: tester.cpp
 	$(CXX) $(CXXFLAGS) $(CINCLUDES) $(CXXINCLUDES) $< $(shell pwd)/$(TARGET) -Wl,-rpath=$(shell pwd)/bin -o bin/$@
 	@bin/$@
 	@echo 'Test Success'
+
+install:
+	mkdir -p $(HEADER_DEST)
+	install ri_api.h $(HEADER_DEST)
+	install $(TARGET) $(LIB_DEST)
+	ldconfig
 
 clean:
 	rm -rf objs

--- a/apache2/regex_integrator/Makefile
+++ b/apache2/regex_integrator/Makefile
@@ -1,0 +1,64 @@
+3RD = 3rd
+RE2_SITE = https://github.com/google/re2.git
+RE2_DIR = $(3RD)/re2
+PCRE_VER = pcre-8.42
+PCRE_SITE = https://ftp.pcre.org/pub/pcre/$(PCRE_VER).tar.gz
+PCRE_DIR = $(3RD)/$(PCRE_VER)
+
+CC = gcc
+CXX = g++
+CFLAGS = -g -O3 -Wall -Werror -std=c99
+CXXFLAGS = -g -O3 -Wall -Werror -std=c++11
+LIBS = -pthread -L./$(PCRE_DIR)/.libs -I./$(PCRE_DIR) -lpcre
+CXXLIBS = -L./$(RE2_DIR)/obj -I./$(RE2_DIR)/re2 -lre2
+TARGET = bin/libregex_integrator.so
+OBJS = objs/ri_pcre.o objs/ri_re2.o objs/ri_api.o
+
+# initialize enviroment
+ifeq ($(wildcard $(3RD)), )
+$(shell mkdir $(3RD))
+endif
+ifeq ($(wildcard objs), )
+$(shell mkdir objs)
+endif
+ifeq ($(wildcard bin), )
+$(shell mkdir bin)
+endif
+
+all: build_pcre build_re2 $(TARGET) test
+
+build_pcre:
+ifeq ($(wildcard $(PCRE_DIR)), )
+	@cd $(3RD) && wget $(PCRE_SITE)
+	@cd $(3RD) && tar -xvzf $(PCRE_VER).tar.gz
+	@cd $(PCRE_DIR) && CFLAGS=-fPIC ./configure --enable-static=true --enable-shared=false
+endif
+	@cd $(PCRE_DIR) && make -j
+
+build_re2:
+ifeq ($(wildcard $(RE2_DIR)), )
+	@git clone $(RE2_SITE) $(RE2_DIR)
+	@cd $(RE2_DIR)
+else
+	@cd $(RE2_DIR) && git pull
+endif
+	@cd $(RE2_DIR) && CXXFLAGS=-fPIC make -j;
+
+objs/%.o: %.c
+	$(CC) $(CFLAGS) -fPIC -c $< -o $@
+
+objs/%.o: %.cpp %.h
+	$(CXX) $(CXXFLAGS) -fPIC -c $< -o $@
+
+$(TARGET): $(OBJS)
+	$(CXX) $(CXXFLAGS) -fPIC -shared -o $@ $(OBJS) $(LIBS) $(CXXLIBS)
+	@echo $(TARGET)" Compile Success"
+
+test: tester.cpp
+	$(CXX) $(CXXFLAGS) $< $(shell pwd)/$(TARGET) -Wl,-rpath=$(shell pwd)/bin -o bin/$@
+	@bin/$@
+	@echo 'Test Success'
+
+clean:
+	rm -rf objs
+	rm -rf bin

--- a/apache2/regex_integrator/Makefile
+++ b/apache2/regex_integrator/Makefile
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
 
 PREFIX = /usr/local
 HEADER_DEST = $(PREFIX)/include/regex_integrator

--- a/apache2/regex_integrator/Makefile
+++ b/apache2/regex_integrator/Makefile
@@ -7,10 +7,12 @@ PCRE_DIR = $(3RD)/$(PCRE_VER)
 
 CC = gcc
 CXX = g++
+CINCLUDES = -I./$(PCRE_DIR)
+CXXINCLUDES = -I./$(RE2_DIR) 
 CFLAGS = -g -O3 -Wall -Werror -std=c99
 CXXFLAGS = -g -O3 -Wall -Werror -std=c++11
-LIBS = -pthread -L./$(PCRE_DIR)/.libs -I./$(PCRE_DIR) -lpcre
-CXXLIBS = -L./$(RE2_DIR)/obj -I./$(RE2_DIR)/re2 -lre2
+CLIBS = -pthread -L./$(PCRE_DIR)/.libs -lpcre
+CXXLIBS = -L./$(RE2_DIR)/obj -lre2
 TARGET = bin/libregex_integrator.so
 OBJS = objs/ri_pcre.o objs/ri_re2.o objs/ri_api.o
 
@@ -45,17 +47,17 @@ endif
 	@cd $(RE2_DIR) && CXXFLAGS=-fPIC make -j;
 
 objs/%.o: %.c
-	$(CC) $(CFLAGS) -fPIC -c $< -o $@
+	$(CC) $(CFLAGS) $(CINCLUDES) -fPIC -c $< -o $@
 
 objs/%.o: %.cpp %.h
-	$(CXX) $(CXXFLAGS) -fPIC -c $< -o $@
+	$(CXX) $(CXXFLAGS) $(CXXINCLUDES) -fPIC -c $< -o $@
 
 $(TARGET): $(OBJS)
-	$(CXX) $(CXXFLAGS) -fPIC -shared -o $@ $(OBJS) $(LIBS) $(CXXLIBS)
+	$(CXX) $(CXXFLAGS) -fPIC -shared -o $@ $(OBJS) $(CLIBS) $(CXXLIBS)
 	@echo $(TARGET)" Compile Success"
 
 test: tester.cpp
-	$(CXX) $(CXXFLAGS) $< $(shell pwd)/$(TARGET) -Wl,-rpath=$(shell pwd)/bin -o bin/$@
+	$(CXX) $(CXXFLAGS) $(CINCLUDES) $(CXXINCLUDES) $< $(shell pwd)/$(TARGET) -Wl,-rpath=$(shell pwd)/bin -o bin/$@
 	@bin/$@
 	@echo 'Test Success'
 

--- a/apache2/regex_integrator/bench.cpp
+++ b/apache2/regex_integrator/bench.cpp
@@ -1,0 +1,376 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/timeb.h>
+
+#include <re2/re2.h>
+#include <pcre.h>
+#include "ri_api.h"
+
+#define OVECCOUNT 30
+
+#define BENCH_TIME 3 // seconds
+#define BENCH(STATEMENT, OPS) do{                               \
+        struct timeb _start = {0}, _end = {0};                  \
+        int _time = 0, _i = 0;                                  \
+        int _eslapse =0;                                        \
+        ftime(&_start);                                         \
+        do {                                                    \
+            for (_i = 0; _i < 10; ++_i) {                       \
+                STATEMENT;                                      \
+                ++_time;                                        \
+            }                                                   \
+            ftime(&_end);                                       \
+            _eslapse = (1000 * (_end.time - _start.time)        \
+                + (_end.millitm - _start.millitm));             \
+        } while(_eslapse < (BENCH_TIME * 1000));                \
+        OPS = (((double)_time / _eslapse) * 1000);              \
+    }while(0);
+    
+const char * human_readable(double number) {
+    static char buffer[1024] = {0};
+    char unit = ' ';
+
+    if (number >= 1e9) {
+        unit = 'G';
+        number /= 1e9;
+    } else if (number > 1e6) {
+        unit = 'M';
+        number /= 1e6;
+    } else if (number > 1e3) {
+        unit = 'K';
+        number /= 1e3;
+    }
+    sprintf(buffer, "%.3f %c", number, unit);
+    return buffer;
+}
+
+int test(
+    const std::string & pattern_str, 
+    const std::string & subject_str, 
+    int comp_opt,   // Options for compilation
+    int exec_opt,   // Options for execution
+    int exec_expect // Expected result for execution
+    ) {
+    int ret = 0;
+    double ops = 0;
+
+    //print limiter
+    for (int i =0; i < 120;i++) {
+        fprintf(stderr,"-");
+    }
+    fprintf(stderr, "\n");
+ 
+    fprintf(stderr, 
+            "BENCH START\n\t"                      
+            "pattern(%s)\n\t"                    
+            "subject(%s)\n\t"                    
+            "compile option(%d)\n\t"              
+            "execution option(%d)\n\t"
+            "expected execution result(%d)\n", 
+            pattern_str.c_str(), 
+            subject_str.c_str(),
+            comp_opt, 
+            exec_opt,
+            exec_expect);
+
+
+
+    // Regex Integrator
+
+    {
+        ri_regex_t ri_regex = NULL;
+        const char *log = NULL;
+        int ovector[OVECCOUNT] = {0};
+
+        ri_set_log_level(RI_LOG_ERROR);
+
+        ret = ri_create(&ri_regex, pattern_str.c_str(), comp_opt, NULL, NULL, &log);
+        if (ret != RI_SUCCESS)
+        {
+            fprintf(stderr, "RI compilation fail: %s\n", ri_get_error_msg(ret));
+            goto ri_finish;
+        }
+
+        BENCH(
+            ret = ri_exec(ri_regex, subject_str.c_str(), subject_str.length(), 0, exec_opt, NULL, ovector, OVECCOUNT, NULL);
+            if (ret != exec_expect) {
+                fprintf(stderr, "RI match result is unmatched.\n");
+                fprintf(stderr, "%s\n", ri_get_error_msg(ret));
+                goto ri_finish;
+            },
+            ops);
+
+        if (ret != exec_expect)
+        {
+            fprintf(stderr, "Unexpected execution result: expect(%d) get(%d)\n", exec_expect, ret);
+            goto ri_finish;
+        }
+        fprintf(stderr, "RI OPS(%s)\n", human_readable(ops));
+        // fprintf(stderr, "OPS(%.3f)\n", ops);
+
+    ri_finish:
+        ri_free(ri_regex);
+        ri_regex = NULL;
+        fprintf(stderr, "RI BENCH FINISH\n");
+    }
+
+    // RE2
+    {
+        std::string re2_pattern = pattern_str;
+        RE2::Options re2_options;
+        re2_options.set_encoding(RE2::Options::EncodingLatin1);
+
+        // We store the error message in the log instead of printing it out
+        re2_options.set_log_errors(false);
+
+        if (comp_opt & RI_COMP_CASELESS)
+        {
+            re2_options.set_case_sensitive(false);
+        }
+
+        if (comp_opt & RI_COMP_DOTALL)
+        {
+            re2_options.set_dot_nl(true);
+        }
+
+        // To enable MULTILINE options, modify the pattern to (?m:pattern)
+        if (comp_opt & RI_COMP_MULTILINE)
+        {
+            re2_pattern = "(?m:" + re2_pattern + ")";
+        }
+        re2::RE2 re2_regex(re2_pattern, re2_options);
+        re2::StringPiece submatches[1 + re2_regex.NumberOfCapturingGroups()];
+        if (!re2_regex.ok())
+        {
+            fprintf(stderr, "RE2 compilation fail: %s\n", re2_regex.error().c_str());
+            goto re2_finish;
+        }
+
+        BENCH({
+            if (
+                re2_regex.Match(
+                    subject_str.c_str(), 
+                    0, 
+                    subject_str.length(), 
+                    RE2::UNANCHORED, 
+                    submatches, 
+                    sizeof(submatches)/sizeof(submatches[0]))) {
+                if (exec_expect <= 0) {
+                    fprintf(stderr, "RE2 match result is unmatched.\n");
+                    goto re2_finish;
+                }
+            } else {
+                if (exec_expect > 0) {
+                    fprintf(stderr, "RE2 match result is unmatched.\n");
+                    goto re2_finish;
+                }
+            } },
+              ops);
+        fprintf(stderr, "RE2 OPS(%s)\n", human_readable(ops));
+    re2_finish:
+        fprintf(stderr, "RE2 BENCH FINISH\n");
+    }
+
+    //PCRE
+    {
+        int pcre_options = 0;
+        const char * error_ptr;
+        int error_offset;
+        int rt;
+        int ovector[OVECCOUNT] = {0};
+
+        if (comp_opt & RI_COMP_CASELESS)
+            pcre_options |= PCRE_CASELESS;
+
+        if (comp_opt & RI_COMP_MULTILINE)
+            pcre_options |= PCRE_MULTILINE;
+
+        if (comp_opt & RI_COMP_DOTALL)
+            pcre_options |= PCRE_DOTALL;
+
+        if (comp_opt & RI_COMP_DOLLAR_ENDONLY)
+            pcre_options |= PCRE_DOLLAR_ENDONLY;
+
+        void * pcre_regex = pcre_compile(pattern_str.c_str(), pcre_options, &error_ptr, &error_offset, NULL);
+        if ( pcre_regex ==NULL ) {
+            fprintf(stderr, "PCRE compilation fail : %s, offset = %d\n", error_ptr, error_offset);
+            goto pcre_finish;
+        }
+
+        pcre_options = 0;
+        if (exec_expect & RI_EXEC_NOTEMPTY)
+            pcre_options |= PCRE_NOTEMPTY;
+
+        BENCH({
+            rt = pcre_exec(
+                (pcre *)pcre_regex, 
+                NULL, 
+                subject_str.c_str(), 
+                subject_str.length(), 
+                0, 
+                pcre_options, 
+                ovector, 
+                OVECCOUNT);
+            if (rt != exec_expect) {
+                fprintf(stderr, "PCRE match result is unmatched.\n");
+                goto pcre_finish;
+            } }
+            ,ops
+        );
+        fprintf(stderr, "PCRE OPS(%s)\n", human_readable(ops));
+    pcre_finish:;
+        fprintf(stderr, "PCRE BENCH FINISH \n");
+        if (pcre_regex) {
+            pcre_free(pcre_regex);
+        }
+    }
+
+    //PCRE-JIT
+    {
+        int pcre_options = 0;
+        const char * error_ptr;
+        int error_offset;
+        int rt;
+        int ovector[OVECCOUNT] = {0};
+
+        if (comp_opt & RI_COMP_CASELESS)
+            pcre_options |= PCRE_CASELESS;
+
+        if (comp_opt & RI_COMP_MULTILINE)
+            pcre_options |= PCRE_MULTILINE;
+
+        if (comp_opt & RI_COMP_DOTALL)
+            pcre_options |= PCRE_DOTALL;
+
+        if (comp_opt & RI_COMP_DOLLAR_ENDONLY)
+            pcre_options |= PCRE_DOLLAR_ENDONLY;
+
+        void * pcre_regex = pcre_compile(pattern_str.c_str(), pcre_options, &error_ptr, &error_offset, NULL);
+        void * pcre_pe = NULL;
+        if (pcre_regex != NULL) {
+            pcre_pe = pcre_study((pcre *)pcre_regex, PCRE_STUDY_JIT_COMPILE, &error_ptr);
+        }
+        if (pcre_regex == NULL || pcre_pe == NULL){
+            fprintf(stderr, "PCRE-JIT compile fail : %s, offset = %d\n", error_ptr, error_offset);
+            goto pcre_jit_finish;
+        }
+
+        pcre_options = 0;
+        if (exec_expect & RI_EXEC_NOTEMPTY)
+            pcre_options |= PCRE_NOTEMPTY;
+
+        BENCH({
+            rt = pcre_exec(
+                (pcre *)pcre_regex, 
+                (pcre_extra *)pcre_pe, 
+                subject_str.c_str(), 
+                subject_str.length(), 
+                0, 
+                pcre_options, 
+                ovector, 
+                OVECCOUNT);
+            if (rt != exec_expect) {
+                fprintf(stderr, "PCRE-JIT match result is unmatched.\n");
+                goto pcre_jit_finish;
+            } }
+            ,ops
+        );
+        fprintf(stderr, "PCRE-JIT OPS(%s)\n", human_readable(ops));
+    pcre_jit_finish:;
+        fprintf(stderr, "PCRE-JIT BENCH FINISH \n");
+        if (pcre_regex) {
+            pcre_free(pcre_regex);
+        }
+        if (pcre_pe) {
+            pcre_free_study((pcre_extra *)pcre_pe);
+        }
+    }
+
+    return 0;
+
+}
+
+int main() {
+    ri_init();
+
+    // Normal match
+    if (test("abc", "abc", RI_COMP_DEFAULT, RI_EXEC_DEFAULT, 1) != 0) {
+        goto exit_error;
+    }
+
+    // Normal un-match
+    if (test("def", "abc", RI_COMP_DEFAULT, RI_EXEC_DEFAULT, -1) != 0) {
+        goto exit_error;
+    }
+
+    // Compile error
+    if (test("{abc(:", "abc", RI_COMP_DEFAULT, RI_EXEC_DEFAULT, -1) != 0) {
+        goto exit_error;
+    }
+
+    // Large match
+    if (test("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 
+        RI_COMP_DEFAULT, 
+        RI_EXEC_DEFAULT,
+        1) != 0) {
+        goto exit_error;
+    }
+
+    // A challenging case for PCRE
+    if (test("a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?aaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 
+        RI_COMP_DEFAULT, 
+        RI_EXEC_DEFAULT,
+        1) != 0) {
+        goto exit_error;
+    }
+
+    // Multi-line support
+    if (test("b$", "b\nb", RI_COMP_MULTILINE, RI_EXEC_DEFAULT, 1) != 0) {
+        goto exit_error;
+    }
+
+    // Caseless support
+    if (test("ABC", "abc", RI_COMP_CASELESS, RI_EXEC_DEFAULT, 1) != 0) {
+        goto exit_error;
+    }
+
+    // Capture groups
+    if (test("(a+b)(c+d)(e+f)", 
+        "abcdef", 
+        RI_COMP_DEFAULT, 
+        RI_EXEC_DEFAULT,
+        4) != 0) {
+        goto exit_error;
+    }
+
+    // No enough space to store capture groups
+    if (test("(a?)(b?)(c?)(d?)(e?)(f?)(g?)(h?)(i?)(j?)(k?)", 
+        "abcdefghijk", 
+        RI_COMP_DEFAULT, 
+        RI_EXEC_DEFAULT,
+        0) != 0) {
+        goto exit_error;
+    }    
+
+    // Not empty match
+    if (test("a?b?c?d?e?", 
+        "ffff", 
+        RI_COMP_DEFAULT, 
+        RI_EXEC_NOTEMPTY,
+        -1) != 0) {
+        goto exit_error;
+    }       
+
+    ri_release();
+    return 0;
+
+exit_error:
+    ri_release();
+    return -1;
+}

--- a/apache2/regex_integrator/ri_api.c
+++ b/apache2/regex_integrator/ri_api.c
@@ -253,7 +253,7 @@ int ri_exec(const ri_regex_t regex, const char *subject,
             return error_code;
     }
 
-    for (unsigned int i = 0; i < priority_exec.engine_count; i++) {
+    for (unsigned int i = 0; i < MIN(priority_exec.engine_count, RI_ENGINE_COUNT); i++) {
         switch (priority_exec.engines[i]) {
         case RI_PCRE:
             if (t_regex->pcre_re != NULL)

--- a/apache2/regex_integrator/ri_api.c
+++ b/apache2/regex_integrator/ri_api.c
@@ -1,0 +1,639 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+#include "ri_api_internal.h"
+#include "ri_pcre.h"
+#include "ri_re2.h"
+#include <memory.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+// Default priority
+static const struct ri_priority RI_PRIORITY_DEFAULT = {
+    {
+        RI_RE2, 
+        RI_PCRE_JIT, 
+        RI_PCRE
+    },
+    3
+};
+// Default param
+static const struct ri_pcre_params RI_PCRE_PARAMS_DEFAULT= {
+    0,
+    0,
+};
+
+// Global log level
+static ri_log_level_t g_ri_log_level = RI_LOG_ERROR;
+// Global log message
+static __thread char *g_ri_log_msg = NULL;
+static size_t g_ri_log_len = 0;
+
+#define MAX(a, b)               \
+    ({ __typeof__ (a) _a = (a); \
+       __typeof__ (b) _b = (b); \
+     _a > _b ? _a : _b; })
+
+#define MIN(a, b)               \
+    ({ __typeof__ (a) _a = (a); \
+       __typeof__ (b) _b = (b); \
+     _a < _b ? _a : _b; })
+
+/** Update priority_dst using priority_src.
+** @param priority_dst:     The priority to update.
+** @param priority_dst_len: The length of priority_dst.
+** @param priority_src:     The priority used to update.
+** @param priority_src_len: The length of priority_src.
+** @param pattern:          The regex expression for profiling in RI_AUTO mode.
+** @param comp_comptions:   Compilation options for profiling in RI_AUTO mode.
+** @param exec_comptions:   Execution options for profiling in RI_AUTO mode.
+** @param log:              The pointer to the log. It is optional.
+** return: 0 if it succeeds,
+**         or the error code.
+**/
+static int ri_update_priority(struct ri_priority *priority_dst,
+        const struct ri_priority *priority_src,
+        const char *pattern, int comp_options, int exec_options,
+        const char **log);
+
+/**
+** Check whether the priority is valid.
+** @param priority:     The pointer to the priority.
+** @param priority_len: The length of priority.
+** @param log:          The pointer to the log. It is optional.
+** return: 0 if the priority is valid,
+**         or the error code.
+**/
+static int ri_validate_priority(const struct ri_priority *priority,
+        const char **log);
+
+/**
+** Perform profiling to figure out the optimal priority of regex engines.
+** @param pattern:      The pointer to the pattern.
+** @param comp_options: Compilation options.
+** @param exec_options: Execution options.
+** @param priority:     The pointer to the priority output by profiling.
+** @param priority_len: The length of priority.
+** @param log:          The pointer to the log. It is optional.
+** return: 0 if the profiling succeeds,
+**         or the error code.
+**/
+static int ri_do_profiling(const char *pattern, int comp_options, 
+        int exec_options, struct ri_priority *priority, 
+        const char **log);
+
+/**
+** Compile the provided regular expression pattern.
+** @param regex:        The pointer to the compiled regex.
+** @param pattern:      The regular expression for compilation.
+** @param options:      The compilation options.
+**                      It contains various bit settings of ri_comp_option.
+**                      Its usage is as same as the bitmap.
+** @param priority:     The pointer to the priority of regex engines.
+**                      It is optional.
+** @param priority_len: The length of priority.
+** @param params:       The pointer to additional parameters for compilation.
+**                      It is optional.
+** @param log:          The pointer to the log. It is optional.
+**                      We would not output the log message if it is NULL.
+** return: 0 if compilation succeeds,
+**         or the error code.
+**/
+int ri_create(ri_regex_t *regex, const char *pattern, int options,
+        const struct ri_priority *priority, const struct ri_params *params,
+        const char **log)
+{
+    int error_code = 0;
+    struct ri_regex *t_regex = NULL;
+    int match_limit = 0;
+    int match_limit_recursion = 0;
+
+    if (regex == NULL) {
+        error_code = RI_ERROR_REGEX_NULL;
+        ri_fill_log(log, RI_LOG_ERROR, error_code);
+        return error_code;
+    }
+
+    if (pattern == NULL) {
+        error_code = RI_ERROR_PATTERN_NULL;
+        ri_fill_log(log, RI_LOG_ERROR, error_code);
+        return error_code;
+    }
+
+    *regex = calloc(1, sizeof(struct ri_regex));
+    if (*regex == NULL) {
+        error_code = RI_ERROR_CANNOT_ALLOCATE_MEMORY_TO_REGEX;
+        ri_fill_log(log, RI_LOG_ERROR, error_code);
+        return error_code;
+    }
+
+    t_regex = (struct ri_regex *) *regex;
+
+    // Set regex's pattern
+    t_regex->pattern = (char *) malloc(strlen(pattern) + 1);
+    if (t_regex->pattern == NULL) {
+        ri_free(*regex);
+        *regex = NULL;
+        error_code = RI_ERROR_CANNOT_ALLOCATE_MEMORY_TO_REGEX;
+        ri_fill_log(log, RI_LOG_ERROR, error_code);
+        return error_code;
+    }
+    strcpy(t_regex->pattern, pattern);
+
+    // Set regex's priority
+    error_code = ri_update_priority(&t_regex->priority,
+            priority, t_regex->pattern, options, 0, log);
+    if (error_code != RI_SUCCESS) {
+        ri_free(*regex);
+        *regex = NULL;
+        return error_code;
+    }
+
+    // PCRE compile
+    if (params == NULL) {
+        match_limit = RI_PCRE_PARAMS_DEFAULT.match_limit;
+        match_limit_recursion = RI_PCRE_PARAMS_DEFAULT.match_limit_recursion;
+    } else {
+        match_limit = params->pcre.match_limit;
+        match_limit_recursion = params->pcre.match_limit_recursion;
+    }
+    error_code = ri_pcre_comp(&(t_regex->pcre_re), &(t_regex->pcre_pe),
+        t_regex->pattern, options, match_limit, match_limit_recursion,
+        0, log);
+    if (error_code != RI_SUCCESS) {
+        ri_free(*regex);
+        *regex = NULL;
+        return error_code;
+    }
+
+    // PCRE-JIT compile
+    if (params == NULL) {
+        match_limit = RI_PCRE_PARAMS_DEFAULT.match_limit;
+        match_limit_recursion = RI_PCRE_PARAMS_DEFAULT.match_limit_recursion;
+    } else {
+        match_limit = params->pcre_jit.match_limit;
+        match_limit_recursion = params->pcre_jit.match_limit_recursion;
+    }
+    error_code = ri_pcre_comp(&(t_regex->pcre_re), &(t_regex->pcre_jit_pe),
+        t_regex->pattern, options, match_limit, match_limit_recursion,
+        1, log);
+    if (error_code != RI_SUCCESS) {
+        ri_free(*regex);
+        *regex = NULL;
+        return error_code;
+    }
+
+    // RE2 compile
+    t_regex->re2_re = ri_re2_comp(t_regex->pattern, options, log);
+
+    error_code = RI_SUCCESS;
+    ri_fill_log(log, RI_LOG_ERROR, error_code);
+    return error_code;
+}
+
+/**
+** Execute regular expression.
+** @param regex:        The compiled regex.
+** @param subject:      The pointer to the subject string.
+** @param subject_len:  The length of the subject string.
+** @param start_offset: The offset in the subject at which to start matching.
+** @param options:      The execution options.
+**                      It contains various bit settings of ri_exec_option.
+**                      Its usage is as same as the bitmap.
+** @param priority:     The priority of regex engines for execution.
+**                      It is optional.
+**                      If it is NULL, use the priority in the regex.
+**                      It does not override the priority in the regex.
+** @param priority_len: The length of priority.
+** @param ovector:      The pointer to a vector storing sub-matches.
+**                      Please refer to the explanation of arguments in pcre_exec().
+**                      It is optional.
+** @param ovec_size:    Number of elements in the vector (a multiple of 3).
+**                      Please refer to the explanation of arguments in pcre_exec().
+** @param log:          The pointer to the log.
+**                      It is optional.
+** return: The number of captured sub-matches,
+**         or 0 if the subject matches but the output vector is not big enough,
+**         or -1 if there is no match,
+**         or error code (< -1) if error occurs.
+**/
+int ri_exec(const ri_regex_t regex, const char *subject,
+        unsigned int subject_len, int start_offset, int options,
+        const struct ri_priority *priority,
+        int *ovector, int ovec_size, const char **log)
+{
+    int error_code = 0;
+    struct ri_regex *t_regex = NULL;
+    // The priority for execution
+    struct ri_priority priority_exec = RI_PRIORITY_DEFAULT;
+    // Returned value of RE2
+    int rv_re2 = 0;
+
+    if (regex == NULL) {
+        error_code = RI_ERROR_REGEX_NULL;
+        ri_fill_log(log, RI_LOG_ERROR, error_code);
+        return error_code;
+    }
+
+    if (subject == NULL) {
+        error_code = RI_ERROR_EXEC_SUBJECT_NULL;
+        ri_fill_log(log, RI_LOG_ERROR, error_code);
+        return error_code;
+    }
+
+    t_regex = (struct ri_regex *) regex;
+
+    // Get the priority for execution
+    if (priority == NULL) {
+        priority_exec = t_regex->priority;
+    } else {
+        error_code = ri_update_priority(&priority_exec,
+                priority, t_regex->pattern, 0, 0, log);
+        if (error_code != RI_SUCCESS)
+            return error_code;
+    }
+
+    for (unsigned int i = 0; i < priority_exec.engine_count; i++) {
+        switch (priority_exec.engines[i]) {
+        case RI_PCRE:
+            if (t_regex->pcre_re != NULL)
+                return ri_pcre_exec(t_regex->pcre_re, t_regex->pcre_pe, subject,
+                        subject_len, start_offset, options, ovector, ovec_size);
+            break;
+        case RI_PCRE_JIT:
+            if (t_regex->pcre_re != NULL)
+                return ri_pcre_exec(t_regex->pcre_re, t_regex->pcre_jit_pe,
+                        subject, subject_len, start_offset, options,
+                        ovector, ovec_size);
+            break;
+        case RI_RE2:
+            if (t_regex->re2_re != NULL) {
+                rv_re2 = ri_re2_exec(t_regex->re2_re, subject, subject_len,
+                        start_offset, ovector, ovec_size);
+                // When the string matches the regex and EXEC_NOTEMPTY is on,
+                // use PCRE to do matching again if:
+                // 1) ovector == NULL;
+                // 2) the match is an empty string, i.e., ovector[1] == ovector[0]
+                // Otherwise, return the result.
+                if (!(rv_re2 >= 0 && (options & RI_EXEC_NOTEMPTY) &&
+                      (!ovector || ovector[1] == ovector[0]))) {
+                    return rv_re2;
+                }
+            }
+            break;
+        case RI_AUTO:
+        default:
+            error_code = RI_ERROR_EXEC_INVALID_REGEX_ENGINE;
+            ri_fill_log(log, RI_LOG_ERROR, error_code);
+            return error_code;
+        }
+    }
+
+    error_code = RI_ERROR_EXEC_NO_USABLE_REGEX_ENGINE;
+    ri_fill_log(log, RI_LOG_ERROR, error_code);
+    return error_code;
+}
+
+/**
+** Free the compiled regex.
+** @param regex: The compiled regex.
+**/
+void ri_free(ri_regex_t regex)
+{
+    if (regex != NULL) {
+        struct ri_regex *t_regex = (struct ri_regex *) regex;
+
+        if (t_regex->pattern != NULL) {
+            free(t_regex->pattern);
+            t_regex->pattern = NULL;
+        }
+
+        if (t_regex->pcre_re != NULL) {
+            ri_pcre_free(t_regex->pcre_re, NULL);
+            t_regex->pcre_re = NULL;
+        }
+
+        if (t_regex->pcre_pe != NULL) {
+            ri_pcre_free(NULL, t_regex->pcre_pe);
+            t_regex->pcre_pe = NULL;
+        }
+
+        if (t_regex->pcre_jit_pe != NULL) {
+            ri_pcre_free(NULL, t_regex->pcre_jit_pe);
+            t_regex->pcre_jit_pe = NULL;
+        }
+
+        if (t_regex->re2_re != NULL) {
+            ri_re2_free(t_regex->re2_re);
+            t_regex->re2_re = NULL;
+        }
+
+        free(t_regex);
+        t_regex = NULL;
+    }
+}
+
+/**
+** Set regex's priority using the new priority.
+** @param regex:            The compiled regex.
+** @param priority_new:     The pointor to the new priority.
+** @param priority_new_len: The length of the new priority.
+** return: 0 if it succeeds,
+**         or the error code.
+**/
+int ri_set_priority(ri_regex_t regex, 
+        const struct ri_priority * priority_new, 
+        const char ** log)
+{
+    struct ri_regex *t_regex = NULL;
+
+    if (regex == NULL)
+        return RI_ERROR_REGEX_NULL;
+
+    t_regex = (struct ri_regex *) regex;
+
+    return ri_update_priority(&(t_regex->priority),
+            priority_new, t_regex->pattern, 0, 0, log);
+}
+
+/** Update priority_dst using priority_src.
+** @param priority_dst:     The priority to update.
+** @param priority_dst_len: The length of priority_dst.
+** @param priority_src:     The priority used to update.
+** @param priority_src_len: The length of priority_src.
+** @param pattern:          The regex expression for profiling in RI_AUTO mode.
+** @param comp_comptions:   Compilation options for profiling in RI_AUTO mode.
+** @param exec_comptions:   Execution options for profiling in RI_AUTO mode.
+** @param log:              The pointer to the log. It is optional.
+** return: 0 if it succeeds,
+**         or the error code.
+**/
+static int ri_update_priority(struct ri_priority * priority_dst,
+        const struct ri_priority *priority_src,
+        const char *pattern, int comp_options, int exec_options, 
+        const char **log)
+{
+    int error_code = 0;
+
+    if (priority_dst == NULL) {
+        error_code = RI_ERROR_PRIORITY_NULL;
+        ri_fill_log(log, RI_LOG_ERROR, error_code);
+        return error_code;
+    }
+
+    if (priority_src != NULL) {
+        // Validate the priority
+        error_code = ri_validate_priority(priority_src, log);
+        if (error_code != RI_SUCCESS)
+            return error_code;
+
+        if (priority_src->engines[0] == RI_AUTO) {
+            // Do profiling to determine the priority
+            error_code = ri_do_profiling(pattern, comp_options, exec_options,
+                    priority_dst, log);
+            if (error_code != RI_SUCCESS)
+                return error_code;
+        } else {
+            // Use the setting of users
+            *priority_dst = *priority_dst;
+        }
+    } else {
+        // Use default setting
+        *priority_dst = RI_PRIORITY_DEFAULT;
+    }
+
+    return RI_SUCCESS;
+}
+
+/**
+** Check whether the priority is valid.
+** @param priority:     The pointer to the priority.
+** @param priority_len: The length of priority.
+** @param log:          The pointer to the log. It is optional.
+** return: 0 if the priority is valid,
+**         or the error code.
+**/
+static int ri_validate_priority(const struct ri_priority *priority, 
+        const char **log)
+{
+    int error_code = 0;
+
+    if (priority == NULL || priority->engine_count < 1) {
+        error_code = RI_ERROR_REGEX_NULL;
+        ri_fill_log(log, RI_LOG_ERROR, error_code);
+        return error_code;
+    }
+
+    // If the first preference is RI_RE2, user must set the second priority,
+    // which should be RI_PCRE or RI_PCRE-JIT.
+    if (priority->engines[0] == RI_RE2) {
+        if (!(priority->engine_count > 1 &&
+              (priority->engines[1] == RI_PCRE || priority->engines[1] == RI_PCRE_JIT))) {
+            error_code = RI_ERROR_INVALID_PRIORITY_RE2;
+            ri_fill_log(log, RI_LOG_ERROR, error_code);
+            return error_code;
+        }
+    }
+
+    // To enable RI_AUTO, priority should be {RI_AUTO} and
+    // priority_len = 1.
+    if (priority->engines[0] == RI_AUTO && priority->engine_count != 1) {
+        error_code = RI_ERROR_INVALID_PRIORITY_AUTO;
+        ri_fill_log(log, RI_LOG_ERROR, error_code);
+        return error_code;
+    }
+
+    // RI_AUTO can only appear on the first priority.
+    for (int i = 1; i < priority->engine_count; i++) {
+        if (priority->engines[i] == RI_AUTO) {
+            error_code = RI_ERROR_INVALID_PRIORITY_AUTO;
+            ri_fill_log(log, RI_LOG_ERROR, error_code);
+            return error_code;
+        }
+    }
+
+    return RI_SUCCESS;
+}
+
+/**
+** Perform profiling to figure out the optimal priority of regex engines.
+** @param pattern:      The pointer to the pattern.
+** @param comp_options: Compilation options.
+** @param exec_options: Execution options.
+** @param priority:     The pointer to the priority output by profiling.
+** @param priority_len: The length of priority.
+** @param log:          The pointer to the log. It is optional.
+** return: 0 if the profiling succeeds,
+**         or the error code.
+**/
+static int ri_do_profiling(const char *pattern, int comp_options, int exec_options,
+        struct ri_priority *priority,  const char **log)
+{
+    // TODO: Determine the priority of engines based on profiling.
+    return RI_ERROR_NOT_SUPPORT;
+}
+
+/**
+** Get the detailed information of an error code.
+** @param error_code: The code returned by a function.
+** return: The string including the detailed information.
+**/
+const char *ri_get_error_msg(int error_code)
+{
+    switch (error_code) {
+    case RI_SUCCESS:
+        return "Success!";
+    case RI_ERROR:
+        return "Error!";
+    case RI_ERROR_REGEX_NULL:
+        return "ERROR: regex is NULL!";
+    case RI_ERROR_PATTERN_NULL:
+        return "ERROR: pattern is NULL!";
+    case RI_ERROR_CANNOT_ALLOCATE_MEMORY_TO_REGEX:
+        return "ERROR: Can NOT allocate memory to regex!";
+
+    case RI_ERROR_PRIORITY_NULL:
+        return "ERROR: The priority to update is NULL!";
+    case RI_ERROR_INVALID_PRIORITY_LENGTH:
+        return "ERROR: Invalid priority_len, which should be in \
+            [0,SUPPORT_ENGINE_NUMBER]!";
+    case RI_ERROR_INVALID_PRIORITY_RE2:
+        return "ERROR: Invalid priority: the second priority should be \
+            PCRE or PCRE-JIT if RE2 has the highest priority.";
+    case RI_ERROR_INVALID_PRIORITY_AUTO:
+        return "ERROR: priority should be {RI_AUTO} and priority_len is 1 \
+            if RI_AUTO mode is preferred to use.";
+
+    case RI_ERROR_PCRE_COMPILATION_FAILURE:
+        return "ERROR: PCRE compilation fails.";
+    case RI_ERROR_PCRE_NULL_POINTER:
+        return "ERROR: PCRE pointer **re in compilation is NULL.";
+    case RI_ERROR_PCRE_MALLOC:
+        return "ERROR: pcre_malloc() fails.";
+    case RI_ERROR_RE2_CANNOT_CONSTRUCT:
+        return "ERROR: Can NOT construct RE2!";
+
+    case RI_ERROR_EXEC_SUBJECT_NULL:
+        return "ERROR: The subject to match is NULL!";
+    case RI_ERROR_EXEC_INVALID_REGEX_ENGINE:
+        return "ERROR: Invalid regex engine for execution.";
+    case RI_ERROR_EXEC_NO_USABLE_REGEX_ENGINE:
+        return "ERROR: No usable regex engine for execution.";
+    
+    case RI_ERROR_LOG_SPACE_INSUFFICIENT:
+        return "ERROR: Log space is insufficient.";
+    case RI_ERROR_LOG_FORMAT:
+        return "ERROR: Log format error.";
+    
+    default:
+        return "Error code is not found.";
+    }
+}
+
+/**
+** Fill in g_ri_log_msg according on the error_code
+** @param error_code: The error code.
+** @param level:      The log level to fill the detailed error information.
+** @param log:        The pointer to the log.
+**/
+
+int ri_fill_log(const char ** log, ri_log_level_t log_level, int error_code) {
+    if (log != NULL && log_level <= g_ri_log_level) {
+        *log = ri_get_error_msg(error_code);
+    }
+    return RI_SUCCESS;
+}
+
+int ri_fill_log_ex(const char ** log, ri_log_level_t log_level, const char * format, ...) {
+    int size = 0;
+    char *p = NULL;
+    va_list ap;
+
+    if (log == NULL || log_level > g_ri_log_level) {
+        return RI_SUCCESS;
+    }
+
+    /* Determine required size */
+    va_start(ap, format);
+    size = vsnprintf(p, size, format, ap);
+    va_end(ap);
+    if (size < 0) {
+        ri_fill_log(log, log_level, RI_ERROR_LOG_FORMAT);
+        return RI_ERROR_LOG_FORMAT;
+    }
+
+    size++; /* For '\0' */
+    if (size > g_ri_log_len) {
+        if (g_ri_log_msg)
+            free(g_ri_log_msg);
+        g_ri_log_msg = NULL;
+        g_ri_log_len = 0;
+        p = malloc(size);
+    } else {
+        p = g_ri_log_msg;
+    }
+    if (p == NULL) {
+        ri_fill_log(log, log_level, RI_ERROR_LOG_SPACE_INSUFFICIENT); 
+        return RI_ERROR_LOG_SPACE_INSUFFICIENT;
+    }
+
+    va_start(ap, format);
+    size = vsnprintf(p, size, format, ap);
+    va_end(ap);
+
+    if (size < 0)
+    {
+        free(p);
+        ri_fill_log(log, log_level, RI_ERROR_LOG_FORMAT);
+        return RI_ERROR_LOG_FORMAT;
+    }
+
+    g_ri_log_msg = p;
+    g_ri_log_len = MAX(g_ri_log_len, size);
+
+    *log = g_ri_log_msg;
+    return RI_SUCCESS;
+}
+
+/**
+** Perform initialization.
+**/
+void ri_init()
+{
+    if (g_ri_log_msg != NULL)
+        free(g_ri_log_msg);
+    g_ri_log_msg = NULL;
+    g_ri_log_len = 0;
+}
+
+/**
+** Free the allocated memory.
+**/
+void ri_release()
+{
+    if (g_ri_log_msg != NULL)
+        free(g_ri_log_msg);
+    g_ri_log_msg = NULL;
+    g_ri_log_len = 0;
+}
+
+/**
+** Get the global log level.
+** return: The global log level.
+**/
+int ri_get_log_level()
+{
+    return g_ri_log_level;
+}
+
+/**
+** Set the global log level.
+** @param level: The level used to update log_level.
+** return: 0 if update succeeds,
+**         or the error code.
+**/
+int ri_set_log_level(ri_log_level_t level)
+{
+    g_ri_log_level = level;
+    return RI_SUCCESS;
+}

--- a/apache2/regex_integrator/ri_api.c
+++ b/apache2/regex_integrator/ri_api.c
@@ -396,7 +396,7 @@ static int ri_update_priority(struct ri_priority * priority_dst,
                 return error_code;
         } else {
             // Use the setting of users
-            *priority_dst = *priority_dst;
+            *priority_dst = *priority_src;
         }
     } else {
         // Use default setting

--- a/apache2/regex_integrator/ri_api.c
+++ b/apache2/regex_integrator/ri_api.c
@@ -173,10 +173,14 @@ int ri_create(ri_regex_t *regex, const char *pattern, int options,
     }
 
     // RE2 compile
-    t_regex->re2_re = ri_re2_comp(t_regex->pattern, options, log);
-
-    error_code = RI_SUCCESS;
-    ri_fill_log(log, RI_LOG_ERROR, error_code);
+    error_code = ri_re2_comp(&(t_regex->re2_re), t_regex->pattern, options, log);
+    if (error_code == RI_SUCCESS) {
+        ri_fill_log(log, RI_LOG_ERROR, error_code);
+    } else {
+        // RE2 isn't mandatory
+        error_code = RI_SUCCESS;
+    }
+    
     return error_code;
 }
 

--- a/apache2/regex_integrator/ri_api.h
+++ b/apache2/regex_integrator/ri_api.h
@@ -1,0 +1,159 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+#ifndef _RI_API_H_
+#define _RI_API_H_
+
+#include "ri_error.h"
+
+typedef void *ri_regex_t;
+
+typedef enum {
+    RI_PCRE,     // Use PCRE
+    RI_PCRE_JIT, // Use PCRE-JIT
+    RI_RE2,      // Use RE2
+    RI_AUTO,      // Select regex engine automatically
+    RI_ENGINE_COUNT, // The supported count of regex integrator 
+} ri_engine_t;
+
+/* Options for compilation. */
+enum ri_comp_option {
+    RI_COMP_DEFAULT = 0x000000,       // Default Option
+    RI_COMP_CASELESS = 0x000001,      // PCRE_CASELESS
+    RI_COMP_MULTILINE = 0x000002,     // PCRE_MULTILINE
+    RI_COMP_DOTALL = 0x000004,        // PCRE_DOTALL
+    RI_COMP_DOLLAR_ENDONLY = 0x000008, // PCRE_DOLLAR_ENDONLY
+};
+
+/* Options for execution. */
+enum ri_exec_option {
+    RI_EXEC_DEFAULT = 0x000000,  // Default Option
+    RI_EXEC_NOTEMPTY = 0x001000, // PCRE_NOTEMPTY
+};
+
+struct ri_priority {
+    ri_engine_t engines[RI_ENGINE_COUNT];
+    unsigned int engine_count; // The count of engine
+};
+
+struct ri_pcre_params {
+    int match_limit;            
+    int match_limit_recursion;
+};
+
+struct ri_params {
+    struct ri_pcre_params pcre;
+    struct ri_pcre_params pcre_jit;
+};
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+** Compile the provided regular expression pattern.
+** @param regex:        The pointer to the compiled regex.
+** @param pattern:      The regular expression for compilation.
+** @param options:      The compilation options.
+**                      It contains various bit settings of ri_comp_option.
+**                      Its usage is as same as the bitmap.
+** @param priority:     The pointer to the priority of regex engines.
+**                      It is optional.
+** @param priority_len: The length of priority.
+** @param params:       The pointer to additional parameters for compilation.
+**                      It is optional.
+** @param log:          The pointer to the log. It is optional.
+**                      We would not output the log message if it is NULL.
+** return: 0 if compilation succeeds,
+**         or the error code.
+**/
+int ri_create(ri_regex_t *regex, const char *pattern, int options,
+        const struct ri_priority *priority, const struct ri_params *params, 
+        const char **log);
+
+/**
+** Execute regular expression.
+** @param regex:        The compiled regex.
+** @param subject:      The pointer to the subject string.
+** @param subject_len:  The length of the subject string.
+** @param start_offset: The offset in the subject at which to start matching.
+** @param options:      The execution options.
+**                      It contains various bit settings of ri_exec_option.
+**                      Its usage is as same as the bitmap.
+** @param priority:     The priority of regex engines for execution.
+**                      It is optional.
+**                      If it is NULL, use the priority in the regex.
+**                      It does not override the priority in the regex.
+** @param priority_len: The length of priority.
+** @param ovector:      The pointer to a vector storing sub-matches.
+**                      Please refer to the explanation of arguments in pcre_exec().
+**                      It is optional.
+** @param ovec_size:    Number of elements in the vector (a multiple of 3).
+**                      Please refer to the explanation of arguments in pcre_exec().
+** @param log:          The pointer to the log.
+**                      It is optional.
+** return: The number of captured sub-matches,
+**         or 0 if the subject matches but the output vector is not big enough,
+**         or -1 if there is no match,
+**         or error code (< -1) if error occurs.
+**/
+int ri_exec(const ri_regex_t regex, const char *subject,
+        unsigned int subject_len, int start_offset, int options,
+        const struct ri_priority *priority, int *ovector, int ovec_size, 
+        const char **log);
+
+/**
+** Free the compiled regex.
+** @param regex: The compiled regex.
+**/
+void ri_free(ri_regex_t regex);
+
+/**
+** Set regex's priority using the new priority.
+** @param regex:            The compiled regex.
+** @param priority_new:     The pointor to the new priority.
+** @param priority_new_len: The length of the new priority.
+** return: 0 if it succeeds,
+**         or the error code.
+**/
+int ri_set_priority(ri_regex_t regex, 
+        const struct ri_priority * priority, 
+        const char ** log);
+
+/**
+** Get the detailed information of an error code.
+** @param error_code: The code returned by a function.
+** return: The string including the detailed information.
+**/
+const char *ri_get_error_msg(int error_code);
+
+/**
+** Perform initialization.
+**/
+void ri_init();
+
+/**
+** Free the allocated memory.
+**/
+void ri_release();
+
+/**
+** Get the global log level.
+** return: The global log level.
+**/
+int ri_get_log_level();
+
+/**
+** Set the global log level.
+** @param level: The level used to update log_level.
+** return: 0 if update succeeds,
+**         or the error code.
+**/
+int ri_set_log_level(ri_log_level_t level);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* _RI_API_H_ */

--- a/apache2/regex_integrator/ri_api.h
+++ b/apache2/regex_integrator/ri_api.h
@@ -7,40 +7,46 @@
 
 typedef void *ri_regex_t;
 
-typedef enum {
-    RI_PCRE,     // Use PCRE
-    RI_PCRE_JIT, // Use PCRE-JIT
-    RI_RE2,      // Use RE2
-    RI_AUTO,      // Select regex engine automatically
-    RI_ENGINE_COUNT, // The supported count of regex integrator 
+typedef enum
+{
+    RI_PCRE,         // Use PCRE
+    RI_PCRE_JIT,     // Use PCRE-JIT
+    RI_RE2,          // Use RE2
+    RI_AUTO,         // Select regex engine automatically
+    RI_ENGINE_COUNT, // The supported count of regex integrator
 } ri_engine_t;
 
 /* Options for compilation. */
-enum ri_comp_option {
-    RI_COMP_DEFAULT = 0x000000,       // Default Option
-    RI_COMP_CASELESS = 0x000001,      // PCRE_CASELESS
-    RI_COMP_MULTILINE = 0x000002,     // PCRE_MULTILINE
-    RI_COMP_DOTALL = 0x000004,        // PCRE_DOTALL
+enum ri_comp_option
+{
+    RI_COMP_DEFAULT = 0x000000,        // Default Option
+    RI_COMP_CASELESS = 0x000001,       // PCRE_CASELESS
+    RI_COMP_MULTILINE = 0x000002,      // PCRE_MULTILINE
+    RI_COMP_DOTALL = 0x000004,         // PCRE_DOTALL
     RI_COMP_DOLLAR_ENDONLY = 0x000008, // PCRE_DOLLAR_ENDONLY
 };
 
 /* Options for execution. */
-enum ri_exec_option {
+enum ri_exec_option
+{
     RI_EXEC_DEFAULT = 0x000000,  // Default Option
     RI_EXEC_NOTEMPTY = 0x001000, // PCRE_NOTEMPTY
 };
 
-struct ri_priority {
+struct ri_priority
+{
     ri_engine_t engines[RI_ENGINE_COUNT];
     unsigned int engine_count; // The count of engine
 };
 
-struct ri_pcre_params {
-    int match_limit;            
+struct ri_pcre_params
+{
+    int match_limit;
     int match_limit_recursion;
 };
 
-struct ri_params {
+struct ri_params
+{
     struct ri_pcre_params pcre;
     struct ri_pcre_params pcre_jit;
 };
@@ -58,18 +64,17 @@ extern "C"
 **                      It contains various bit settings of ri_comp_option.
 **                      Its usage is as same as the bitmap.
 ** @param priority:     The pointer to the priority of regex engines.
-**                      It is optional.
-** @param priority_len: The length of priority.
+**                      It is optional, NULL is using default priority.
 ** @param params:       The pointer to additional parameters for compilation.
-**                      It is optional.
+**                      It is optional, NULL is using default params.
 ** @param log:          The pointer to the log. It is optional.
 **                      We would not output the log message if it is NULL.
 ** return: 0 if compilation succeeds,
 **         or the error code.
 **/
 int ri_create(ri_regex_t *regex, const char *pattern, int options,
-        const struct ri_priority *priority, const struct ri_params *params, 
-        const char **log);
+              const struct ri_priority *priority, const struct ri_params *params,
+              const char **log);
 
 /**
 ** Execute regular expression.
@@ -84,23 +89,22 @@ int ri_create(ri_regex_t *regex, const char *pattern, int options,
 **                      It is optional.
 **                      If it is NULL, use the priority in the regex.
 **                      It does not override the priority in the regex.
-** @param priority_len: The length of priority.
 ** @param ovector:      The pointer to a vector storing sub-matches.
 **                      Please refer to the explanation of arguments in pcre_exec().
 **                      It is optional.
 ** @param ovec_size:    Number of elements in the vector (a multiple of 3).
 **                      Please refer to the explanation of arguments in pcre_exec().
-** @param log:          The pointer to the log.
-**                      It is optional.
+** @param log:          The pointer to the log. It is optional.
+**                      We would not output the log message if it is NULL.
 ** return: The number of captured sub-matches,
 **         or 0 if the subject matches but the output vector is not big enough,
 **         or -1 if there is no match,
 **         or error code (< -1) if error occurs.
 **/
 int ri_exec(const ri_regex_t regex, const char *subject,
-        unsigned int subject_len, int start_offset, int options,
-        const struct ri_priority *priority, int *ovector, int ovec_size, 
-        const char **log);
+            unsigned int subject_len, int start_offset, int options,
+            const struct ri_priority *priority, int *ovector, int ovec_size,
+            const char **log);
 
 /**
 ** Free the compiled regex.
@@ -111,14 +115,16 @@ void ri_free(ri_regex_t regex);
 /**
 ** Set regex's priority using the new priority.
 ** @param regex:            The compiled regex.
-** @param priority_new:     The pointor to the new priority.
-** @param priority_new_len: The length of the new priority.
+** @param priority_new:     The pointer to the new priority.
+**                          If it is NULL, set default priority for the regex.
+** @param log:              The pointer to the log. It is optional.
+**                          We would not output the log message if it is NULL.
 ** return: 0 if it succeeds,
 **         or the error code.
 **/
-int ri_set_priority(ri_regex_t regex, 
-        const struct ri_priority * priority, 
-        const char ** log);
+int ri_set_priority(ri_regex_t regex,
+                    const struct ri_priority *priority_new,
+                    const char **log);
 
 /**
 ** Get the detailed information of an error code.
@@ -129,11 +135,13 @@ const char *ri_get_error_msg(int error_code);
 
 /**
 ** Perform initialization.
+** It need be called at the first using of this module
 **/
 void ri_init();
 
 /**
-** Free the allocated memory.
+** Perform release.
+** It need be called at the last using of this module
 **/
 void ri_release();
 
@@ -154,6 +162,5 @@ int ri_set_log_level(ri_log_level_t level);
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif /* _RI_API_H_ */

--- a/apache2/regex_integrator/ri_api_internal.h
+++ b/apache2/regex_integrator/ri_api_internal.h
@@ -1,0 +1,37 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+#ifndef _RI_API_INTERNAL_H_
+#define _RI_API_INTERNAL_H_
+
+#include "ri_api.h"
+
+struct ri_regex {
+    char *pattern;             // The regex pattern
+    void *pcre_re;             // pcre*, compiled PCRE regex
+    void *pcre_pe;             // pcre_extra* for PCRE
+    void *pcre_jit_pe;         // pcre_extra* for PCRE-JIT
+    void *re2_re;              // RE2*, compiled RE2 regex
+    struct ri_priority priority; // The priority of regex engines for the pattern
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+** Fill in g_ri_log_msg according on the error_code
+** @param error_code: The error code.
+** @param level:      The log level to fill the detailed error information.
+** @param log:        The pointer to the log.
+**/
+
+extern int ri_fill_log(const char ** log,  ri_log_level_t log_level,
+        int error_code);
+extern int ri_fill_log_ex(const char ** log, ri_log_level_t log_level,
+        const char * format, ...);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _RI_API_INTERNAL_H_ */

--- a/apache2/regex_integrator/ri_api_internal.h
+++ b/apache2/regex_integrator/ri_api_internal.h
@@ -9,6 +9,7 @@ struct ri_regex {
     char *pattern;             // The regex pattern
     void *pcre_re;             // pcre*, compiled PCRE regex
     void *pcre_pe;             // pcre_extra* for PCRE
+    void *pcre_jit_re;         // pcre*, compiled PCRE regex
     void *pcre_jit_pe;         // pcre_extra* for PCRE-JIT
     void *re2_re;              // RE2*, compiled RE2 regex
     struct ri_priority priority; // The priority of regex engines for the pattern

--- a/apache2/regex_integrator/ri_api_internal.h
+++ b/apache2/regex_integrator/ri_api_internal.h
@@ -19,14 +19,23 @@ extern "C" {
 #endif
 
 /**
-** Fill in g_ri_log_msg according on the error_code
-** @param error_code: The error code.
-** @param level:      The log level to fill the detailed error information.
+** Fill in log according on the error_code
 ** @param log:        The pointer to the log.
+** @param level:      The log level to fill the detailed error information.
+** @param error_code: The error code.
+** return: RI_SUCCESS if it succeeds, or the error code.
 **/
-
 extern int ri_fill_log(const char ** log,  ri_log_level_t log_level,
         int error_code);
+
+/**
+** Fill in log according on the format and rested paramenters
+** @param log:        The pointer to the log.
+** @param level:      The log level to fill the detailed error information.
+** @param error_code: The error code.
+** @param format:     The format string to record log, like printf.
+** return: RI_SUCCESS if it succeeds, or the error code.
+**/
 extern int ri_fill_log_ex(const char ** log, ri_log_level_t log_level,
         const char * format, ...);
 

--- a/apache2/regex_integrator/ri_error.h
+++ b/apache2/regex_integrator/ri_error.h
@@ -1,0 +1,55 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+#ifndef _RI_ERROR_H_
+#define _RI_ERROR_H_
+
+/**
+** First Digit: equals 1 if it is an error code.
+** Second Digit: the module where the error happens:
+**               1 means in compilation, 2 means execution,
+**               0 means internal error occurs besides compilatin and execution.
+** Third and fourth Digit: the detailed error number.
+**/
+#define ERROR_TYPE int
+#define ERROR_NO(NO) ((ERROR_TYPE)(-(NO)))
+
+#define RI_SUCCESS ((ERROR_TYPE)(0x0000))
+
+#define RI_ERROR    ERROR_NO(0x1000)
+
+#define RI_ERROR_REGEX_NULL    ERROR_NO(0x1001)
+#define RI_ERROR_PATTERN_NULL    ERROR_NO(0x1002)
+#define RI_ERROR_CANNOT_ALLOCATE_MEMORY_TO_REGEX ERROR_NO(0x1003)
+#define RI_ERROR_NOT_SUPPORT   ERROR_NO(0x1004)
+
+#define RI_ERROR_PRIORITY_NULL ERROR_NO(0x1010)
+#define RI_ERROR_INVALID_PRIORITY_LENGTH ERROR_NO(0x1011)
+#define RI_ERROR_INVALID_PRIORITY_RE2 ERROR_NO(0x1012)
+#define RI_ERROR_INVALID_PRIORITY_AUTO ERROR_NO(0x1013)
+
+#define RI_ERROR_PCRE_COMPILATION_FAILURE ERROR_NO(0x1101)
+#define RI_ERROR_PCRE_NULL_POINTER ERROR_NO(0x1102)
+#define RI_ERROR_PCRE_MALLOC ERROR_NO(0x1103)
+#define RI_ERROR_RE2_CANNOT_CONSTRUCT ERROR_NO(0x1104)
+
+#define RI_ERROR_EXEC_SUBJECT_NULL    ERROR_NO(0x1200)
+#define RI_ERROR_EXEC_INVALID_REGEX_ENGINE    ERROR_NO(0x1201)
+#define RI_ERROR_EXEC_NO_USABLE_REGEX_ENGINE    ERROR_NO(0x1202)
+
+#define RI_ERROR_LOG_SPACE_INSUFFICIENT ERROR_NO(0x1301)
+#define RI_ERROR_LOG_FORMAT ERROR_NO(0x1302)
+
+/**
+** The log level.
+** Use ri_get_log_level() to get the global log level.
+** Use ri_set_log_level() to set the global log level.
+**/
+typedef enum {
+    RI_LOG_NONE,
+    RI_LOG_ERROR,
+    RI_LOG_WARN,
+    RI_LOG_INFO,
+    RI_LOG_DEBUG
+} ri_log_level_t;
+
+#endif /* _RI_ERROR_H_ */

--- a/apache2/regex_integrator/ri_pcre.c
+++ b/apache2/regex_integrator/ri_pcre.c
@@ -2,7 +2,7 @@
    Licensed under the MIT License. */
 #include "ri_api_internal.h"
 #include "ri_pcre.h"
-#include "pcre.h"
+#include <pcre.h>
 #include <string.h>
 #include <stdio.h>
 

--- a/apache2/regex_integrator/ri_pcre.c
+++ b/apache2/regex_integrator/ri_pcre.c
@@ -26,10 +26,7 @@ static int ri_pcre_translate_exec_options(int options);
 **                               We perform PCRE study when it is not NULL.
 ** @param pattern:               The regular expression for compilation.
 ** @param options:               The compilation options.
-** @param match_limit:           The limit on internal resource use.
-**                               It is optional. It takes effect when it is > 0.
-** @param match_limit_recursion: The limit on internal recursion depth.
-**                               It is optional. It takes effect when it is > 0.
+** @param params:                The params needed by PCRE.
 ** @param use_pcre_jit:          The indicator to enable PCRE-JIT.
 **                               0 means disabling PCRE-JIT;
 **                               otherwise, enable PCRE-JIT.
@@ -40,7 +37,7 @@ static int ri_pcre_translate_exec_options(int options);
 **/
 int ri_pcre_comp(void **re, void **pe,
         const char *pattern, int options,
-        int match_limit, int match_limit_recursion,
+        const struct ri_pcre_params * params,
         int use_pcre_jit, const char **log)
 {
     int error_code = 0;
@@ -97,27 +94,29 @@ int ri_pcre_comp(void **re, void **pe,
 
         pcre_extra *t_pe = (pcre_extra *) *pe;
 
+        if (params) {
 #ifdef PCRE_EXTRA_MATCH_LIMIT
-        // If match limit is available, then use it
-        if (match_limit > 0) {
-            t_pe->match_limit = match_limit;
-            t_pe->flags |= PCRE_EXTRA_MATCH_LIMIT;
-        }
+            // If match limit is available, then use it
+            if (params->match_limit > 0) {
+                t_pe->match_limit = params->match_limit;
+                t_pe->flags |= PCRE_EXTRA_MATCH_LIMIT;
+            }
 #else
 #pragma message ("This PCRE version does not support match limits! Upgrade to \
         at least PCRE v6.5.")
 #endif /* PCRE_EXTRA_MATCH_LIMIT */
 
 #ifdef PCRE_EXTRA_MATCH_LIMIT_RECURSION
-        // If match limit recursion is available, then use it
-        if (match_limit_recursion > 0) {
-            t_pe->match_limit_recursion = match_limit_recursion;
-            t_pe->flags |= PCRE_EXTRA_MATCH_LIMIT_RECURSION;
-        }
+            // If match limit recursion is available, then use it
+            if (params->match_limit_recursion > 0) {
+                t_pe->match_limit_recursion = params->match_limit_recursion;
+                t_pe->flags |= PCRE_EXTRA_MATCH_LIMIT_RECURSION;
+            }
 #else
 #pragma message ("This PCRE version does not support match recursion limits! \
         Upgrade to at least PCRE v6.5.")
 #endif /* PCRE_EXTRA_MATCH_LIMIT_RECURSION */
+        }
     }
 
     return RI_SUCCESS;

--- a/apache2/regex_integrator/ri_pcre.c
+++ b/apache2/regex_integrator/ri_pcre.c
@@ -1,0 +1,200 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+#include "ri_api_internal.h"
+#include "ri_pcre.h"
+#include "pcre.h"
+#include <string.h>
+#include <stdio.h>
+
+/**
+** Translate RI's options to PCRE's compilation options.
+** @param options: The RI options for compilation.
+**/
+static int ri_pcre_translate_comp_options(int options);
+
+/**
+** Translate RI's options to PCRE's execution options.
+** @param options: The RI options for execution.
+**/
+static int ri_pcre_translate_exec_options(int options);
+
+/**
+** Compile the provided regular expression pattern.
+** @param re:                    The pointer to the compiled regex.
+** @param pe:                    The pointer to the studied information.
+**                               It is optional.
+**                               We perform PCRE study when it is not NULL.
+** @param pattern:               The regular expression for compilation.
+** @param options:               The compilation options.
+** @param match_limit:           The limit on internal resource use.
+**                               It is optional. It takes effect when it is > 0.
+** @param match_limit_recursion: The limit on internal recursion depth.
+**                               It is optional. It takes effect when it is > 0.
+** @param use_pcre_jit:          The indicator to enable PCRE-JIT.
+**                               0 means disabling PCRE-JIT;
+**                               otherwise, enable PCRE-JIT.
+** @param log:                   The pointer to the log. It is optional.
+**                               If it is NULL, we would not fill in detailed log message.
+** return: 0 if compilation succeeds,
+**         or the error code if compilation fails.
+**/
+int ri_pcre_comp(void **re, void **pe,
+        const char *pattern, int options,
+        int match_limit, int match_limit_recursion,
+        int use_pcre_jit, const char **log)
+{
+    int error_code = 0;
+    const char *error_ptr = NULL;
+    int error_offset = 0;
+
+    if (pattern == NULL) {
+        error_code = RI_ERROR_PATTERN_NULL;
+        ri_fill_log(log, RI_LOG_ERROR, error_code);
+        return error_code;
+    }
+
+    if (re == NULL) {
+        error_code = RI_ERROR_PCRE_NULL_POINTER;
+        ri_fill_log(log, RI_LOG_ERROR, error_code);
+        return error_code;
+    }
+
+    // Translate options to PCRE's options
+    int pcre_comp_options = ri_pcre_translate_comp_options(options);
+
+    // PCRE Compile
+    // If *re is not NULL, we would not do compilation
+    if (*re == NULL) {
+        *re = pcre_compile(pattern, pcre_comp_options,
+                &error_ptr, &error_offset, NULL);
+        if (*re == NULL) {
+            ri_fill_log_ex(log, RI_LOG_ERROR, "%s, error offset = %d", error_ptr, error_offset);
+            return RI_ERROR_PCRE_COMPILATION_FAILURE;
+        }
+    }
+
+    // If pe is NULL, then no need to call pcre_study()
+    if (pe == NULL) {
+        return RI_SUCCESS;
+    }
+
+    // If *pe is not NULL, we would not do study
+    if (*pe == NULL) {
+        *pe = use_pcre_jit 
+            ? pcre_study((pcre *) *re, PCRE_STUDY_JIT_COMPILE, &error_ptr)
+            : pcre_study((pcre *) *re,0 , &error_ptr);
+
+        // Set up the pcre_extra record if pcre_study did not do it
+        if (*pe == NULL) {
+            *pe = (pcre_extra *) pcre_malloc(sizeof(pcre_extra));
+            if (*pe == NULL) {
+                error_code = RI_ERROR_PCRE_MALLOC;
+                ri_fill_log(log, RI_LOG_ERROR, error_code);
+                return error_code;
+            }
+            memset(*pe, 0, sizeof(pcre_extra));
+        }
+
+        pcre_extra *t_pe = (pcre_extra *) *pe;
+
+#ifdef PCRE_EXTRA_MATCH_LIMIT
+        // If match limit is available, then use it
+        if (match_limit > 0) {
+            t_pe->match_limit = match_limit;
+            t_pe->flags |= PCRE_EXTRA_MATCH_LIMIT;
+        }
+#else
+#pragma message ("This PCRE version does not support match limits! Upgrade to \
+        at least PCRE v6.5.")
+#endif /* PCRE_EXTRA_MATCH_LIMIT */
+
+#ifdef PCRE_EXTRA_MATCH_LIMIT_RECURSION
+        // If match limit recursion is available, then use it
+        if (match_limit_recursion > 0) {
+            t_pe->match_limit_recursion = match_limit_recursion;
+            t_pe->flags |= PCRE_EXTRA_MATCH_LIMIT_RECURSION;
+        }
+#else
+#pragma message ("This PCRE version does not support match recursion limits! \
+        Upgrade to at least PCRE v6.5.")
+#endif /* PCRE_EXTRA_MATCH_LIMIT_RECURSION */
+    }
+
+    return RI_SUCCESS;
+}
+
+/**
+** Execute regular expression.
+** @param re:           The pointer to the compiled regex.
+** @param pe:           The pointer to an associated pcre_extra structure.
+** @param subject:      The pointer to the subject string.
+** @param subject_len:  The length of the subject string.
+** @param start_offset: The offset in the subject at which to start matching.
+** @param options:      The execution options.
+** @param ovector:      The pointer to a vector storing sub-matches.
+** @param ovec_size:    The number of elements in the vector (a multiple of 3).
+** return: The number of captured sub-matches,
+**         or 0 if the subject matches but the output vector is not big enough,
+**         or -1 if there is no match,
+**         or error code (< -1) if error occurs.
+**/
+int ri_pcre_exec(const void *re, const void *pe, const char *subject,
+        unsigned int subject_len, int start_offset,
+        int options, int *ovector, int ovec_size)
+{
+    int pcre_exec_options = ri_pcre_translate_exec_options(options);
+
+    return pcre_exec((pcre *) re, (pcre_extra *) pe, subject, subject_len,
+            start_offset, pcre_exec_options, ovector, ovec_size);
+}
+
+/**
+** Free compiled pcre regex and study data.
+** @param re: The pointer to a compiled regex.
+** @param pe: The pointer to an associated pcre_extra structure.
+**/
+void ri_pcre_free(void *re, void *pe)
+{
+    if (re != NULL)
+        pcre_free((pcre *) re);
+
+    // This function was added to the API for release 8.20.
+    if (pe != NULL)
+        pcre_free_study((pcre_extra *) pe);
+}
+
+/**
+** Translate RI's options to PCRE's compilation options.
+** @param options: The RI options for compilation.
+**/
+static int ri_pcre_translate_comp_options(int options)
+{
+    int pcre_options = 0;
+    if (options & RI_COMP_CASELESS)
+        pcre_options |= PCRE_CASELESS;
+
+    if (options & RI_COMP_MULTILINE)
+        pcre_options |= PCRE_MULTILINE;
+
+    if (options & RI_COMP_DOTALL)
+        pcre_options |= PCRE_DOTALL;
+
+    if (options & RI_COMP_DOLLAR_ENDONLY)
+        pcre_options |= PCRE_DOLLAR_ENDONLY;
+
+    return pcre_options;
+}
+
+/**
+** Translate RI's options to PCRE's execution options.
+** @param options: The RI options for execution.
+**/
+static int ri_pcre_translate_exec_options(int options)
+{
+    int pcre_options = 0;
+
+    if (options & RI_EXEC_NOTEMPTY)
+        pcre_options |= PCRE_NOTEMPTY;
+
+    return pcre_options;
+}

--- a/apache2/regex_integrator/ri_pcre.c
+++ b/apache2/regex_integrator/ri_pcre.c
@@ -82,11 +82,11 @@ int ri_pcre_comp(void **re, void **pe,
     if (*pe == NULL) {
         *pe = use_pcre_jit 
             ? pcre_study((pcre *) *re, PCRE_STUDY_JIT_COMPILE, &error_ptr)
-            : pcre_study((pcre *) *re,0 , &error_ptr);
+            : pcre_study((pcre *) *re, 0, &error_ptr);
 
         // Set up the pcre_extra record if pcre_study did not do it
         if (*pe == NULL) {
-            *pe = (pcre_extra *) pcre_malloc(sizeof(pcre_extra));
+            *pe = (pcre_extra *) malloc(sizeof(pcre_extra));
             if (*pe == NULL) {
                 error_code = RI_ERROR_PCRE_MALLOC;
                 ri_fill_log(log, RI_LOG_ERROR, error_code);

--- a/apache2/regex_integrator/ri_pcre.h
+++ b/apache2/regex_integrator/ri_pcre.h
@@ -13,8 +13,7 @@
 **                               We perform PCRE study when it is not NULL.
 ** @param pattern:               The regular expression for compilation.
 ** @param options:               The compilation options.
-** @param match_limit:           The limit on internal resource use.
-**                               It is optional. It takes effect when it is > 0.
+** @param params:                The params needed by PCRE.
 ** @param match_limit_recursion: The limit on internal recursion depth.
 **                               It is optional. It takes effect when it is > 0.
 ** @param use_pcre_jit:          The indicator to enable PCRE-JIT.
@@ -27,7 +26,7 @@
 **/
 int ri_pcre_comp(void **re, void **pe,
         const char *pattern, int options,
-        int match_limit, int match_limit_recursion,
+        const struct ri_pcre_params * params,
         int use_pcre_jit, const char **log);
 
 /**

--- a/apache2/regex_integrator/ri_pcre.h
+++ b/apache2/regex_integrator/ri_pcre.h
@@ -1,0 +1,59 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+#ifndef _RI_PCRE_H_
+#define _RI_PCRE_H_
+
+#include "ri_error.h"
+
+/**
+** Compile the provided regular expression pattern.
+** @param re:                    The pointer to the compiled regex.
+** @param pe:                    The pointer to the studied information.
+**                               It is optional.
+**                               We perform PCRE study when it is not NULL.
+** @param pattern:               The regular expression for compilation.
+** @param options:               The compilation options.
+** @param match_limit:           The limit on internal resource use.
+**                               It is optional. It takes effect when it is > 0.
+** @param match_limit_recursion: The limit on internal recursion depth.
+**                               It is optional. It takes effect when it is > 0.
+** @param use_pcre_jit:          The indicator to enable PCRE-JIT.
+**                               0 means disabling PCRE-JIT;
+**                               otherwise, enable PCRE-JIT.
+** @param log:                   The pointer to the log. It is optional.
+**                               If it is NULL, we would not fill in detailed log message.
+** return: 0 if compilation succeeds,
+**         or the error code if compilation fails.
+**/
+int ri_pcre_comp(void **re, void **pe,
+        const char *pattern, int options,
+        int match_limit, int match_limit_recursion,
+        int use_pcre_jit, const char **log);
+
+/**
+** Execute regular expression.
+** @param re:           The pointer to the compiled regex.
+** @param pe:           The pointer to an associated pcre_extra structure.
+** @param subject:      The pointer to the subject string.
+** @param subject_len:  The length of the subject string.
+** @param start_offset: The offset in the subject at which to start matching.
+** @param options:      The execution options.
+** @param ovector:      The pointer to a vector storing sub-matches.
+** @param ovec_size:    The number of elements in the vector (a multiple of 3).
+** return: The number of captured sub-matches,
+**         or 0 if the subject matches but the output vector is not big enough,
+**         or -1 if there is no match,
+**         or error code (< -1) if error occurs.
+**/
+int ri_pcre_exec(const void *re, const void *pe, const char *subject,
+        unsigned int subject_len, int start_offset,
+        int options, int *ovector, int ovec_size);
+
+/**
+** Free compiled pcre regex and study data.
+** @param re: The pointer to a compiled regex.
+** @param pe: The pointer to an associated pcre_extra structure.
+**/
+void ri_pcre_free(void *re, void *pe);
+
+#endif /*_RI_PCRE_H */

--- a/apache2/regex_integrator/ri_re2.cpp
+++ b/apache2/regex_integrator/ri_re2.cpp
@@ -1,0 +1,165 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "ri_api_internal.h"
+#include "ri_re2.h"
+#include <re2/re2.h>
+#include <utility>
+#include <string.h>
+
+/**
+** Translate RI options to RE2 options.
+** @param pattern:     The regular expression for compilation.
+** @param options:     The RI options for compilation.
+** @param re2_pattern: The regular expression for RE2's compilation.
+** @param re2_options: The options for RE2's compilation.
+**/
+static void ri_re2_translate_comp_options(const char *pattern, int options,
+        std::string &re2_pattern, RE2::Options &re2_options);
+
+/**
+** Compile the provided regular expression pattern.
+** @param pattern: The regular expression for compilation.
+** @param options: The options for compilation.
+** @param log:     The pointer to the log.
+** return: A pointer to RE2 object if compilation succeeds,
+**         or NULL if compilation fails.
+**/
+void *ri_re2_comp(const char *pattern, int options, const char **log)
+{
+    int error_code = 0;
+    RE2 *re2_re = NULL;
+    std::string re2_pattern;
+    RE2::Options re2_options;
+
+    if (pattern == NULL) {
+        error_code = RI_ERROR_PATTERN_NULL;
+        ri_fill_log(log, RI_LOG_ERROR, error_code);
+        return NULL;
+    }
+
+    ri_re2_translate_comp_options(pattern, options,
+            re2_pattern, re2_options);
+
+    // Construct RE2 object
+    re2_re = new RE2(re2_pattern, re2_options);
+
+    if (re2_re == NULL) {
+        error_code = RI_ERROR_RE2_CANNOT_CONSTRUCT;
+        ri_fill_log(log, RI_LOG_ERROR, error_code);
+        return NULL;
+    } else {
+        if (re2_re->ok()) {
+            return re2_re;
+        } else {
+            ri_fill_log_ex(log, RI_LOG_ERROR, re2_re->error().c_str());
+            ri_re2_free(re2_re);
+            return NULL;
+        }
+    }
+}
+
+/**
+** Execute regular expression.
+** @param re:           The pointer to the compiled regex of RE2.
+** @param subject:      The pointer to the subject string.
+** @param subject_len:  The length of the subject string.
+** @param start_offset: The offset in the subject at which to start matching.
+** @param ovector:      The pointer to a vector storing the sub-matches.
+** @param ovec_size:    The number of elements in the vector (a multiple of 3).
+** return: The number of captured sub-matches,
+**         or 0 if the subject matches but the output vector is not big enough,
+**         or -1 if there is no match.
+**/
+int ri_re2_exec(void *re, const char *subject, unsigned int subject_len, int
+        start_offset, int *ovector, int ovec_size)
+{
+    RE2 *re2_re = static_cast<RE2 *>(re);
+    size_t start_pos = start_offset;
+    const size_t end_pos = subject_len;
+    // Total number of sub-matches in the regex pattern
+    int num_submatch = 1 + re2_re->NumberOfCapturingGroups();
+    re2::StringPiece submatches[num_submatch];
+    // Index of the last NULL sub-match
+    int last_null_submatch = num_submatch - 1;
+
+    // If the string does not match the pattern
+    if (!re2_re->Match(subject, start_pos, end_pos, RE2::UNANCHORED,
+                submatches, num_submatch))
+        return -1;
+
+    // Find the last NULL sub-match
+    while (!submatches[last_null_submatch].data()) {
+        last_null_submatch--;
+    }
+
+    int count = std::min(last_null_submatch + 1, ovec_size / 3);
+    // Extract sub-match information as much as possible
+    for (int i = 0; i < count; i++) {
+        if (!submatches[i].data()) {
+            ovector[2 * i] = -1;
+            ovector[2 * i + 1] = -1;
+        } else {
+            ovector[2 * i] = submatches[i].data() - subject;
+            ovector[2 * i + 1] = ovector[2 * i] + submatches[i].length();
+        }
+    }
+
+    // The output vector has enough space to store the information of
+    // all valid sub-matches and NULL sub-matches among valid sub-matches
+    if (last_null_submatch + 1 <= ovec_size / 3)
+        return last_null_submatch + 1;
+
+    // Truncate NULL sub-matches at the tail of 'ovector'
+    // if (!submatches[ovec_size / 3 - 1].data()) {
+    //     for (int i = ovec_size / 3 - 2; i >= 0; i--) {
+    //         if (submatches[i].data()) {
+    //             return i + 1;
+    //         }
+    //     }
+    // }
+    return 0;
+}
+
+/**
+** Free the compiled regex.
+** @param re: The pointer to the compiled regex of RE2.
+**/
+void ri_re2_free(void *re)
+{
+    delete (RE2 *) re;
+}
+
+/**
+** Translate RI options to RE2 options.
+** @param pattern:     The regular expression for compilation.
+** @param options:     The RI options for compilation.
+** @param re2_pattern: The regular expression for RE2's compilation.
+** @param re2_options: The options for RE2's compilation.
+**/
+static void ri_re2_translate_comp_options(const char *pattern, int options,
+        std::string &re2_pattern, RE2::Options &re2_options)
+{
+    re2_pattern.assign(pattern, strlen(pattern));
+
+    // Use Latin-1 encoding which processes the string as one-byte characters
+    re2_options.set_encoding(RE2::Options::EncodingLatin1);
+
+    // We store the error message in the log instead of printing it out
+    re2_options.set_log_errors(false);
+
+    if (options & RI_COMP_CASELESS) {
+        re2_options.set_case_sensitive(false);
+    }
+
+    if (options & RI_COMP_DOTALL) {
+        re2_options.set_dot_nl(true);
+    }
+
+    // To enable MULTILINE options, modify the pattern to (?m:pattern)
+    if (options & RI_COMP_MULTILINE) {
+        std::string prefix = "(?m:";
+        std::string t_pattern(pattern);
+        std::string postfix = ")";
+        re2_pattern = prefix + t_pattern + postfix;
+    }
+}

--- a/apache2/regex_integrator/ri_re2.cpp
+++ b/apache2/regex_integrator/ri_re2.cpp
@@ -18,14 +18,16 @@ static void ri_re2_translate_comp_options(const char *pattern, int options,
 
 /**
 ** Compile the provided regular expression pattern.
+** @param re:      A pointer to RE2 object if compilation succeeds,
+**                 or NULL if compilation fails.
 ** @param pattern: The regular expression for compilation.
 ** @param options: The options for compilation.
 ** @param log:     The pointer to the log. It is optional.
 **                 If it is NULL, we would not fill in detailed log message.
-** return: A pointer to RE2 object if compilation succeeds,
-**         or NULL if compilation fails.
+** return: 0 if compilation succeeds,
+**         or the error code if compilation fails.
 **/
-void *ri_re2_comp(const char *pattern, int options, const char **log)
+int ri_re2_comp(void **re, const char *pattern, int options, const char **log)
 {
     int error_code = 0;
     RE2 *re2_re = NULL;
@@ -35,7 +37,7 @@ void *ri_re2_comp(const char *pattern, int options, const char **log)
     if (pattern == NULL) {
         error_code = RI_ERROR_PATTERN_NULL;
         ri_fill_log(log, RI_LOG_ERROR, error_code);
-        return NULL;
+        return error_code;
     }
 
     ri_re2_translate_comp_options(pattern, options,
@@ -47,14 +49,16 @@ void *ri_re2_comp(const char *pattern, int options, const char **log)
     if (re2_re == NULL) {
         error_code = RI_ERROR_RE2_CANNOT_CONSTRUCT;
         ri_fill_log(log, RI_LOG_ERROR, error_code);
-        return NULL;
+        return error_code;
     } else {
         if (re2_re->ok()) {
-            return re2_re;
+            *re = re2_re;
+            return error_code;
         } else {
             ri_fill_log_ex(log, RI_LOG_ERROR, re2_re->error().c_str());
             ri_re2_free(re2_re);
-            return NULL;
+            error_code = RI_ERROR_RE2_CANNOT_CONSTRUCT;
+            return error_code;
         }
     }
 }

--- a/apache2/regex_integrator/ri_re2.cpp
+++ b/apache2/regex_integrator/ri_re2.cpp
@@ -20,7 +20,8 @@ static void ri_re2_translate_comp_options(const char *pattern, int options,
 ** Compile the provided regular expression pattern.
 ** @param pattern: The regular expression for compilation.
 ** @param options: The options for compilation.
-** @param log:     The pointer to the log.
+** @param log:     The pointer to the log. It is optional.
+**                 If it is NULL, we would not fill in detailed log message.
 ** return: A pointer to RE2 object if compilation succeeds,
 **         or NULL if compilation fails.
 **/

--- a/apache2/regex_integrator/ri_re2.h
+++ b/apache2/regex_integrator/ri_re2.h
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#ifndef _RI_RE2_H_
+#define _RI_RE2_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "ri_error.h"
+
+/**
+** Compile the provided regular expression pattern.
+** @param pattern: The regular expression for compilation.
+** @param options: The options for compilation.
+** @param log:     The pointer to the log.
+** return: A pointer to RE2 object if compilation succeeds,
+**         or NULL if compilation fails.
+**/
+void *ri_re2_comp(const char *pattern, int options, const char ** log);
+
+/**
+** Execute regular expression.
+** @param re:           The pointer to the compiled regex of RE2.
+** @param subject:      The pointer to the subject string.
+** @param subject_len:  The length of the subject string.
+** @param start_offset: The offset in the subject at which to start matching.
+** @param ovector:      The pointer to a vector storing the sub-matches.
+** @param ovec_size:    The number of elements in the vector (a multiple of 3).
+** return: The number of captured sub-matches,
+**         or 0 if the subject matches but the output vector is not big enough,
+**         or -1 if there is no match.
+**/
+int ri_re2_exec(void *re, const char *subject, unsigned int subject_len, int
+        start_offset, int *ovector, int ovec_size);
+
+/**
+** Free the compiled regex.
+** @param re: The pointer to the compiled regex of RE2.
+**/
+void ri_re2_free(void *re);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _RI_RE2_H_ */

--- a/apache2/regex_integrator/ri_re2.h
+++ b/apache2/regex_integrator/ri_re2.h
@@ -14,7 +14,8 @@ extern "C"
 ** Compile the provided regular expression pattern.
 ** @param pattern: The regular expression for compilation.
 ** @param options: The options for compilation.
-** @param log:     The pointer to the log.
+** @param log:     The pointer to the log. It is optional.
+**                 If it is NULL, we would not fill in detailed log message.
 ** return: A pointer to RE2 object if compilation succeeds,
 **         or NULL if compilation fails.
 **/

--- a/apache2/regex_integrator/ri_re2.h
+++ b/apache2/regex_integrator/ri_re2.h
@@ -12,14 +12,16 @@ extern "C"
 
 /**
 ** Compile the provided regular expression pattern.
+** @param re:      A pointer to RE2 object if compilation succeeds,
+**                 or NULL if compilation fails.
 ** @param pattern: The regular expression for compilation.
 ** @param options: The options for compilation.
 ** @param log:     The pointer to the log. It is optional.
 **                 If it is NULL, we would not fill in detailed log message.
-** return: A pointer to RE2 object if compilation succeeds,
-**         or NULL if compilation fails.
+** return: 0 if compilation succeeds,
+**         or the error code if compilation fails.
 **/
-void *ri_re2_comp(const char *pattern, int options, const char ** log);
+int ri_re2_comp(void **re, const char *pattern, int options, const char ** log);
 
 /**
 ** Execute regular expression.

--- a/apache2/regex_integrator/tester.cpp
+++ b/apache2/regex_integrator/tester.cpp
@@ -1,5 +1,6 @@
-/* Copyright (c) Microsoft Corporation. All rights reserved.
- *    Licensed under the MIT License. */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/apache2/regex_integrator/tester.cpp
+++ b/apache2/regex_integrator/tester.cpp
@@ -8,53 +8,74 @@
 
 #define OVECCOUNT 30
 
-
 int test(
-    const char * pattern_str, 
-    const char * subject_str, 
-    int comp_opt,
-    int expect) {
+    const char *pattern_str, 
+    const char *subject_str, 
+    int comp_opt,   // Options for compilation
+    int exec_opt,   // Options for execution
+    int comp_expect,// Expected result for compilation
+    int exec_expect // Expected result for execution
+    ) {
     
-    // pattern_str = "a$";
-    // subject_str = "b\nb";
     ri_regex_t regex = NULL;
     const char *log = NULL;
     int ovector[OVECCOUNT] = {0};
     int ret = 0;
 
-    // comp_opt = RI_COMP_MULTILINE | RI_COMP_CASELESS;
-    fprintf(stderr, "TEST START \n\tpattern(%s)\n\tsubject(%s)\n\tcompile option(%d)\n\texpect(%d)\n", 
-        pattern_str, 
-        subject_str, 
-        comp_opt, 
-        expect);
+    fprintf(stderr, 
+            "TEST START\n\t"                      
+            "pattern(%s)\n\t"                    
+            "subject(%s)\n\t"                    
+            "compile option(%d)\n\t"              
+            "exection option(%d)\n\t"             
+            "expected compilation result(%d)\n\t" 
+            "expected execution result(%d)\n", 
+            pattern_str, 
+            subject_str, 
+            comp_opt, 
+            exec_opt,
+            comp_expect,
+            exec_expect);
     ri_set_log_level(RI_LOG_DEBUG);
 
     ret = ri_create(&regex, pattern_str, comp_opt, NULL,  NULL, &log);
-    if (ret != RI_SUCCESS) {
-        fprintf(stderr,"%s\n", log);
+    if (ret != comp_expect) {
+        fprintf(stderr, "Unexpected compilation result: expect(%d) get(%d)\n", comp_expect, ret);
         goto test_error;
+
+    // Get compilation error as expected.
+    } else if (ret != RI_SUCCESS) {
+        goto test_pass;
     }
 
-    ret = ri_exec(regex, subject_str, strlen(subject_str), 0, 0, NULL, ovector, OVECCOUNT, NULL);
+    //if (ret != RI_SUCCESS) {
+    //    fprintf(stderr, "%s\n", log);
+    //    goto test_error;
+    //}
+
+    ret = ri_exec(regex, subject_str, strlen(subject_str), 0, exec_opt, NULL, ovector, OVECCOUNT, NULL);
     if (ret < 0) {
         fprintf(stderr, "%s\n", ri_get_error_msg(ret));
     }
-    if (ret != expect) {
-        fprintf(stderr, "FAIL get(%d)\n", ret);
+
+    if (ret != exec_expect) {
+        fprintf(stderr, "Unexpected execution result: expect(%d) get(%d)\n", exec_expect, ret);
         goto test_error;
     }
+
+test_pass:
     if(regex != NULL) {
         ri_free(regex);
         regex = NULL;
     }
-    fprintf(stderr, "TEST FINISH\n");
+    fprintf(stderr, "TEST PASS\n");
     return 0;
+
 test_error:
     if (regex) {
         ri_free(regex);
     }
-    fprintf(stderr, "TEST FINISH\n");
+    fprintf(stderr, "TEST FAIL\n");
     return -1;
 }
 
@@ -62,33 +83,83 @@ int main() {
     ri_init();
 
     // Normal match
-    if (test("abc", "abc", 0, 1) != 0) {
+    if (test("abc", "abc", RI_COMP_DEFAULT, RI_EXEC_DEFAULT, RI_SUCCESS, 1) != 0) {
         goto exit_error;
     }
     
     // Normal un-match
-    if (test("def", "abc", 0, -1) != 0) {
+    if (test("def", "abc", RI_COMP_DEFAULT, RI_EXEC_DEFAULT, RI_SUCCESS, -1) != 0) {
         goto exit_error;
     }
 
     // Compile error
-    if (test("{abc(:", "abc", 0, -1) != -1) {
+    if (test("{abc(:", "abc", RI_COMP_DEFAULT, RI_EXEC_DEFAULT, -4353, -1) != 0) {
         goto exit_error;
     }
 
     // Large match
-    if (test("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 0, 1) != 0) {
+    if (test("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 
+        RI_COMP_DEFAULT, 
+        RI_EXEC_DEFAULT,
+        RI_SUCCESS,
+        1) != 0) {
         goto exit_error;
     }
 
-    // Newline support
-    if (test("b$", "b\nb", RI_COMP_MULTILINE | RI_COMP_CASELESS, 1) != 0) {
+    // A challenging case for PCRE
+    if (test("a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?aaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 
+        RI_COMP_DEFAULT, 
+        RI_EXEC_DEFAULT,
+        RI_SUCCESS,
+        1) != 0) {
         goto exit_error;
     }
 
+    // Multi-line support
+    if (test("b$", "b\nb", RI_COMP_MULTILINE, RI_EXEC_DEFAULT, RI_SUCCESS, 1) != 0) {
+        goto exit_error;
+    }
+
+    // Caseless support
+    if (test("ABC", "abc", RI_COMP_CASELESS, RI_EXEC_DEFAULT, RI_SUCCESS, 1) != 0) {
+        goto exit_error;
+    }
+
+    // Capture groups
+    if (test("(a+b)(c+d)(e+f)", 
+        "abcdef", 
+        RI_COMP_DEFAULT, 
+        RI_EXEC_DEFAULT,
+        RI_SUCCESS,
+        4) != 0) {
+        goto exit_error;
+    }
+
+    // No enough space to store capture groups
+    if (test("(a?)(b?)(c?)(d?)(e?)(f?)(g?)(h?)(i?)(j?)(k?)", 
+        "abcdefghijk", 
+        RI_COMP_DEFAULT, 
+        RI_EXEC_DEFAULT,
+        RI_SUCCESS,
+        0) != 0) {
+        goto exit_error;
+    }    
+
+    // Not empty match
+    if (test("a?b?c?d?e?", 
+        "ffff", 
+        RI_COMP_DEFAULT, 
+        RI_EXEC_NOTEMPTY,
+        RI_SUCCESS,
+        -1) != 0) {
+        goto exit_error;
+    }       
 
     ri_release();
     return 0;
+
 exit_error:
     ri_release();
     return -1;

--- a/apache2/regex_integrator/tester.cpp
+++ b/apache2/regex_integrator/tester.cpp
@@ -1,0 +1,94 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+ *    Licensed under the MIT License. */
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "ri_api.h"
+
+#define OVECCOUNT 30
+
+
+int test(
+    const char * pattern_str, 
+    const char * subject_str, 
+    int comp_opt,
+    int expect) {
+    
+    // pattern_str = "a$";
+    // subject_str = "b\nb";
+    ri_regex_t regex = NULL;
+    const char *log = NULL;
+    int ovector[OVECCOUNT] = {0};
+    int ret = 0;
+
+    // comp_opt = RI_COMP_MULTILINE | RI_COMP_CASELESS;
+    fprintf(stderr, "TEST START \n\tpattern(%s)\n\tsubject(%s)\n\tcompile option(%d)\n\texpect(%d)\n", 
+        pattern_str, 
+        subject_str, 
+        comp_opt, 
+        expect);
+    ri_set_log_level(RI_LOG_DEBUG);
+
+    ret = ri_create(&regex, pattern_str, comp_opt, NULL,  NULL, &log);
+    if (ret != RI_SUCCESS) {
+        fprintf(stderr,"%s\n", log);
+        goto test_error;
+    }
+
+    ret = ri_exec(regex, subject_str, strlen(subject_str), 0, 0, NULL, ovector, OVECCOUNT, NULL);
+    if (ret < 0) {
+        fprintf(stderr, "%s\n", ri_get_error_msg(ret));
+    }
+    if (ret != expect) {
+        fprintf(stderr, "FAIL get(%d)\n", ret);
+        goto test_error;
+    }
+    if(regex != NULL) {
+        ri_free(regex);
+        regex = NULL;
+    }
+    fprintf(stderr, "TEST FINISH\n");
+    return 0;
+test_error:
+    if (regex) {
+        ri_free(regex);
+    }
+    fprintf(stderr, "TEST FINISH\n");
+    return -1;
+}
+
+int main() {
+    ri_init();
+
+    // Normal match
+    if (test("abc", "abc", 0, 1) != 0) {
+        goto exit_error;
+    }
+    
+    // Normal un-match
+    if (test("def", "abc", 0, -1) != 0) {
+        goto exit_error;
+    }
+
+    // Compile error
+    if (test("{abc(:", "abc", 0, -1) != -1) {
+        goto exit_error;
+    }
+
+    // Large match
+    if (test("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 0, 1) != 0) {
+        goto exit_error;
+    }
+
+    // Newline support
+    if (test("b$", "b\nb", RI_COMP_MULTILINE | RI_COMP_CASELESS, 1) != 0) {
+        goto exit_error;
+    }
+
+
+    ri_release();
+    return 0;
+exit_error:
+    ri_release();
+    return -1;
+}

--- a/configure.ac
+++ b/configure.ac
@@ -615,6 +615,22 @@ AC_ARG_ENABLE(waf_json_logging,
 # Always Enable json waf logging support
 waf_lock="-I"`pwd`"/apache2/waf_lock"
 
+# Enable regex integrator support
+AC_ARG_ENABLE(regex_integrator,
+              AS_HELP_STRING([--enable-regex_integrator],
+                             [Enable library regex integrator (no is disable, other is enable).]),
+[
+  if test "$enableval" != "no"; then
+    regex_integrator="-I"`pwd`"/apache2/ag_mdb -DREGEX_INTEGRATOR"
+    MODSEC_EXTRA_CFLAGS="$MODSEC_EXTRA_CFLAGS $regex_integrator"
+  else
+    regex_integrator=""
+  fi
+],
+[
+  regex_integrator=""
+])
+
 # Ignore configure errors
 AC_ARG_ENABLE(errors,
               AS_HELP_STRING([--disable-errors],
@@ -881,7 +897,7 @@ else
   fi
 fi
 
-MODSEC_EXTRA_CFLAGS="$pcre_study $pcre_match_limit $pcre_match_limit_recursion $pcre_jit $request_early $htaccess_config $lua_cache $debug_conf $debug_cache $debug_acmp $debug_mem $perf_meas $modsec_api $cpu_type $unique_id $log_filename $log_server $log_collection_delete_problem $log_dechunk $log_stopwatch $log_handler $log_server_context $collection_global_lock $large_stream_input $collection_memory_database $waf_json_logging $waf_lock"
+MODSEC_EXTRA_CFLAGS="$pcre_study $pcre_match_limit $pcre_match_limit_recursion $pcre_jit $request_early $htaccess_config $lua_cache $debug_conf $debug_cache $debug_acmp $debug_mem $perf_meas $modsec_api $cpu_type $unique_id $log_filename $log_server $log_collection_delete_problem $log_dechunk $log_stopwatch $log_handler $log_server_context $collection_global_lock $large_stream_input $collection_memory_database $waf_json_logging $waf_lock $regex_integrator"
 
 APXS_WRAPPER=build/apxs-wrapper
 APXS_EXTRA_CFLAGS=""

--- a/nginx/modsecurity/config.in
+++ b/nginx/modsecurity/config.in
@@ -24,7 +24,8 @@ CORE_LIBS="$CORE_LIBS \
     @YAJL_LIBS@ \
     @SSDEEP_LDFLAGS@ \
     -lstdc++ \
-    -lprotobuf"
+    -lprotobuf\
+    -lregex_integrator"
 
 ngx_addon_name=ngx_http_modsecurity
 

--- a/standalone/Makefile.am
+++ b/standalone/Makefile.am
@@ -45,7 +45,9 @@ standalone_la_SOURCES = ../apache2/acmp.c \
     filters.c \
     hooks.c \
     regex.c \
-    server.c
+    server.c \
+    ../apache2/msc_ri.c \
+    ../apache2/msc_regex.c
 
     # FIXME: Standalone does not mean that it will be a nginx build.
 standalone_la_CFLAGS = -DVERSION_NGINX \

--- a/standalone/modules.mk
+++ b/standalone/modules.mk
@@ -1,11 +1,13 @@
 MOD_SECURITY2 = mod_security2 apache2_config apache2_io apache2_util \
     re re_operators re_actions re_tfns re_variables \
     msc_logging msc_xml msc_multipart modsecurity msc_parsers msc_util msc_pcre \
-    persist_dbm msc_reqbody pdf_protect msc_geo msc_gsb msc_unicode acmp msc_lua
+    persist_dbm msc_reqbody pdf_protect msc_geo msc_gsb msc_unicode acmp msc_lua \
+    msc_ri msc_regex
 
 H = re.h modsecurity.h msc_logging.h msc_multipart.h msc_parsers.h \
     msc_pcre.h msc_util.h msc_xml.h persist_dbm.h apache2.h pdf_protect.h \
-    msc_geo.h msc_gsb.h msc_unicode.h acmp.h utf8tables.h msc_lua.h
+    msc_geo.h msc_gsb.h msc_unicode.h acmp.h utf8tables.h msc_lua.h \
+    msc_ri.h msc_regex.h
 
 ${MOD_SECURITY2:=.slo}: ${H}
 ${MOD_SECURITY2:=.lo}: ${H}


### PR DESCRIPTION
**Integrate RE2 into Regex Integrator**: Regex Integrator can select the regex engine(re2/pcre/pcre-jit) at run-time.
**Make ModSecurity support Regex Integrator**: Select regex engine by rule configuration(SecRegexIntegrator).

1.  Compile & install library regex_integrator
```
cd apache2/regex_integrator/
make
make install
````

2.  Compile modsecurity & nginx
    - ModSecurity:
        ./configure --enable-regex_integrator
    - nginx:
	as same as before

3.  Enable/Disable RI using SecRegexIntegrator [the priority list of engines]

    - Enable the engine in the priority list, and pick the first available engine 
        - E.g. SecRegexIntegrator “RE2 PCRE”

    - If included engine cannot fully support all rules, there will be a compiling error
        - E.g. SecRegexIntegrator “RE2”

    - Support Option: RE2, PCRE, and PCRE-JIT

    - SecRegexIntegrator should be ahead of all rules

