### PR TITLE
fix non waf json log mode compilation

### DIFF
--- a/nginx/modsecurity/ngx_http_modsecurity.c
+++ b/nginx/modsecurity/ngx_http_modsecurity.c
@@ -22,7 +22,9 @@
 #undef CRLF
 
 #include "api.h"
+#ifdef WAF_JSON_LOGGING_ENABLE
 #include <waf_log_util_external.h>
+#endif
 
 #define NOTE_NGINX_REQUEST_CTX "nginx-ctx"
 
@@ -561,7 +563,9 @@ ngx_http_modsecurity_init(ngx_conf_t *cf)
     extern pthread_mutex_t msc_pregcomp_ex_mtx;
     pthread_mutex_init(&msc_pregcomp_ex_mtx, NULL);
 
+#ifdef WAF_JSON_LOGGING_ENABLE
     init_appgw_rules_id_hash();
+#endif    
 
     return NGX_OK;
 }


### PR DESCRIPTION
MSR report compilation failed for non-waf json log mode, add ifdef to fix it