### PR TITLE
Make detection mode run fully in background and not block Nginx requests

### DIFF
--- a/nginx/modsecurity/apr_bucket_nginx.c
+++ b/nginx/modsecurity/apr_bucket_nginx.c
@@ -22,7 +22,6 @@ typedef struct apr_bucket_nginx {
 
 /* ngx_buf_t to apr_bucket */
 apr_bucket * apr_bucket_nginx_create(ngx_buf_t *buf,
-                                     apr_pool_t *p,
                                      apr_bucket_alloc_t *list)
 {
 
@@ -31,11 +30,10 @@ apr_bucket * apr_bucket_nginx_create(ngx_buf_t *buf,
     APR_BUCKET_INIT(b); /* link */
     b->free = apr_bucket_free;
     b->list = list;
-    return apr_bucket_nginx_make(b, buf, p);
+    return apr_bucket_nginx_make(b, buf);
 }
 
-apr_bucket * apr_bucket_nginx_make(apr_bucket *b, ngx_buf_t *buf,
-                                   apr_pool_t *pool)
+apr_bucket * apr_bucket_nginx_make(apr_bucket *b, ngx_buf_t *buf)
 {
     apr_bucket_nginx *n;
 
@@ -93,11 +91,11 @@ static void nginx_bucket_destroy(void *data)
 
 
 ngx_int_t
-copy_chain_to_brigade(ngx_chain_t *chain, apr_bucket_brigade *bb, ngx_pool_t *pool, ngx_int_t last_buf) {
+copy_chain_to_brigade(ngx_chain_t *chain, apr_bucket_brigade *bb, ngx_int_t last_buf) {
     apr_bucket         *e;
 
     while (chain) {
-        e = ngx_buf_to_apr_bucket(chain->buf, bb->p, bb->bucket_alloc);
+        e = ngx_buf_to_apr_bucket(chain->buf, bb->bucket_alloc);
         if (e == NULL) {
             return NGX_ERROR;
         }

--- a/nginx/modsecurity/apr_bucket_nginx.h
+++ b/nginx/modsecurity/apr_bucket_nginx.h
@@ -2,13 +2,10 @@
 #include <ngx_core.h>
 #include "apr_buckets.h"
 
-apr_bucket * apr_bucket_nginx_create(ngx_buf_t *buf,
-                                     apr_pool_t *p,
-                                     apr_bucket_alloc_t *list);
+apr_bucket * apr_bucket_nginx_create(ngx_buf_t *buf, apr_bucket_alloc_t *list);
 
-apr_bucket * apr_bucket_nginx_make(apr_bucket *e, ngx_buf_t *buf,
-                                   apr_pool_t *pool);
+apr_bucket * apr_bucket_nginx_make(apr_bucket *e, ngx_buf_t *buf);
 
 #define ngx_buf_to_apr_bucket apr_bucket_nginx_create
 
-ngx_int_t copy_chain_to_brigade(ngx_chain_t *chain, apr_bucket_brigade *bb, ngx_pool_t *pool, ngx_int_t last_buf);
+ngx_int_t copy_chain_to_brigade(ngx_chain_t *chain, apr_bucket_brigade *bb, ngx_int_t last_buf);

--- a/nginx/modsecurity/ngx_http_modsecurity.c
+++ b/nginx/modsecurity/ngx_http_modsecurity.c
@@ -52,8 +52,14 @@ typedef struct {
 
 typedef struct {
     ngx_http_request_t *r;
-} ngx_http_modsecurity_thread_ctx_t;
+} ngx_http_modsecurity_prevention_thread_ctx_t;
 
+typedef struct {
+    conn_rec            *connection;
+    request_rec         *req;
+
+    apr_bucket_brigade  *brigade;
+} ngx_http_modsecurity_detection_thread_ctx_t;
 
 /*
 ** Module's registred function/handlers.
@@ -149,6 +155,34 @@ ngx_pstrdup0(ngx_pool_t *pool, ngx_str_t *src)
 }
 
 
+static inline char *
+dup_ngx_str_to_apr(apr_pool_t *pool, ngx_str_t *src)
+{
+    return apr_pstrmemdup(pool, (char *)src->data, src->len);
+}
+
+/*
+ * Helper to allocate a thread task using an Apache pool.
+ * This is useful when the background task can outlive the Nginx request
+ * it is initiated for.
+ */
+ngx_thread_task_t *
+apr_thread_task_alloc(apr_pool_t *pool, size_t size)
+{
+    ngx_thread_task_t  *task;
+
+    // The logic of ngx_thread_task_post relies on the task to be zero-initialized.
+    // That is why we use apr_pcalloc here.
+    task = apr_pcalloc(pool, sizeof(ngx_thread_task_t) + size);
+    if (task == NULL) {
+        return NULL;
+    }
+
+    task->ctx = task + 1;
+
+    return task;
+}
+
 static inline int
 ngx_http_modsecurity_method_number(unsigned int nginx)
 {
@@ -193,6 +227,11 @@ ngx_http_modsecurity_method_number(unsigned int nginx)
     return MultiplyDeBruijnBitPosition[((uint32_t)((nginx & -nginx) * 0x077CB531U)) >> 27];
 }
 
+/*
+ * Use APR pool for all allocations because they should not depend on Nginx request pool.
+ * In case of detection mode, processing will take place entirely in background and may last
+ * longer than the original request lives.
+ */
 static ngx_inline ngx_int_t
 ngx_http_modsecurity_load_request(ngx_http_request_t *r)
 {
@@ -210,7 +249,7 @@ ngx_http_modsecurity_load_request(ngx_http_request_t *r)
     req = ctx->req;
 
     /* request line */
-    req->method = (char *)ngx_pstrdup0(r->pool, &r->method_name);
+    req->method = dup_ngx_str_to_apr(req->pool, &r->method_name);
 
     /* TODO: how to use ap_method_number_of ?
      * req->method_number = ap_method_number_of(req->method);
@@ -223,18 +262,18 @@ ngx_http_modsecurity_load_request(ngx_http_request_t *r)
         return NGX_ERROR;
     }
 
-    req->filename = (char *) path.data;
+    req->filename = dup_ngx_str_to_apr(req->pool, &path);
     req->path_info = req->filename;
 
-    req->args = (char *)ngx_pstrdup0(r->pool, &r->args);
+    req->args = dup_ngx_str_to_apr(req->pool, &r->args);
 
     req->proto_num = r->http_major *1000 + r->http_minor;
-    req->protocol = (char *)ngx_pstrdup0(r->pool, &r->http_protocol);
+    req->protocol = dup_ngx_str_to_apr(req->pool, &r->http_protocol);
     req->request_time = apr_time_make(r->start_sec, r->start_msec);
-    req->the_request = (char *)ngx_pstrdup0(r->pool, &r->request_line);
+    req->the_request = dup_ngx_str_to_apr(req->pool, &r->request_line);
 
-    req->unparsed_uri = (char *)ngx_pstrdup0(r->pool, &r->unparsed_uri);
-    req->uri = (char *)ngx_pstrdup0(r->pool, &r->uri);
+    req->unparsed_uri = dup_ngx_str_to_apr(req->pool, &r->unparsed_uri);
+    req->uri = dup_ngx_str_to_apr(req->pool, &r->uri);
 
     req->parsed_uri.scheme = "http";
 
@@ -244,7 +283,7 @@ ngx_http_modsecurity_load_request(ngx_http_request_t *r)
     }
 #endif
 
-    req->parsed_uri.path = (char *)ngx_pstrdup0(r->pool, &r->uri);
+    req->parsed_uri.path = dup_ngx_str_to_apr(req->pool, &r->uri);
     req->parsed_uri.is_initialized = 1;
 
     switch (r->connection->local_sockaddr->sa_family) {
@@ -269,18 +308,16 @@ ngx_http_modsecurity_load_request(ngx_http_request_t *r)
     }
 
     req->parsed_uri.port = port;
-    req->parsed_uri.port_str = ngx_pnalloc(r->pool, sizeof("65535"));
+    req->parsed_uri.port_str = apr_palloc(req->pool, sizeof("65535"));
     (void) ngx_sprintf((u_char *)req->parsed_uri.port_str, "%ui%c", port, '\0');
 
     req->parsed_uri.query = r->args.len ? req->args : NULL;
     req->parsed_uri.dns_looked_up = 0;
     req->parsed_uri.dns_resolved = 0;
 
-    // req->parsed_uri.password = (char *)ngx_pstrdup0(r->pool, &r->headers_in.passwd);
-    // req->parsed_uri.user = (char *)ngx_pstrdup0(r->pool, &r->headers_in.user);
-    req->parsed_uri.fragment = (char *)ngx_pstrdup0(r->pool, &r->exten);
+    req->parsed_uri.fragment = dup_ngx_str_to_apr(req->pool, &r->exten);
 
-    req->hostname = (char *)ngx_pstrdup0(r->pool, (ngx_str_t *)&ngx_cycle->hostname);
+    req->hostname = dup_ngx_str_to_apr(req->pool, (ngx_str_t *)&ngx_cycle->hostname);
 
     req->header_only = r->header_only ? r->header_only : (r->method == NGX_HTTP_HEAD);
 
@@ -319,7 +356,15 @@ ngx_http_modsecurity_load_headers_in(ngx_http_request_t *r)
             i = 0;
         }
 
-        apr_table_setn(req->headers_in, (char *)h[i].key.data, (char *)h[i].value.data);
+        const char *key = dup_ngx_str_to_apr(req->pool, &h[i].key);
+        if (key == NULL) {
+            return NGX_ERROR;
+        }
+        const char *value = dup_ngx_str_to_apr(req->pool, &h[i].value);
+        if (value == NULL) {
+            return NGX_ERROR;
+        }
+        apr_table_setn(req->headers_in, key, value);
         ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                        "ModSecurity: load headers in: \"%V: %V\"",
                        &h[i].key, &h[i].value);
@@ -335,14 +380,14 @@ ngx_http_modsecurity_load_headers_in(ngx_http_request_t *r)
     lang = apr_table_get(ctx->req->headers_in, "Content-Languages");
     if(lang != NULL)
     {
-        ctx->req->content_languages = apr_array_make(ctx->req->pool, 1, sizeof(const char *));
+        ctx->req->content_languages = apr_array_make(req->pool, 1, sizeof(const char *));
 
-        *(const char **)apr_array_push(ctx->req->content_languages) = lang;
+        *(const char **)apr_array_push(req->content_languages) = lang;
     }
 
     req->ap_auth_type = (char *)apr_table_get(req->headers_in, "Authorization");
 
-    req->user = (char *)ngx_pstrdup0(r->pool, &r->headers_in.user);
+    req->user = dup_ngx_str_to_apr(req->pool, &r->headers_in.user);
 
 
 
@@ -363,10 +408,10 @@ ngx_http_modsecurity_load_request_body(ngx_http_request_t *r)
 
     if (r->request_body == NULL || r->request_body->bufs == NULL) {
 
-        return copy_chain_to_brigade(NULL, ctx->brigade, r->pool, 1);
+        return copy_chain_to_brigade(NULL, ctx->brigade, 1);
     }
 
-    if (copy_chain_to_brigade(r->request_body->bufs, ctx->brigade, r->pool, 1) != NGX_OK) {
+    if (copy_chain_to_brigade(r->request_body->bufs, ctx->brigade, 1) != NGX_OK) {
         return NGX_ERROR;
     }
 
@@ -374,10 +419,8 @@ ngx_http_modsecurity_load_request_body(ngx_http_request_t *r)
 }
 
 static ngx_inline ngx_int_t
-ngx_http_modsecurity_status(ngx_http_request_t *r, int status)
+ngx_http_modsecurity_status(int status)
 {
-    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "ModSecurity: status %d", status);
-
     if (status == DECLINED || status == APR_SUCCESS) {
         return NGX_DECLINED;
     }
@@ -558,11 +601,11 @@ ngx_http_modsecurity_init_process(ngx_cycle_t *cycle)
 
 
 static void
-ngx_http_modsecurity_thread_func(void *data, ngx_log_t *log)
+ngx_http_modsecurity_prevention_thread_func(void *data, ngx_log_t *log)
 {
     // Executed in a separate thread
 
-    ngx_http_modsecurity_thread_ctx_t *thread_ctx = data;
+    ngx_http_modsecurity_prevention_thread_ctx_t *thread_ctx = data;
     ngx_http_request_t *r = thread_ctx->r;
 
     ngx_http_modsecurity_ctx_t* mod_ctx = ngx_http_get_module_ctx(r, ngx_http_modsecurity);
@@ -576,7 +619,9 @@ ngx_http_modsecurity_thread_func(void *data, ngx_log_t *log)
     }
 
     // Processing request headers
-    ngx_int_t rc = ngx_http_modsecurity_status(r, modsecProcessRequestHeaders(mod_ctx->req));
+    ngx_int_t rc = modsecProcessRequestHeaders(mod_ctx->req);
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "ModSecurity process headers: status %d", rc);
+    rc = ngx_http_modsecurity_status(rc);
 
     if (rc != NGX_DECLINED) {
         mod_ctx->status_code = rc;
@@ -596,13 +641,14 @@ ngx_http_modsecurity_thread_func(void *data, ngx_log_t *log)
     }
 
     // The name of modsecProcessRequestBody is a bit misleading. This function call is needed even to just process GET args.
-    rc = ngx_http_modsecurity_status(r, modsecProcessRequestBody(mod_ctx->req));
-    mod_ctx->status_code = rc;
+    rc = modsecProcessRequestBody(mod_ctx->req);
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "ModSecurity process body: status %d", rc);
+    mod_ctx->status_code = ngx_http_modsecurity_status(rc);
 }
 
 
 static void
-ngx_http_modsecurity_thread_completion(ngx_event_t *ev)
+ngx_http_modsecurity_prevention_thread_completion(ngx_event_t *ev)
 {
     // executed in nginx event loop after thread task is done, in order to pick up and continue processing request
 
@@ -619,13 +665,52 @@ ngx_http_modsecurity_thread_completion(ngx_event_t *ev)
 }
 
 
-static ngx_int_t
-ngx_http_modsecurity_task_offload(ngx_http_request_t *r)
+static void
+ngx_http_modsecurity_detection_thread_func(void *data, ngx_log_t *log)
 {
-    ngx_http_modsecurity_thread_ctx_t *thread_ctx;
+    // Executed in a separate thread
+    ngx_http_modsecurity_detection_thread_ctx_t *thread_ctx = data;
+
+    // Processing request headers
+    ngx_int_t rc = ngx_http_modsecurity_status(modsecProcessRequestHeaders(thread_ctx->req));
+    if (rc != NGX_DECLINED) {
+        return;
+    }
+
+    if (modsecContextState(thread_ctx->req) == MODSEC_DISABLED) {
+        return;
+    }
+
+    // The name of modsecProcessRequestBody is a bit misleading. This function call is needed even to just process GET args.
+    modsecProcessRequestBody(thread_ctx->req);
+}
+
+
+static void
+ngx_http_modsecurity_detection_thread_completion(ngx_event_t *ev)
+{
+    // executed in nginx event loop after thread task is done, in order to pick up and continue processing request
+    ngx_http_modsecurity_detection_thread_ctx_t *ctx = ev->data;
+
+    request_rec *req = ctx->req;
+    conn_rec *connection = ctx->connection;
+
+    if (req != NULL) {
+        modsecFinishRequest(req);
+    }
+    if (connection != NULL) {
+        modsecFinishConnection(connection);
+    }
+}
+
+
+static ngx_int_t
+ngx_http_modsecurity_prevention_task_offload(ngx_http_request_t *r)
+{
+    ngx_http_modsecurity_prevention_thread_ctx_t *thread_ctx;
     ngx_thread_task_t *task;
 
-    task = ngx_thread_task_alloc(r->pool, sizeof(ngx_http_modsecurity_thread_ctx_t));
+    task = ngx_thread_task_alloc(r->pool, sizeof(ngx_http_modsecurity_prevention_thread_ctx_t));
     if (task == NULL) {
         return NGX_ERROR;
     }
@@ -633,8 +718,8 @@ ngx_http_modsecurity_task_offload(ngx_http_request_t *r)
     thread_ctx = task->ctx;
     thread_ctx->r = r;
 
-    task->handler = ngx_http_modsecurity_thread_func;
-    task->event.handler = ngx_http_modsecurity_thread_completion;
+    task->handler = ngx_http_modsecurity_prevention_thread_func;
+    task->event.handler = ngx_http_modsecurity_prevention_thread_completion;
     task->event.data = r;
 
     ngx_thread_pool_t* thread_pool = ngx_thread_pool_get((ngx_cycle_t *)ngx_cycle, &thread_pool_name);
@@ -648,6 +733,52 @@ ngx_http_modsecurity_task_offload(ngx_http_request_t *r)
     return NGX_OK;
 }
 
+static ngx_int_t
+ngx_http_modsecurity_detection_task_offload(ngx_http_request_t *r)
+{
+    ngx_http_modsecurity_ctx_t *ctx = ngx_http_get_module_ctx(r, ngx_http_modsecurity);
+    request_rec *req = ctx->req;
+
+    // Load request to request rec
+    if (ngx_http_modsecurity_load_request(r) != NGX_OK ||
+            ngx_http_modsecurity_load_headers_in(r) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    if (modsecIsRequestBodyAccessEnabled(req) && (r->headers_in.content_length || r->headers_in.chunked)) {
+        if (ngx_http_modsecurity_load_request_body(r) != NGX_OK) {
+            return NGX_ERROR;
+        }
+    }
+
+    ngx_thread_task_t *task = apr_thread_task_alloc(req->pool, sizeof(ngx_http_modsecurity_detection_thread_ctx_t));
+    if (task == NULL) {
+        return NGX_ERROR;
+    }
+
+    ngx_http_modsecurity_detection_thread_ctx_t *thread_ctx = task->ctx;
+    thread_ctx->connection = ctx->connection;
+    thread_ctx->req = ctx->req;
+    thread_ctx->brigade = ctx->brigade;
+
+    task->handler = ngx_http_modsecurity_detection_thread_func;
+    task->event.handler = ngx_http_modsecurity_detection_thread_completion;
+    task->event.data = thread_ctx;
+
+    ngx_thread_pool_t* thread_pool = ngx_thread_pool_get((ngx_cycle_t *)ngx_cycle, &thread_pool_name);
+    if (ngx_thread_task_post(thread_pool, task) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    // We need to reset these so they don't get cleaned up when the request is complete.
+    // This is important as the background task can outlive the request and we need to
+    // make sure the memory it uses is still alive.
+    ctx->connection = NULL;
+    ctx->req = NULL;
+    ctx->brigade = NULL;
+
+    return NGX_OK;
+}
 
 static void
 ngx_http_modsecurity_body_handler(ngx_http_request_t *r)
@@ -712,8 +843,17 @@ ngx_http_modsecurity_handler(ngx_http_request_t *r)
         return NGX_DECLINED;
     }
 
+    /* When in detection mode, don't wait for background task to complete because it won't affect the request status */
+    if (cf->config->is_enabled == MODSEC_DETECTION_ONLY) {
+        if (ngx_http_modsecurity_detection_task_offload(r) != NGX_OK) {
+            return NGX_ERROR;
+        }
+
+        return NGX_DECLINED;
+    }
+
     ctx->thread_running = 1;
-    if (ngx_http_modsecurity_task_offload(r) != NGX_OK) {
+    if (ngx_http_modsecurity_prevention_task_offload(r) != NGX_OK) {
         return NGX_ERROR;
     }
 
@@ -760,9 +900,9 @@ ngx_http_modsecurity_create_ctx(ngx_http_request_t *r)
         ctx->connection = modsecNewConnection();
 
         /* fill apr_sockaddr_t */
-        asa = ngx_palloc(r->pool, sizeof(apr_sockaddr_t));
+        asa = apr_palloc(ctx->connection->pool, sizeof(apr_sockaddr_t));
         asa->pool = ctx->connection->pool;
-        asa->hostname = (char *)ngx_pstrdup0(r->pool, &r->connection->addr_text);
+        asa->hostname = dup_ngx_str_to_apr(asa->pool, &r->connection->addr_text);
         asa->servname = asa->hostname;
         asa->next = NULL;
         asa->salen = r->connection->socklen;
@@ -806,7 +946,9 @@ ngx_http_modsecurity_create_ctx(ngx_http_request_t *r)
 
     ctx->req = modsecNewRequest(ctx->connection, cf->config);
 
-    apr_table_setn(ctx->req->notes, NOTE_NGINX_REQUEST_CTX, (const char *) ctx);
+    if (cf->config->is_enabled != MODSEC_DETECTION_ONLY) {
+        apr_table_setn(ctx->req->notes, NOTE_NGINX_REQUEST_CTX, (const char *)ctx);
+    }
     apr_generate_random_bytes(salt, TXID_SIZE);
 
     txid = apr_pcalloc (ctx->req->pool, TXID_SIZE);


### PR DESCRIPTION
When ModSecurity runs in the detection-only mode, a request does not
have to be blocked awaiting to be processed and can be transmitted
immediately because the result of executing rules on it does not affect
its status.
This allows to minimize the latency overhead.

To achieve this, the processing is offloaded to a thread pool and runs
independently from the main request processing by Nginx.

Performance testing
----------------------

The following table shows average latencies (ms) collected for specified requests by sending them to WAF for 1 minute using a single concurrent connection.

Request   type | ModSec disabled | DetectionOnly, before the fix | DetectionOnly, after the fix
-- | -- | -- | --
get-none-16-fields-1kb | 53.05 | 67.57 | 57.62
get-none-32-fields-1kb | 52.39 | 79.3 | 65.85
get-none-64-fields-1kb | 53.66 | 100.21 | 88.84
post-application-x-www-form-urlencoded-16-fields-1kb | 53.85 | 69.92 | 55.45
post-application-x-www-form-urlencoded-32-fields-1kb | 54.14 | 79.01 | 53.01
post-application-x-www-form-urlencoded-64-fields-1kb | 54.12 | 90.35 | 63.3
post-multipart-form-data-16-fields-2kb | 52.6 | 69.38 | 53.48
post-multipart-form-data-32-fields-4kb | 55.73 | 80.22 | 53.22
post-multipart-form-data-64-fields-7kb | 56.03 | 109.47 | 55.83
post-text-plain-1-fields-1kb | 52.76 | 59.32 | 55.12
post-text-plain-1-fields-32kb | 59.71 | 60.4 | 63.94
post-text-plain-1-fields-100kb | 61.01 | 69.78 | 70.84
post-multipart-form-data-6-fields-1kb | 53.27 | 57.83 | 53.18
post-multipart-form-data-194-fields-32kb | 70.55 | 383.48 | 68.45
post-multipart-form-data-603-fields-100kb | 75.31 | 2270 | 74.22
post-application-x-www-form-urlencoded-15-fields-1kb | 51.59 | 63.83 | 55.27
post-application-x-www-form-urlencoded-470-fields-32kb | 65.19 | 389.33 | 66.24
post-application-x-www-form-urlencoded-1458-fields-100kb | 70.18 | 1070 | 68.52
post-application-json-16-fields-1kb | 50.6 | 66.68 | 52.35
post-application-json-512-fields-32kb | 55.63 | 367.81 | 58.12
post-application-json-1600-fields-100kb | 64.29 | 1020 | 68.2
post-text-xml-16-fields-1kb | 53.1 | 61.49 | 55.51
post-text-xml-512-fields-32kb | 58.7 | 1000 | 59.37
post-text-xml-1600-fields-100kb | 66.52 | 3140 | 82.92

Stress testing
----------------------

Stressed the WAF setup using two simultaneously running load generators, Apache Bench and SuperBenchmarker:
1) ab -p aaa.aaa -n 100000 -c 100 -k http://mywafv2/
2) .\sb.exe -u "http://mywafv2/" -c 20 -n 100000


All requests are responded with 200 OK, no connection resets.