### PR TITLE
Add timestamp to logs

### DIFF
--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -318,7 +318,7 @@ static int write_file_with_lock(struct waf_lock* lock, apr_file_t* fd, char* str
 /**
  * send all waf fields in json format to a file.
  */
-static void send_waf_log(struct waf_lock* lock, apr_file_t* fd, const char* str1, const char* ip_port, const char* uri, int mode, const char* hostname, char* unique_id, request_rec *r, const char* waf_policy_id, const char* waf_policy_scope, const char* waf_policy_scope_name) {
+static void send_waf_log(const char* timestamp, struct waf_lock* lock, apr_file_t* fd, const char* str1, const char* ip_port, const char* uri, int mode, const char* hostname, char* unique_id, request_rec *r, const char* waf_policy_id, const char* waf_policy_scope, const char* waf_policy_scope_name) {
     char waf_filename[1024] = "";
     char waf_line[1024] = "";
     char waf_id[1024] = "";
@@ -344,7 +344,7 @@ static void send_waf_log(struct waf_lock* lock, apr_file_t* fd, const char* str1
     get_short_filename(waf_filename);
     get_ruleset_type_version(waf_ruleset_info, waf_ruleset_type, waf_ruleset_version); 
 
-    char* json_str = generate_json(msc_waf_resourceId, WAF_LOG_UTIL_OPERATION_NAME, WAF_LOG_UTIL_CATEGORY, msc_waf_instanceId, waf_ip, waf_port, uri, waf_ruleset_type, waf_ruleset_version, waf_id, waf_message, mode, 0, waf_detail_message, waf_data, waf_filename, waf_line, hostname, waf_unique_id, waf_policy_id, waf_policy_scope, waf_policy_scope_name);
+    char* json_str = generate_json(timestamp, msc_waf_resourceId, WAF_LOG_UTIL_OPERATION_NAME, WAF_LOG_UTIL_CATEGORY, msc_waf_instanceId, waf_ip, waf_port, uri, waf_ruleset_type, waf_ruleset_version, waf_id, waf_message, mode, 0, waf_detail_message, waf_data, waf_filename, waf_line, hostname, waf_unique_id, waf_policy_id, waf_policy_scope, waf_policy_scope_name);
     if (!json_str) {
 #if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER > 2
        ap_log_rerror(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, r,
@@ -478,7 +478,7 @@ static void internal_log_ex(request_rec *r, directory_config *dcfg, modsec_rec *
             msc_waf_log_reopened = 0;
         }
 
-        send_waf_log(msr->modsecurity->wafjsonlog_lock, msc_waf_log_fd, str1, r->useragent_ip ? r->useragent_ip : r->connection->client_ip, log_escape(msr->mp, r->uri), dcfg->is_enabled, r->hostname, unique_id, r, dcfg->waf_policy_id, dcfg->waf_policy_scope, dcfg->waf_policy_scope_name);
+        send_waf_log(current_logtime(msr->mp), msr->modsecurity->wafjsonlog_lock, msc_waf_log_fd, str1, r->useragent_ip ? r->useragent_ip : r->connection->client_ip, log_escape(msr->mp, r->uri), dcfg->is_enabled, r->hostname, unique_id, r, dcfg->waf_policy_id, dcfg->waf_policy_scope, dcfg->waf_policy_scope_name);
 #endif
 
 #if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER > 2

--- a/apache2/waf_logging/waf_log_util.cc
+++ b/apache2/waf_logging/waf_log_util.cc
@@ -40,6 +40,7 @@ struct property
 
 struct waf_log
 {
+    jsoncons::string_view timeStamp;
     jsoncons::string_view resourceId;
     jsoncons::string_view operationName;
     jsoncons::string_view category;
@@ -50,7 +51,7 @@ struct waf_log
 
 JSONCONS_TYPE_TRAITS_DECL(waf_logging::detail, message, data, file, line);
 JSONCONS_TYPE_TRAITS_DECL(waf_logging::property, instanceId, clientIp, clientPort, requestUri, ruleSetType, ruleSetVersion, ruleId, message, action, site, details, hostname, transactionId, policyId, policyScope, policyScopeName);
-JSONCONS_TYPE_TRAITS_DECL(waf_logging::waf_log, resourceId, operationName, category, properties);
+JSONCONS_TYPE_TRAITS_DECL(waf_logging::waf_log, timeStamp, resourceId, operationName, category, properties);
 
 static std::string to_json_string(const waf_logging::waf_log& log) {
     jsoncons::json_options options;
@@ -124,10 +125,10 @@ static bool is_mandatory_rule(const rule_set_types type, const rule_set_versions
     return contains_current_id(current_rule_ids);
 }
 
-static std::string get_json_log_message(const char* resource_id, const char* operation_name, const char* category,
-        const char* instance_id, const char* client_ip, const char* client_port, const char* request_uri,
-        const char* rule_set_type, const char* rule_set_version, const char* rule_id, const char* messages,
-        const int action, const int site, const char* details_messages, const char* details_data,
+static std::string get_json_log_message(const char* timestamp, const char* resource_id, const char* operation_name, 
+        const char* category, const char* instance_id, const char* client_ip, const char* client_port, 
+        const char* request_uri, const char* rule_set_type, const char* rule_set_version, const char* rule_id, 
+        const char* messages, const int action, const int site, const char* details_messages, const char* details_data,
         const char* details_file, const char* details_line, const char* hostname, const char* waf_unique_id,
         const char* waf_policy_id, const char* waf_policy_scope, const char* waf_policy_scope_name) {
 
@@ -185,26 +186,27 @@ static std::string get_json_log_message(const char* resource_id, const char* ope
     const str_view waf_unique_id_str = make_string_view_strip_quotes(waf_unique_id);
 
     return to_json_string({
-            resource_id,
-            operation_name,
-            category,
-            waf_logging::property {
-                instance_id,
-                client_ip,
-                client_port,
-                request_uri,
-                rule_set_type,
-                rule_set_version,
-                rule_id_str,
-                message_str,
-                action_str,
-                site_str,
-                waf_logging::detail {
-                    details_messages,
-                    details_data_str,
-                    details_file_str,
-                    details_line_str
-                },
+        timestamp,
+        resource_id,
+        operation_name,
+        category,
+        waf_logging::property {
+            instance_id,
+            client_ip,
+            client_port,
+            request_uri,
+            rule_set_type,
+            rule_set_version,
+            rule_id_str,
+            message_str,
+            action_str,
+            site_str,
+            waf_logging::detail {
+                details_messages,
+                details_data_str,
+                details_file_str,
+                details_line_str
+            },
             hostname,
             waf_unique_id_str,
             waf_policy_id,
@@ -215,7 +217,7 @@ static std::string get_json_log_message(const char* resource_id, const char* ope
 }
 
 // Get fields from ModSec and format them to JSON.
-char* generate_json(const char* resource_id, const char* operation_name, const char* category,
+char* generate_json(const char* timestamp, const char* resource_id, const char* operation_name, const char* category,
         const char* instance_id, const char* client_ip, const char* client_port, const char* request_uri,
         const char* rule_set_type, const char* rule_set_version, const char* rule_id, const char* messages,
         const int action, const int site, const char* details_messages, const char* details_data,
@@ -223,7 +225,7 @@ char* generate_json(const char* resource_id, const char* operation_name, const c
         const char* waf_policy_id, const char* waf_policy_scope, const char* waf_policy_scope_name) {
     
     try {
-        const std::string json_string = get_json_log_message(resource_id, operation_name, category,
+        const std::string json_string = get_json_log_message(timestamp, resource_id, operation_name, category,
                 instance_id, client_ip, client_port, request_uri, rule_set_type, rule_set_version,
                 rule_id, messages, action, site, details_messages, details_data, details_file,
                 details_line, hostname, waf_unique_id, waf_policy_id, waf_policy_scope, waf_policy_scope_name);

--- a/apache2/waf_logging/waf_log_util.h
+++ b/apache2/waf_logging/waf_log_util.h
@@ -17,7 +17,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-char* generate_json(const char* resourceId, const char* operationName, const char* category, const char* instanceId, const char* clientIP, const char* clientPort, const char* requestUri, const char* ruleSetType, const char* ruleSetVersion, const char* ruleId, const char* messages, const int action, const int site, const char* details_messages, const char* details_data, const char* details_file, const char* details_line, const char* hostname, const char* waf_unique_id,
+char* generate_json(const char* timestamp, const char* resourceId, const char* operationName, const char* category, const char* instanceId, const char* clientIP, const char* clientPort, const char* requestUri, const char* ruleSetType, const char* ruleSetVersion, const char* ruleId, const char* messages, const int action, const int site, const char* details_messages, const char* details_data, const char* details_file, const char* details_line, const char* hostname, const char* waf_unique_id,
 const char* waf_policy_id, const char* waf_policy_scope, const char* waf_policy_scope_name);
 void free_json(char* str);
 // Returns 0 if succeeded, non-zero code otherwise


### PR DESCRIPTION
**Summary:**
Add timestamps to modsecurity logs

**Output:**
```
{
    "time": "30/Jul/2019:19:32:07 +0000",
    "resourceId": "/A/B/C",
    "operationName": "ApplicationGatewayFirewall",
    "category": "ApplicationGatewayFirewallLog",
    "properties": {
        "instanceId": "dummyRole_0",
        "clientIp": "127.0.0.1",
        "clientPort": "",
        "requestUri": "/",
        "ruleSetType": "OWASP_CRS",
        "ruleSetVersion": "3.0.0",
        "ruleId": "920350",
        "message": "Host header is a numeric IP address",
        "action": "Matched",
        "site": "Global",
        "details": {
            "message": "Warning. Pattern match \"^[\\d.:]+$\" at REQUEST_HEADERS:Host .... ",
            "data": "127.0.0.1",
            "file": "rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf",
            "line": "791"
        },
        "hostname": "127.0.0.1",
        "transactionId": "AcwcHcAX7cAcAcAcAcAcAcAc"
    }
}
```

**Testing:**
Tested locally by updating the modsecurity submodule in AppGW to this branch's latest commit