### PR TITLE
ModSecurity for IIS: process HTTP request in background when in detection mode.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "iis/asio"]
+	path = iis/asio
+	url = https://github.com/chriskohlhoff/asio.git
+	branch = tags/asio-1-12-2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ services:
     - iis                 # start IIS
 
 install:
+    - git submodule update --init --recursive
     - "python --version"
     - ps: cd iis; .\getModSecurityPkgs.ps1 https://modsecurity.blob.core.windows.net/windows-artifacts
 

--- a/iis/Makefile.win
+++ b/iis/Makefile.win
@@ -37,7 +37,8 @@ INCLUDES = -I. -I.. \
            -I..\apache2 \
            -I..\standalone \
            -I..\apache2\ag_mdb \
-           -I..\apache2\waf_lock
+           -I..\apache2\waf_lock \
+           -Iasio\asio\include
 
 # Enables support for SecRemoteRules and external resources.
 DEFS=$(DEFS) -DWITH_CURL -DWITH_REMOTE_RULES

--- a/iis/mymodule.cpp
+++ b/iis/mymodule.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <cctype>
 #include <memory>
+#include <future>
 
 //  IIS7 Server API header file
 #include <Windows.h>
@@ -34,6 +35,9 @@
 #include "moduleconfig.h"
 
 #include "winsock2.h"
+
+#include "asio/packaged_task.hpp"
+#include "asio/post.hpp"
 
 // These helpers make sure that the underlying structures
 // are correctly released on any exit path due to RAII.
@@ -62,6 +66,8 @@ struct RequestStoredContext
     char* responseBuffer = nullptr;
     ULONGLONG responseLength = 0;
     ULONGLONG responsePosition = 0;
+    bool responseProcessingEnabled = false;
+    std::future<int> detectionProcessing;
 
     void CleanupStoredContext() override
     {
@@ -496,6 +502,97 @@ static HRESULT SaveRequestBodyToRequestRec(RequestStoredContext* rsc)
     return iisRequest->InsertEntityBody(requestBuffer, contentLength);
 }
 
+
+static apr_status_t ReadBodyCallback(request_rec *r, char *buf, unsigned int length, unsigned int *readcnt, int *is_eos)
+{
+    RequestStoredContext *rsc = RetrieveIISContext(r);
+
+    *readcnt = 0;
+
+    if (rsc == NULL)
+    {
+        *is_eos = 1;
+        return APR_SUCCESS;
+    }
+
+    IHttpContext *pHttpContext = rsc->httpContext;
+    IHttpRequest *pRequest = pHttpContext->GetRequest();
+
+    if (pRequest->GetRemainingEntityBytes() == 0)
+    {
+        *is_eos = 1;
+        return APR_SUCCESS;
+    }
+
+    HRESULT hr = pRequest->ReadEntityBody(buf, length, false, (DWORD *)readcnt, NULL);
+
+    if (FAILED(hr))
+    {
+        // End of data is okay.
+        if (ERROR_HANDLE_EOF != (hr & 0x0000FFFF))
+        {
+            // Set the error status.
+            rsc->provider->SetErrorStatus(hr);
+        }
+
+        *is_eos = 1;
+    }
+
+    return APR_SUCCESS;
+}
+
+static apr_status_t WriteBodyCallback(request_rec *r, char *buf, unsigned int length)
+{
+    RequestStoredContext *rsc = RetrieveIISContext(r);
+
+    if (!rsc || !rsc->requestRec)
+        return APR_SUCCESS;
+
+    IHttpContext *pHttpContext = rsc->httpContext;
+    IHttpRequest *pHttpRequest = pHttpContext->GetRequest();
+
+    auto lengthStr = std::to_string(length);
+
+    // Remove/Modify Transfer-Encoding header if "chunked" Encoding is set in the request. 
+    // This is to avoid sending both Content-Length and Chunked Transfer-Encoding in the request header.
+
+    USHORT ctcch = 0;
+    char *ct = (char *)pHttpRequest->GetHeader(HttpHeaderTransferEncoding, &ctcch);
+    if (ct)
+    {
+        char *ctz = ZeroTerminate(ct, ctcch, r->pool);
+        if (ctcch != 0)
+        {
+            if (0 == stricmp(ctz, "chunked"))
+            {
+                pHttpRequest->DeleteHeader(HttpHeaderTransferEncoding);
+            }
+        }
+    }
+
+    HRESULT hr = pHttpRequest->SetHeader(
+        HttpHeaderContentLength,
+        lengthStr.c_str(),
+        (USHORT)lengthStr.size(),
+        TRUE);
+
+    if (FAILED(hr))
+    {
+        // possible, but there's nothing we can do
+    }
+
+    // since we clean the APR pool at the end of OnSendRequest, we must get IIS-managed memory chunk
+    //
+    void *reqbuf = pHttpContext->AllocateRequestMemory(length);
+
+    memcpy(reqbuf, buf, length);
+
+    pHttpRequest->InsertEntityBody(reqbuf, length);
+
+    return APR_SUCCESS;
+}
+
+
 REQUEST_NOTIFICATION_STATUS
 CMyHttpModule::OnSendResponse(
     IN IHttpContext * pHttpContext,
@@ -505,12 +602,18 @@ CMyHttpModule::OnSendResponse(
     RequestStoredContext* rsc = dynamic_cast<RequestStoredContext*>(pHttpContext->GetModuleContextContainer()->GetModuleContext(g_pModuleContext));
 
     CriticalSectionLock lock{cs};
-	// here we must check if response body processing is enabled
-	//
-	if(!rsc || !rsc->requestRec || rsc->responseBuffer != nullptr || !modsecIsResponseBodyAccessEnabled(rsc->requestRec.get()))
-	{
-		goto Exit;
-	}
+    // here we must check if response body processing is enabled
+    //
+    if (!rsc || !rsc->requestRec || rsc->responseBuffer != nullptr || !rsc->responseProcessingEnabled)
+    {
+        goto Exit;
+    }
+
+    // If we have offloaded request processing to the thread pool
+    // we need to wait for its completion before we can proceed
+    if (rsc->detectionProcessing.valid()) {
+        rsc->detectionProcessing.get();
+    }
 
     HRESULT hr = S_OK;
 	IHttpResponse *pHttpResponse = NULL;
@@ -850,6 +953,17 @@ CMyHttpModule::OnBeginRequest(IHttpContext* httpContext, IHttpEventProvider* pro
 
         delete apppath;
         delete path;
+
+        if (config->config->is_enabled == MODSEC_DETECTION_ONLY)
+        {
+            modsecSetReadBody(nullptr);
+            modsecSetWriteBody(nullptr);
+        }
+        else
+        {
+            modsecSetReadBody(ReadBodyCallback);
+            modsecSetWriteBody(WriteBodyCallback);
+        }
     }
 
     ConnRecPtr connRec = MakeConnReq();
@@ -862,6 +976,8 @@ CMyHttpModule::OnBeginRequest(IHttpContext* httpContext, IHttpEventProvider* pro
     rsc->requestRec = requestRec;
     rsc->httpContext = httpContext;
     rsc->provider = provider;
+    rsc->responseProcessingEnabled = (config->config->resbody_access == 1);
+    RequestStoredContext* context = rsc.get();
 
     // on IIS we force input stream inspection flag, because its absence does not add any performance gain
     // it's because on IIS request body must be restored each time it was read
@@ -1098,121 +1214,40 @@ CMyHttpModule::OnBeginRequest(IHttpContext* httpContext, IHttpEventProvider* pro
 #endif
 	c->remote_host = NULL;
 
-    lock.unlock();
-    int status = modsecProcessRequest(r);
-    lock.lock();
+    if (config->config->is_enabled == MODSEC_DETECTION_ONLY)
+    {
+        hr = SaveRequestBodyToRequestRec(context);
+        if (FAILED(hr)) {
+            context->provider->SetErrorStatus(hr);
+            return RQ_NOTIFICATION_FINISH_REQUEST;
+        }
+        // We post the processing task to the thread pool to happen in the background.
+        // We store the future to track and wait for this processing in case if we also
+        // need to process the response because we need request processing to finish
+        // before we can start with the response.
+        context->detectionProcessing = asio::post(threadPool,
+            std::packaged_task<int()> {
+            [connRec, requestRec] {
+                return modsecProcessRequest(requestRec.get());
+            }
+        });
+    }
+    else
+    {
+        lock.unlock();
+        int status = modsecProcessRequest(r);
+        lock.lock();
 
-	if(status != DECLINED)
-	{
-		httpContext->GetResponse()->SetStatus(status, "ModSecurity Action");
-		httpContext->SetRequestHandled();
+        if (status != DECLINED)
+        {
+            httpContext->GetResponse()->SetStatus(status, "ModSecurity Action");
+            httpContext->SetRequestHandled();
 
-        return RQ_NOTIFICATION_FINISH_REQUEST;
-	}
+            return RQ_NOTIFICATION_FINISH_REQUEST;
+        }
+    }
 
 	return RQ_NOTIFICATION_CONTINUE;
-}
-
-
-apr_status_t ReadBodyCallback(request_rec *r, char *buf, unsigned int length, unsigned int *readcnt, int *is_eos)
-{
-    RequestStoredContext *rsc = RetrieveIISContext(r);
-
-    *readcnt = 0;
-
-    if (rsc == NULL)
-    {
-        *is_eos = 1;
-        return APR_SUCCESS;
-    }
-
-    IHttpContext *pHttpContext = rsc->httpContext;
-    IHttpRequest *pRequest = pHttpContext->GetRequest();
-
-    if (pRequest->GetRemainingEntityBytes() == 0)
-    {
-        *is_eos = 1;
-        return APR_SUCCESS;
-    }
-
-    HRESULT hr = pRequest->ReadEntityBody(buf, length, false, (DWORD *)readcnt, NULL);
-
-    if (FAILED(hr))
-    {
-        // End of data is okay.
-        if (ERROR_HANDLE_EOF != (hr & 0x0000FFFF))
-        {
-            // Set the error status.
-            rsc->provider->SetErrorStatus(hr);
-        }
-
-        *is_eos = 1;
-    }
-
-    return APR_SUCCESS;
-}
-
-apr_status_t WriteBodyCallback(request_rec *r, char *buf, unsigned int length)
-{
-	RequestStoredContext *rsc = RetrieveIISContext(r);
-
-	if(!rsc || !rsc->requestRec)
-		return APR_SUCCESS;
-
-	IHttpContext *pHttpContext = rsc->httpContext;
-	IHttpRequest *pHttpRequest = pHttpContext->GetRequest();
-
-    CHAR szLength[21]; //Max length for a 64 bit int is 20
-
-    ZeroMemory(szLength, sizeof(szLength));
-
-    HRESULT hr = StringCchPrintfA(
-            szLength, 
-            sizeof(szLength) / sizeof(CHAR) - 1, "%d", 
-            length);
-
-    if(FAILED(hr))
-    {
-		// not possible
-    }
-
-	// Remove/Modify Transfer-Encoding header if "chunked" Encoding is set in the request. 
-	// This is to avoid sending both Content-Length and Chunked Transfer-Encoding in the request header.
-
-	USHORT ctcch = 0;
-	char *ct = (char *)pHttpRequest->GetHeader(HttpHeaderTransferEncoding, &ctcch);
-	if (ct)
-	{
-		char *ctz = ZeroTerminate(ct, ctcch, r->pool);
-		if (ctcch != 0)
-		{
-			if (0 == stricmp(ctz, "chunked"))
-			{
-				pHttpRequest->DeleteHeader(HttpHeaderTransferEncoding);
-			}
-		}
-	}
-	
-    hr = pHttpRequest->SetHeader(
-            HttpHeaderContentLength, 
-            szLength, 
-            (USHORT)strlen(szLength),
-            TRUE);
-
-    if(FAILED(hr))
-    {
-		// possible, but there's nothing we can do
-    }
-
-	// since we clean the APR pool at the end of OnSendRequest, we must get IIS-managed memory chunk
-	//
-	void *reqbuf = pHttpContext->AllocateRequestMemory(length);
-
-	memcpy(reqbuf, buf, length);
-
-	pHttpRequest->InsertEntityBody(reqbuf, length);
-
-	return APR_SUCCESS;
 }
 
 apr_status_t ReadResponseCallback(request_rec *r, char *buf, unsigned int length, unsigned int *readcnt, int *is_eos)
@@ -1300,9 +1335,7 @@ apr_status_t WriteResponseCallback(request_rec *r, char *buf, unsigned int lengt
 CMyHttpModule::CMyHttpModule()
 {
     modsecSetLogHook(this, Log);
-    modsecSetReadBody(ReadBodyCallback);
     modsecSetReadResponse(ReadResponseCallback);
-    modsecSetWriteBody(WriteBodyCallback);
     modsecSetWriteResponse(WriteResponseCallback);
 
     server_rec* s = modsecInit();

--- a/iis/mymodule.cpp
+++ b/iis/mymodule.cpp
@@ -35,11 +35,8 @@
 
 // These helpers make sure that the underlying structures
 // are correctly released on any exit path due to RAII.
-using ConnRecPtr =
-    std::unique_ptr<conn_rec, decltype(modsecFinishConnection)*>;
-
-using RequestRecPtr =
-    std::unique_ptr<request_rec, decltype(modsecFinishRequest)*>;
+using ConnRecPtr = std::shared_ptr<conn_rec>;
+using RequestRecPtr = std::shared_ptr<request_rec>;
 
 ConnRecPtr MakeConnReq()
 {

--- a/iis/mymodule.h
+++ b/iis/mymodule.h
@@ -12,8 +12,10 @@
 * directly using the email address security@modsecurity.org.
 */
 
-#ifndef __MY_MODULE_H__
-#define __MY_MODULE_H__
+#pragma once
+
+#define ASIO_STANDALONE
+#include "asio/thread_pool.hpp"
 
 #include "critical_section.h"
 #include "event_logger.h"
@@ -46,8 +48,8 @@ public:
 private:
     CriticalSection cs;
     EventLogger logger;
+    asio::thread_pool threadPool;
     DWORD pageSize = 0;
     bool statusCallAlreadySent = false;
 };
 
-#endif


### PR DESCRIPTION
With this change, ModSecurity for IIS posts a processing task to be run in background for an incoming request which allows to release it to the backend immediately and not wait for processing to complete.
Since IIS does not expose its thread pool, we maintain our own internal one specifically for posting those processing tasks.

Note that if we need to process the response body we'll have to wait for background task to complete because we can't process the same `request_rec` structure simultaneously in two different threads because it can introduce races. But we don't want to wait for it unconditionally because that would defeat the whole purpose of task offloading.
To solve that, we first check whether response body processing is enabled. However, it can be either enabled in configuration file or by one of the rules executed during request processing. Since we don't wait for rules execution to complete we can only honor the configuration setting for this purpose.
That is deemed acceptable because AppGW ModSecurity is never used for processing responses anyway.
