### PR TITLE
Revert fix for non-blocking detection mode in ModSecurity IIS

### DIFF
--- a/iis/Makefile.win
+++ b/iis/Makefile.win
@@ -37,8 +37,7 @@ INCLUDES = -I. -I.. \
            -I..\apache2 \
            -I..\standalone \
            -I..\apache2\ag_mdb \
-           -I..\apache2\waf_lock \
-           -Iasio\asio\include
+           -I..\apache2\waf_lock
 
 # Enables support for SecRemoteRules and external resources.
 DEFS=$(DEFS) -DWITH_CURL -DWITH_REMOTE_RULES

--- a/iis/mymodule.h
+++ b/iis/mymodule.h
@@ -12,10 +12,8 @@
 * directly using the email address security@modsecurity.org.
 */
 
-#pragma once
-
-#define ASIO_STANDALONE
-#include "asio/thread_pool.hpp"
+#ifndef __MY_MODULE_H__
+#define __MY_MODULE_H__
 
 #include "critical_section.h"
 #include "event_logger.h"
@@ -48,8 +46,8 @@ public:
 private:
     CriticalSection cs;
     EventLogger logger;
-    asio::thread_pool threadPool;
     DWORD pageSize = 0;
     bool statusCallAlreadySent = false;
 };
 
+#endif


### PR DESCRIPTION
Let's give it more testing before rolling the fix out in production as
we've been hit badly with a bug in a similar fix for Nginx.

This reverts commit 2aa9412ae490d1f9b195ba2c150deeaa689a5514.

--------
Testing.
--------

Ran 100000 requests with both benign and prohibited query parameters for both prevention and detection mode using SuperBenchmarker: https://github.com/aliostad/SuperBenchmarker 

All the response statuses are as expected, no failures or 502s reported. The memory consumption does not grow ( SecStreamInBodyInspection Off).