### PR TITLE
Exclude `iis_maintenance` branch from Travis CI builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ language: c
 services:
   - docker
 
+# The iis_maintenance branch is only used for maintaining ModSecurity for IIS.
+# As such, it should not be built on Linux.
+branches:
+  except:
+    - iis_maintenance
+
 install: 
 # Setting up docker credentials.
   - echo "$DOCKER_PASSWORD" | docker login appgwreg.azurecr.io -u "$DOCKER_USERNAME" --password-stdin


### PR DESCRIPTION
The branch `iis_maintenance` is only intended to be used for building ModSecurity for IIS and as such may not have up-to-date commits for Linux version which will cause Travis CI build to fail.
This fix excludes `iis_maintenance` branch from Travis CI builds leaving it to be only built on Windows by AppVeyor.