### PR TITLE
Introduce configuration cache for ModSecurity on Nginx

### DIFF
--- a/nginx/modsecurity/config.in
+++ b/nginx/modsecurity/config.in
@@ -33,9 +33,11 @@ HTTP_AUX_FILTER_MODULES="ngx_http_modsecurity $HTTP_AUX_FILTER_MODULES"
 
 NGX_ADDON_SRCS="$NGX_ADDON_SRCS \
 		$ngx_addon_dir/ngx_http_modsecurity.c \
+		$ngx_addon_dir/ngx_http_modsecurity_config_cache.c \
 		$ngx_addon_dir/apr_bucket_nginx.c"
 
 NGX_ADDON_DEPS="$NGX_ADDON_DEPS \
+		$ngx_addon_dir/ngx_http_modsecurity_config_cache.h \
 		$ngx_addon_dir/apr_bucket_nginx.h"
 
 CORE_LIBS="$ngx_addon_dir/../../standalone/.libs/standalone.a $CORE_LIBS"

--- a/nginx/modsecurity/ngx_http_modsecurity_config_cache.c
+++ b/nginx/modsecurity/ngx_http_modsecurity_config_cache.c
@@ -1,0 +1,126 @@
+#include "ngx_http_modsecurity_config_cache.h"
+
+typedef struct {
+    // Must be the first member of the structure because of pointer casts 
+    // used by insert/lookup routines.
+    ngx_rbtree_node_t         rbnode;
+
+    ngx_str_t                 path;
+    directory_config          *config;
+} ngx_http_modsecurity_config_cache_node_t;
+
+/*
+ * Implemented similarly to ngx_string.c#ngx_str_rbtree_insert_value()
+ */
+static void
+ngx_http_modsecurity_config_cache_rbtree_insert_value(ngx_rbtree_node_t *temp,
+    ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel)
+{
+    ngx_rbtree_node_t  **p = NULL;
+    for ( ;; ) {
+
+        ngx_http_modsecurity_config_cache_node_t *n = (ngx_http_modsecurity_config_cache_node_t*) node;
+        ngx_http_modsecurity_config_cache_node_t *t = (ngx_http_modsecurity_config_cache_node_t*) temp;
+
+        if (node->key != temp->key) {
+
+            p = (node->key < temp->key) ? &temp->left : &temp->right;
+
+        } else if (n->path.len != t->path.len) {
+
+            p = (n->path.len < t->path.len) ? &temp->left : &temp->right;
+
+        } else {
+            p = (ngx_strncasecmp(n->path.data, t->path.data, n->path.len) < 0)
+                 ? &temp->left : &temp->right;
+        }
+
+        if (*p == sentinel) {
+            break;
+        }
+
+        temp = *p;
+    }
+
+    *p = node;
+    node->parent = temp;
+    node->left = sentinel;
+    node->right = sentinel;
+    ngx_rbt_red(node);
+}
+
+ngx_http_modsecurity_config_cache_t *ngx_http_modsecurity_config_cache_init(ngx_conf_t *cf)
+{
+    ngx_rbtree_node_t *sentinel = ngx_pcalloc(cf->pool, sizeof(ngx_rbtree_node_t));
+    if (sentinel == NULL) {
+        return NULL;
+    }
+
+    ngx_http_modsecurity_config_cache_t *cache = ngx_pcalloc(cf->pool, sizeof(ngx_http_modsecurity_config_cache_t));
+    if (cache == NULL) {
+        return NULL;
+    }
+
+    ngx_rbtree_init(&cache->rbtree, sentinel, ngx_http_modsecurity_config_cache_rbtree_insert_value);
+    return cache;
+}
+
+ngx_int_t ngx_http_modsecurity_config_cache_insert(
+    ngx_http_modsecurity_config_cache_t* cache, ngx_conf_t *cf,
+    ngx_str_t *path, directory_config *config)
+{
+    ngx_http_modsecurity_config_cache_node_t *node = ngx_pcalloc(cf->pool, sizeof(ngx_http_modsecurity_config_cache_node_t));
+    if (node == NULL) {
+        return NGX_ERROR;
+    }
+
+    node->path.data = ngx_pstrdup(cf->pool, path);
+    node->path.len = path->len;
+    node->rbnode.key = ngx_crc32_long(path->data, path->len);
+    node->config = config;
+
+    ngx_rbtree_insert(&cache->rbtree, &node->rbnode);
+    return NGX_OK;
+}
+
+/*
+ * Implemented similarly to ngx_string.c#ngx_str_rbtree_lookup()
+ */
+directory_config *ngx_http_modsecurity_config_cache_lookup(
+    ngx_http_modsecurity_config_cache_t *cache, ngx_str_t *path)
+{
+    ngx_uint_t hash = ngx_crc32_long(path->data, path->len);
+    ngx_rbtree_node_t *node = cache->rbtree.root;
+    ngx_rbtree_node_t *sentinel = cache->rbtree.sentinel;
+
+    while (node != sentinel) {
+        ngx_http_modsecurity_config_cache_node_t *n = (ngx_http_modsecurity_config_cache_node_t *) node;
+
+        if (hash != node->key) {
+            node = (hash < node->key) ? node->left : node->right;
+            continue;
+        }
+
+        if (path->len != n->path.len) {
+            node = (path->len < n->path.len) ? node->left : node->right;
+            continue;
+        }
+
+        ngx_int_t rc = ngx_memcmp(path->data, n->path.data, path->len);
+
+        if (rc < 0) {
+            node = node->left;
+            continue;
+        }
+
+        if (rc > 0) {
+            node = node->right;
+            continue;
+        }
+
+        return n->config;
+    }
+
+    return NULL;
+
+}

--- a/nginx/modsecurity/ngx_http_modsecurity_config_cache.h
+++ b/nginx/modsecurity/ngx_http_modsecurity_config_cache.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <ngx_core.h>
+#include <ngx_string.h>
+
+/*
+ * ModSecurity configuration cache is used to prevent loading configuration
+ * multiple times if one and the same configuration file is applied in multiple
+ * different contexts.
+ *
+ * The main problem with loading ModSecurity configuration independently for each 
+ * context is that the allocated memory block can be quite large (10-20 Mb) so if, 
+ * for example, the same configuration is used for 10-20 listeners it will cause 
+ * significant memory overuse for no good reason.
+ *
+ * The cache helps alleviate this by storing pointers to configuration objects created
+ * from ModSecurity configuration files and re-using existing objects when the same path
+ * occurs several times during Nginx configuration loading.
+ */
+
+typedef struct directory_config directory_config;
+
+typedef struct {
+    ngx_rbtree_t              rbtree;
+} ngx_http_modsecurity_config_cache_t;
+
+/* Create configuration cache */
+ngx_http_modsecurity_config_cache_t *ngx_http_modsecurity_config_cache_init(ngx_conf_t *cf);
+
+/* Add configuration block for the respective file path into configuration cache */
+ngx_int_t ngx_http_modsecurity_config_cache_insert(ngx_http_modsecurity_config_cache_t *cache,
+    ngx_conf_t *cf, ngx_str_t *path, directory_config *config);
+
+/* Look up configuration block for the respective file path in configuration cache */
+directory_config *ngx_http_modsecurity_config_cache_lookup(ngx_http_modsecurity_config_cache_t *cache,
+    ngx_str_t *path);


### PR DESCRIPTION
The logic of ModSecurity configuration on Nginx is that for each context where ModSecurity is enabled, the configuration is loaded into the memory again even though it can be one and the same file.
This causes unnecessary memory allocations that can be reasonably big (15-20 Mb per a config block) which, in case of dozens of contexts, quickly becomes a problem.

This fix introduces configuration cache that maps file names to the respective configuration blocks and lets ModSecurity re-use already initialized configs rather than allocate and load them anew.

------------------
### Testing
------------------

Before the fix:

_root@vladimir-ubuntu # ps aux | grep nginx
root      86151  0.0  0.2 194908 23572 ?        Ss   11:58   0:00 nginx: master process nginx
www-data  86152  0.0  0.5 **503476** 42296 ?        Sl   11:58   0:00 nginx: worker process
root      86197  0.0  0.0  21292  1076 pts/20   S+   11:58   0:00 grep --color=auto nginx_
(add another listener with the same ModSecConfig file)
_root@vladimir-ubuntu # nginx -s reload
root@vladimir-ubuntu # ps aux | grep nginx
root      86151  0.0  0.6 216936 53068 ?        Ss   11:58   0:00 nginx: master process nginx
www-data  86152  0.0  0.5 503476 42296 ?        Sl   11:58   0:00 nginx: worker process is shutting down
www-data  86243  0.0  0.7 **525504** 64208 ?        Sl   11:59   0:00 nginx: worker process
root      86282  0.0  0.0  21292  1000 pts/20   S+   11:59   0:00 grep --color=auto nginx_

(both listeners behave according to settings)

After the fix:

_root@vladimir-ubuntu # ps aux | grep nginx
root      97600  0.0  0.2 194908 23576 ?        Ss   14:03   0:00 nginx: master process nginx
www-data  97601  0.5  0.5 **503476** 42324 ?        Sl   14:03   0:00 nginx: worker process
root      97646  0.0  0.0  21292  1024 pts/20   S+   14:03   0:00 grep --color=auto nginx_
(add another listener with the same ModSecConfig file)
_root@vladimir-ubuntu # nginx -s reload
root@vladimir-ubuntu # ps aux | grep nginx
root      97600  0.0  0.3 195568 31864 ?        Ss   14:03   0:00 nginx: master process nginx
www-data  97601  0.0  0.5 503476 42324 ?        Sl   14:03   0:00 nginx: worker process is shutting down
www-data  97672  0.0  0.5 **504136** 40800 ?        Sl   14:04   0:00 nginx: worker process
root      97711  0.0  0.0  21292   924 pts/20   S+   14:04   0:00 grep --color=auto nginx_
(both listeners behave according to settings)


Plus:

Tested the case when two listeners had different configurations (A) and (B) and their sub-locations `/hello` had the opposite configs (B) and (A) respectively. The memory consumption after adding sub-locations is the same as before adding them, and all requests are processed according to the configuration that applies based on URI pattern matching.