### PR TITLE
Make ModSecurity IIS work with SecStreamInBodyInspection option disabled to prevent memory leak

### DIFF
--- a/iis/mymodule.cpp
+++ b/iis/mymodule.cpp
@@ -448,58 +448,62 @@ static HRESULT SaveRequestBodyToRequestRec(RequestStoredContext* rsc)
         APR_BRIGADE_INSERT_TAIL(brigade, bucket);
     }
 
-    apr_bucket* e = apr_bucket_eos_create(conn->bucket_alloc);
-    if (e == nullptr)
-    {
-        return E_OUTOFMEMORY;
-    }
-    APR_BRIGADE_INSERT_TAIL(brigade, e);
-
-    modsecSetBodyBrigade(aprRequest, brigade);
-
-    apr_off_t contentLength = 0;
-    apr_status_t status = apr_brigade_length(brigade, FALSE, &contentLength);
-    if (status != APR_SUCCESS)
-    {
-        return E_FAIL;
-    }
-
-    // Remove/Modify Transfer-Encoding header if "chunked" Encoding is set in the request. 
-    // This is to avoid sending both Content-Length and Chunked Transfer-Encoding in the request header.
-    static const std::string CHUNKED = "chunked";
-    USHORT encodingLength = 0;
-    const char* transferEncoding = iisRequest->GetHeader(HttpHeaderTransferEncoding, &encodingLength);
-    if (transferEncoding)
-    {
-        if (CHUNKED.size() == encodingLength &&
-            std::equal(CHUNKED.cbegin(), CHUNKED.cend(), transferEncoding,
-                [](char lhs, char rhs) { return std::tolower(lhs) == std::tolower(rhs); }))
+    if (!APR_BRIGADE_EMPTY(brigade)) {
+        apr_bucket* e = apr_bucket_eos_create(conn->bucket_alloc);
+        if (e == nullptr)
         {
-            iisRequest->DeleteHeader(HttpHeaderTransferEncoding);
+            return E_OUTOFMEMORY;
         }
+        APR_BRIGADE_INSERT_TAIL(brigade, e);
+
+        modsecSetBodyBrigade(aprRequest, brigade);
+
+        apr_off_t contentLength = 0;
+        apr_status_t status = apr_brigade_length(brigade, FALSE, &contentLength);
+        if (status != APR_SUCCESS)
+        {
+            return E_FAIL;
+        }
+
+        // Remove/Modify Transfer-Encoding header if "chunked" Encoding is set in the request. 
+        // This is to avoid sending both Content-Length and Chunked Transfer-Encoding in the request header.
+        static const std::string CHUNKED = "chunked";
+        USHORT encodingLength = 0;
+        const char* transferEncoding = iisRequest->GetHeader(HttpHeaderTransferEncoding, &encodingLength);
+        if (transferEncoding)
+        {
+            if (encodingLength == CHUNKED.size() &&
+                std::equal(CHUNKED.cbegin(), CHUNKED.cend(), transferEncoding,
+                [](char lhs, char rhs) { return std::tolower(lhs) == std::tolower(rhs); }))
+            {
+                iisRequest->DeleteHeader(HttpHeaderTransferEncoding);
+            }
+        }
+
+        auto contentLengthStr = std::to_string(contentLength);
+        HRESULT hr = iisRequest->SetHeader(
+            HttpHeaderContentLength,
+            contentLengthStr.c_str(),
+            contentLengthStr.size(),
+            TRUE);
+
+        if (FAILED(hr))
+        {
+            return hr;
+        }
+
+        // since we clean the APR pool at the end of OnSendRequest, we must get IIS-managed memory chunk
+        //
+        char* requestBuffer = static_cast<char*>(rsc->httpContext->AllocateRequestMemory(contentLength));
+        status = apr_brigade_flatten(brigade, requestBuffer, reinterpret_cast<apr_size_t*>(&contentLength));
+        if (status != APR_SUCCESS)
+        {
+            return E_FAIL;
+        }
+        return iisRequest->InsertEntityBody(requestBuffer, contentLength);
     }
 
-    auto contentLengthStr = std::to_string(contentLength);
-    HRESULT hr = iisRequest->SetHeader(
-        HttpHeaderContentLength,
-        contentLengthStr.c_str(),
-        contentLengthStr.size(),
-        TRUE);
-
-    if (FAILED(hr))
-    {
-        return hr;
-    }
-
-    // since we clean the APR pool at the end of OnSendRequest, we must get IIS-managed memory chunk
-    //
-    char* requestBuffer = static_cast<char*>(rsc->httpContext->AllocateRequestMemory(contentLength));
-    status = apr_brigade_flatten(brigade, requestBuffer, reinterpret_cast<apr_size_t*>(&contentLength));
-    if (status != APR_SUCCESS)
-    {
-        return E_FAIL;
-    }
-    return iisRequest->InsertEntityBody(requestBuffer, contentLength);
+    return S_OK;
 }
 
 

--- a/iis/mymodule.cpp
+++ b/iis/mymodule.cpp
@@ -972,11 +972,6 @@ CMyHttpModule::OnBeginRequest(IHttpContext* httpContext, IHttpEventProvider* pro
     rsc->responseProcessingEnabled = (config->config->resbody_access == 1);
     RequestStoredContext* context = rsc.get();
 
-    // on IIS we force input stream inspection flag, because its absence does not add any performance gain
-    // it's because on IIS request body must be restored each time it was read
-    //
-    modsecSetConfigForIISRequestBody(r);
-
     StoreIISContext(r, rsc.get());
 
     httpContext->GetModuleContextContainer()->SetModuleContext(rsc.release(), g_pModuleContext);


### PR DESCRIPTION
Description
===

There is a long-time known memory leak that occurs to requests blocked by ModSecurity when `SecStreamInBodyInspection`. The primary reason for keeping this option is that ModSecurity for IIS needs it turned on - see https://github.com/SpiderLabs/ModSecurity/issues/538 for details.

This is bad, however, because this flag causes a known memory leak: https://github.com/SpiderLabs/ModSecurity/issues/1316

We have earlier disabled this option for ModSecurity for Nginx but couldn't do so for IIS for it would break processing.
Now we can leverage the code implemented for processing requests in background for detection-only mode and not depend on `SecStreamInBodyInspection` being set any longer.

NB: there are some other memory leaks coming from other places even when body processing is disabled. They leak much less memory so are not addressed by this fix but should certainly be chased later.

Testing
===

I've been using requests with 128Kb body carrying randomly generated payload:
```
curl -X POST --data-binary '@payload.bin' "http://localhost:8081/?test=/etc/passwd" -o /dev/null -s -w "got HTTP %{http_code} after %{time_total}s\n"
```

____________________________________
Prevention mode, SecStreamInBodyInspection On
____________________________________
Before any requests: 5.3 Mb
After first request (config loaded): 22.6 Mb
After 100 more requests (101 overall): 36.6 Mb
After another 100 requests (201 overall): 49.1 Mb

____________________________________
Prevention mode, SecStreamInBodyInspection Off
____________________________________
Before any requests: 5.2 Mb
After first request (config loaded): 22.3 Mb
After 100 more requests (101 overall): 23.2 Mb
After another 100 requests (201 overall): 23.6 Mb