### PR TITLE
ModSec on IIS: Block on bad config

### DIFF
--- a/iis/moduleconfig.h
+++ b/iis/moduleconfig.h
@@ -71,7 +71,7 @@ class MODSECURITY_STORED_CONTEXT : public IHttpStoredContext
 
     directory_config* config = nullptr;
 
-    BOOL configLoadingFailed = false;
+    bool configLoadingFailed = false;
 
 private:
     HRESULT 

--- a/iis/moduleconfig.h
+++ b/iis/moduleconfig.h
@@ -71,6 +71,8 @@ class MODSECURITY_STORED_CONTEXT : public IHttpStoredContext
 
     directory_config* config = nullptr;
 
+    BOOL configLoadingFailed = false;
+
 private:
     HRESULT 
     GetBooleanPropertyValue( 

--- a/iis/mymodule.cpp
+++ b/iis/mymodule.cpp
@@ -843,6 +843,7 @@ CMyHttpModule::OnBeginRequest(IHttpContext* httpContext, IHttpEventProvider* pro
         hr = config->GlobalWideCharToMultiByte((WCHAR *)servpath, wcslen(servpath), &apppath, &apppathlen);
         if (FAILED(hr))
         {
+            delete path;
             return reportConfigurationError();
         }
 

--- a/iis/mymodule.cpp
+++ b/iis/mymodule.cpp
@@ -856,7 +856,6 @@ CMyHttpModule::OnBeginRequest(IHttpContext* httpContext, IHttpEventProvider* pro
                 WriteEventViewerLog(err, EVENTLOG_ERROR_TYPE);
                 delete apppath;
                 delete path;
-
                 return reportConfigurationError();
             }
 


### PR DESCRIPTION
Block requests when the ModSecurity config is invalid.

Ideally I wanted to immediately make IIS fail to start by modifying RegisterModule in main.cpp to load and validate the config. But it got too complicated as the right contexts etc werent yet available there...

Tested locally with an invalid config and a valid config.