### PR TITLE
Revert fix for non-blocking detection mode in IIS ModSecurity.

### DIFF
--- a/iis/Makefile.win
+++ b/iis/Makefile.win
@@ -37,8 +37,7 @@ INCLUDES = -I. -I.. \
            -I..\apache2 \
            -I..\standalone \
            -I..\apache2\ag_mdb \
-           -I..\apache2\waf_lock \
-           -Iasio\asio\include
+           -I..\apache2\waf_lock
 
 # Enables support for SecRemoteRules and external resources.
 DEFS=$(DEFS) -DWITH_CURL -DWITH_REMOTE_RULES

--- a/iis/mymodule.h
+++ b/iis/mymodule.h
@@ -14,9 +14,6 @@
 
 #pragma once
 
-#define ASIO_STANDALONE
-#include "asio/thread_pool.hpp"
-
 #include "critical_section.h"
 #include "event_logger.h"
 
@@ -40,7 +37,6 @@ public:
 private:
     CriticalSection cs;
     EventLogger logger;
-    asio::thread_pool threadPool{12};
     DWORD pageSize = 0;
     bool statusCallAlreadySent = false;
 };


### PR DESCRIPTION
## Description
The fix appears to not behave well under heavy load when IIS runs many
threads (up to 200). Further investigation and improvements are due.

Signed-off-by: Vladimir Krivopalov <vlkrivop@microsoft.com>

## Testing
Tested on WAF v1 gateway for both detection and prevention modes, body check enabled or disabled.
WAF works as expected, the processing time is the same for detection and prevention mode (as expected).