### PR TITLE
Add signal process for waf log rotation

### DIFF
--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -1557,7 +1557,7 @@ static const char *cmd_data_dir(cmd_parms *cmd, void *_dcfg, const char *p1)
     }
     
     // Global variable to share between threads
-    strcpy( msc_waf_log_path, wafjsonlog_path );
+    strncpy( msc_waf_log_path, wafjsonlog_path, 1024 );
     msc_waf_log_cmd = cmd;
 #endif
     return NULL;

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -114,9 +114,6 @@ void *create_directory_config(apr_pool_t *mp, char *path)
 
     /* Misc */
     dcfg->data_dir = NOT_SET_P;
-#ifdef WAF_JSON_LOGGING_ENABLE
-    dcfg->wafjsonlog_fd = NOT_SET_P;
-#endif
     dcfg->webappid = NOT_SET_P;
     dcfg->sensor_id = NOT_SET_P;
     dcfg->httpBlkey = NOT_SET_P;
@@ -554,10 +551,6 @@ void *merge_directory_configs(apr_pool_t *mp, void *_parent, void *_child)
     /* Misc */
     merged->data_dir = (child->data_dir == NOT_SET_P
         ? parent->data_dir : child->data_dir);
-#ifdef WAF_JSON_LOGGING_ENABLE
-    merged->wafjsonlog_fd = (child->wafjsonlog_fd == NOT_SET_P
-        ? parent->wafjsonlog_fd : child->wafjsonlog_fd);
-#endif
     merged->webappid = (child->webappid == NOT_SET_P
         ? parent->webappid : child->webappid);
     merged->sensor_id = (child->sensor_id == NOT_SET_P
@@ -726,9 +719,6 @@ void init_directory_config(directory_config *dcfg)
 
     /* Misc */
     if (dcfg->data_dir == NOT_SET_P) dcfg->data_dir = NULL;
-#ifdef WAF_JSON_LOGGING_ENABLE
-    if (dcfg->wafjsonlog_fd == NOT_SET_P) dcfg->wafjsonlog_fd = NULL;
-#endif
     if (dcfg->webappid == NOT_SET_P) dcfg->webappid = "default";
     if (dcfg->sensor_id == NOT_SET_P) dcfg->sensor_id = "default";
     if (dcfg->httpBlkey == NOT_SET_P) dcfg->httpBlkey = NULL;
@@ -1557,7 +1547,7 @@ static const char *cmd_data_dir(cmd_parms *cmd, void *_dcfg, const char *p1)
 #ifdef WAF_JSON_LOGGING_ENABLE
     strcpy( wafjsonlog_path, dcfg->data_dir );
     strcat( wafjsonlog_path, WAF_LOG_UTIL_FILE );
-    rc = apr_file_open(&dcfg->wafjsonlog_fd, wafjsonlog_path,
+    rc = apr_file_open(&msc_waf_log_fd, wafjsonlog_path,
                    APR_WRITE | APR_APPEND | APR_CREATE | APR_BINARY,
                    CREATEMODE | APR_WREAD, cmd->pool);
 
@@ -1565,9 +1555,14 @@ static const char *cmd_data_dir(cmd_parms *cmd, void *_dcfg, const char *p1)
         return apr_psprintf(cmd->pool, "ModSecurity: Failed to open wafjson log file: %s",
             wafjsonlog_path);
     }
+    
+    // Global variable to share between threads
+    strcpy( msc_waf_log_path, wafjsonlog_path );
+    msc_waf_log_cmd = cmd;
 #endif
     return NULL;
 }
+
 
 static const char *cmd_debug_log(cmd_parms *cmd, void *_dcfg, const char *p1)
 {

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -1534,7 +1534,7 @@ static const char *cmd_data_dir(cmd_parms *cmd, void *_dcfg, const char *p1)
 {
 #ifdef WAF_JSON_LOGGING_ENABLE
     int rc;
-    char wafjsonlog_path[1024]; 
+    char wafjsonlog_path[WAF_LOG_PATH_LENGTH]; 
 #endif
     directory_config *dcfg = (directory_config *)_dcfg;
 
@@ -1557,7 +1557,7 @@ static const char *cmd_data_dir(cmd_parms *cmd, void *_dcfg, const char *p1)
     }
     
     // Global variable to share between threads
-    strncpy( msc_waf_log_path, wafjsonlog_path, 1024 );
+    strncpy( msc_waf_log_path, wafjsonlog_path, WAF_LOG_PATH_LENGTH );
     msc_waf_log_cmd = cmd;
 #endif
     return NULL;

--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -462,7 +462,7 @@ static void internal_log_ex(request_rec *r, directory_config *dcfg, modsec_rec *
         else requestheaderhostname = "";
 
 #ifdef WAF_JSON_LOGGING_ENABLE
-        if (msc_waf_log_reopened){
+        if (msc_waf_log_reopened) {
             rc = apr_file_open(&msc_waf_log_fd, msc_waf_log_path,
                    APR_WRITE | APR_APPEND | APR_CREATE | APR_BINARY,
                    CREATEMODE | APR_WREAD, msc_waf_log_cmd->pool);
@@ -470,10 +470,10 @@ static void internal_log_ex(request_rec *r, directory_config *dcfg, modsec_rec *
             if (rc != APR_SUCCESS) {
                 #if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER > 2
                 	ap_log_rerror(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, r,
-                            "MoSecurity not able to reopen %s file", WAF_LOG_UTIL_FILE);
+                            "ModSecurity not able to reopen %s file", WAF_LOG_UTIL_FILE);
                 #else
                         ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, r->server,
-                            "MoSecurity not able to reopen %s file", WAF_LOG_UTIL_FILE);
+                            "ModSecurity not able to reopen %s file", WAF_LOG_UTIL_FILE);
                 #endif
             }
             

--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -390,6 +390,7 @@ static void internal_log_ex(request_rec *r, directory_config *dcfg, modsec_rec *
     char *str = NULL;
     char str1[1024] = "";
     char str2[1256] = "";
+    int rc = 0;
 
     /* Find the logging FD and determine the logging level from configuration. */
     if (dcfg != NULL) {
@@ -461,11 +462,6 @@ static void internal_log_ex(request_rec *r, directory_config *dcfg, modsec_rec *
         else requestheaderhostname = "";
 
 #ifdef WAF_JSON_LOGGING_ENABLE
-        if (msr->modsecurity->wafjsonlog_lock != NULL)
-        {
-            waf_get_exclusive_lock(msr->modsecurity->wafjsonlog_lock);
-        }
-
         if (msc_waf_log_reopened){
             rc = apr_file_open(&msc_waf_log_fd, msc_waf_log_path,
                    APR_WRITE | APR_APPEND | APR_CREATE | APR_BINARY,
@@ -482,11 +478,6 @@ static void internal_log_ex(request_rec *r, directory_config *dcfg, modsec_rec *
             }
             
             msc_waf_log_reopened = 0;
-        }
-
-        if (msr->modsecurity->wafjsonlog_lock != NULL)
-        {
-            rc = waf_free_exclusive_lock(msr->modsecurity->wafjsonlog_lock);
         }
 
         send_waf_log(msr->modsecurity->wafjsonlog_lock, msc_waf_log_fd, str1, r->useragent_ip ? r->useragent_ip : r->connection->client_ip, log_escape(msr->mp, r->uri), dcfg->is_enabled, (char*)msr->hostname, unique_id, r);

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -95,6 +95,10 @@ TreeRoot DSOLOCAL *conn_write_state_suspicious_list = 0;
 #ifdef WAF_JSON_LOGGING_ENABLE
 char DSOLOCAL *msc_waf_resourceId = NULL;
 char DSOLOCAL *msc_waf_instanceId = NULL;
+sig_atomic_t DSOLOCAL msc_waf_log_reopened = 0;
+apr_file_t DSOLOCAL *msc_waf_log_fd = NULL;
+char DSOLOCAL msc_waf_log_path[1024] = ""; 
+cmd_parms DSOLOCAL *msc_waf_log_cmd = NULL;
 #endif
 
 #ifndef _WIN32

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -97,7 +97,7 @@ char DSOLOCAL *msc_waf_resourceId = NULL;
 char DSOLOCAL *msc_waf_instanceId = NULL;
 sig_atomic_t DSOLOCAL msc_waf_log_reopened = 0;
 apr_file_t DSOLOCAL *msc_waf_log_fd = NULL;
-char DSOLOCAL msc_waf_log_path[1024] = ""; 
+char DSOLOCAL msc_waf_log_path[WAF_LOG_PATH_LENGTH] = ""; 
 cmd_parms DSOLOCAL *msc_waf_log_cmd = NULL;
 #endif
 

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -253,7 +253,9 @@ void modsecurity_handle_signals_for_reopen(int signum)
 void modsecurity_child_init(msc_engine *msce) {
     struct waf_lock_args *lock_args;
     char *lock_name;
+#ifdef WAF_JSON_LOGGING_ENABLE
     struct sigaction psa;
+#endif
 
     /* Need to call this once per process before any other XML calls. */
     xmlInitParser();

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -240,12 +240,14 @@ int modsecurity_init(msc_engine *msce, apr_pool_t *mp) {
     return 1;
 }
 
+#ifdef WAF_JSON_LOGGING_ENABLE
 void modsecurity_handle_signals_for_reopen(int signum)
 {
     if (signum == SIGUSR1) {
         msc_waf_log_reopened = 1;
     }
 }
+#endif
 
 /**
  * Performs per-child (new process) initialisation.

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -240,6 +240,13 @@ int modsecurity_init(msc_engine *msce, apr_pool_t *mp) {
     return 1;
 }
 
+void modsecurity_handle_signals_for_reopen(int signum)
+{
+    if (signum == SIGUSR1) {
+        msc_waf_log_reopened = 1;
+    }
+}
+
 /**
  * Performs per-child (new process) initialisation.
  */
@@ -266,7 +273,10 @@ void modsecurity_child_init(msc_engine *msce) {
 
     set_lock_args(lock_args, WAFJSONLOG_LOCK_ID);
 
-    waf_create_lock(msce->wafjsonlog_lock, lock_args);    
+    waf_create_lock(msce->wafjsonlog_lock, lock_args); 
+
+    signal(SIGUSR1, modsecurity_handle_signals_for_reopen); 
+     
 #endif
 
     if (msce->geo_lock == NULL) {

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -255,6 +255,7 @@ void modsecurity_child_init(msc_engine *msce) {
     char *lock_name;
 #ifdef WAF_JSON_LOGGING_ENABLE
     struct sigaction psa;
+    sigset_t block_mask;
 #endif
 
     /* Need to call this once per process before any other XML calls. */
@@ -278,7 +279,10 @@ void modsecurity_child_init(msc_engine *msce) {
 
     waf_create_lock(msce->wafjsonlog_lock, lock_args); 
 
+    sigfillset (&block_mask);
     psa.sa_handler = modsecurity_handle_signals_for_reopen;
+    psa.sa_mask = block_mask;
+    psa.sa_flags = 0;
     sigaction(SIGUSR1, &psa, NULL);     
 #endif
 

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -243,9 +243,7 @@ int modsecurity_init(msc_engine *msce, apr_pool_t *mp) {
 #ifdef WAF_JSON_LOGGING_ENABLE
 void modsecurity_handle_signals_for_reopen(int signum)
 {
-    if (signum == SIGUSR1) {
-        msc_waf_log_reopened = 1;
-    }
+    msc_waf_log_reopened = 1;
 }
 #endif
 
@@ -255,6 +253,7 @@ void modsecurity_handle_signals_for_reopen(int signum)
 void modsecurity_child_init(msc_engine *msce) {
     struct waf_lock_args *lock_args;
     char *lock_name;
+    struct sigaction psa;
 
     /* Need to call this once per process before any other XML calls. */
     xmlInitParser();
@@ -277,8 +276,8 @@ void modsecurity_child_init(msc_engine *msce) {
 
     waf_create_lock(msce->wafjsonlog_lock, lock_args); 
 
-    signal(SIGUSR1, modsecurity_handle_signals_for_reopen); 
-     
+    psa.sa_handler = modsecurity_handle_signals_for_reopen;
+    sigaction(SIGUSR1, &psa, NULL);     
 #endif
 
     if (msce->geo_lock == NULL) {

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -115,6 +115,10 @@ typedef struct msc_parm msc_parm;
 #define SECMARKER_ARGS                          "@noMatch"
 #define SECMARKER_BASE_ACTIONS                  "t:none,pass,marker:"
 
+#ifdef WAF_JSON_LOGGING_ENABLE
+#define WAF_LOG_PATH_LENGTH                     1024
+#endif
+
 #if !defined(OS2) && !defined(WIN32) && !defined(BEOS) && !defined(NETWARE)
 #include "unixd.h"
 #define __SET_MUTEX_PERMS
@@ -173,7 +177,7 @@ extern DSOLOCAL char *msc_waf_resourceId;
 extern DSOLOCAL char *msc_waf_instanceId;
 extern DSOLOCAL sig_atomic_t msc_waf_log_reopened;
 extern DSOLOCAL apr_file_t *msc_waf_log_fd;
-extern DSOLOCAL char msc_waf_log_path[1024];
+extern DSOLOCAL char msc_waf_log_path[WAF_LOG_PATH_LENGTH];
 extern DSOLOCAL cmd_parms *msc_waf_log_cmd;
 #endif
 

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -171,6 +171,10 @@ extern DSOLOCAL int *unicode_map_table;
 #ifdef WAF_JSON_LOGGING_ENABLE
 extern DSOLOCAL char *msc_waf_resourceId;
 extern DSOLOCAL char *msc_waf_instanceId;
+extern DSOLOCAL sig_atomic_t msc_waf_log_reopened;
+extern DSOLOCAL apr_file_t *msc_waf_log_fd;
+extern DSOLOCAL char msc_waf_log_path[1024];
+extern DSOLOCAL cmd_parms *msc_waf_log_cmd;
 #endif
 
 #ifndef _WIN32
@@ -596,9 +600,6 @@ struct directory_config {
 
     /* Misc */
     const char          *data_dir;
-#ifdef WAF_JSON_LOGGING_ENABLE
-    apr_file_t          *wafjsonlog_fd;
-#endif
     const char          *webappid;
     const char          *sensor_id;
     const char          *httpBlkey;


### PR DESCRIPTION
Add  support for waf log rotation.
Since right now modsec is using multiple threading mode, in the init process, register the signal processing function. so when worker process receive the signal, the main thread will set the flag and open the file and populate the global file descriptor and other threads sharing the file descriptor could write to the new file.

Testing:
function testing:
rename the current file, send requests and see log still written to the file, send the signal and send requests again, the log will be logged in the new file.

stress testing:
using ab to send for 100 seconds and the process is still action normally, send the signal and use ab send traffic again, nginx still behave normally.