### PR TITLE
Skip reading request body when body processing is disabled.

### DIFF
--- a/iis/mymodule.cpp
+++ b/iis/mymodule.cpp
@@ -1113,10 +1113,12 @@ CMyHttpModule::OnBeginRequest(IHttpContext* httpContext, IHttpEventProvider* pro
 #endif
     c->remote_host = NULL;
 
-    hr = SaveRequestBodyToRequestRec(context);
-    if (FAILED(hr)) {
-        context->provider->SetErrorStatus(hr);
-        return RQ_NOTIFICATION_FINISH_REQUEST;
+    if (config->config->reqbody_access) {
+        hr = SaveRequestBodyToRequestRec(context);
+        if (FAILED(hr)) {
+            context->provider->SetErrorStatus(hr);
+            return RQ_NOTIFICATION_FINISH_REQUEST;
+        }
     }
 
     lock.unlock();


### PR DESCRIPTION
We have encountered an issue when SetRequestBodyAccess is turned off for
the code would still read the body into Apache brigades and that would
later cause processing to fail because it did not expect any body data
to be present.
Besides, that would allocate twice as much memory for body handling for
no good reason.

With this fix, we only copy the body over from IIS into Apache
structures if we are going to process it.

Testing
-------------

Testing done against a WAF-enabled Azure Application gateway with the following combinations of settings:
1) Prevention mode, request body processing enabled
2) Prevention mode, request body processing disabled
3) Detection-only mode, request body processing enabled
4) Detection-only mode, request body processing disabled

Using the following methods:

- Performance testing framework for Azure WAF
- Using `apib` utility:
    `apib -x "POST" -f aaa.aaa -d 300 -c 16 "http://mywafv1/?test=1=1"`
-  Using `SuperBenchmarker` utility:
   `sb.exe -u "http://mywafv1/?test=1=1" -c 20 -n 10000`
- Manual testing - both GET and POST requests, file uploading.