### PR TITLE
Log WAF policy context information

### DIFF
--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -318,7 +318,7 @@ static int write_file_with_lock(struct waf_lock* lock, apr_file_t* fd, char* str
 /**
  * send all waf fields in json format to a file.
  */
-static void send_waf_log(struct waf_lock* lock, apr_file_t* fd, const char* str1, const char* ip_port, const char* uri, int mode, const char* hostname, char* unique_id, request_rec *r) {
+static void send_waf_log(struct waf_lock* lock, apr_file_t* fd, const char* str1, const char* ip_port, const char* uri, int mode, const char* hostname, char* unique_id, request_rec *r, const char* waf_policy_id, const char* waf_policy_scope, const char* waf_policy_scope_name) {
     char waf_filename[1024] = "";
     char waf_line[1024] = "";
     char waf_id[1024] = "";
@@ -344,7 +344,7 @@ static void send_waf_log(struct waf_lock* lock, apr_file_t* fd, const char* str1
     get_short_filename(waf_filename);
     get_ruleset_type_version(waf_ruleset_info, waf_ruleset_type, waf_ruleset_version); 
 
-    char* json_str = generate_json(msc_waf_resourceId, WAF_LOG_UTIL_OPERATION_NAME, WAF_LOG_UTIL_CATEGORY, msc_waf_instanceId, waf_ip, waf_port, uri, waf_ruleset_type, waf_ruleset_version, waf_id, waf_message, mode, 0, waf_detail_message, waf_data, waf_filename, waf_line, hostname, waf_unique_id);
+    char* json_str = generate_json(msc_waf_resourceId, WAF_LOG_UTIL_OPERATION_NAME, WAF_LOG_UTIL_CATEGORY, msc_waf_instanceId, waf_ip, waf_port, uri, waf_ruleset_type, waf_ruleset_version, waf_id, waf_message, mode, 0, waf_detail_message, waf_data, waf_filename, waf_line, hostname, waf_unique_id, waf_policy_id, waf_policy_scope, waf_policy_scope_name);
     if (!json_str) {
 #if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER > 2
        ap_log_rerror(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, r,
@@ -478,7 +478,7 @@ static void internal_log_ex(request_rec *r, directory_config *dcfg, modsec_rec *
             msc_waf_log_reopened = 0;
         }
 
-        send_waf_log(msr->modsecurity->wafjsonlog_lock, msc_waf_log_fd, str1, r->useragent_ip ? r->useragent_ip : r->connection->client_ip, log_escape(msr->mp, r->uri), dcfg->is_enabled, r->hostname, unique_id, r);
+        send_waf_log(msr->modsecurity->wafjsonlog_lock, msc_waf_log_fd, str1, r->useragent_ip ? r->useragent_ip : r->connection->client_ip, log_escape(msr->mp, r->uri), dcfg->is_enabled, r->hostname, unique_id, r, dcfg->waf_policy_id, dcfg->waf_policy_scope, dcfg->waf_policy_scope_name);
 #endif
 
 #if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER > 2

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -615,6 +615,11 @@ struct directory_config {
     int                 stream_inbody_inspection;
     int                 stream_outbody_inspection;
 
+    /* WAF policy identification information */
+    const char          *waf_policy_id;
+    const char          *waf_policy_scope;
+    const char          *waf_policy_scope_name;
+
     /* Geo Lookup */
     geo_db              *geo;
 

--- a/apache2/waf_logging/waf_log_util.cc
+++ b/apache2/waf_logging/waf_log_util.cc
@@ -173,6 +173,10 @@ static std::string get_json_log_message(const char* resource_id, const char* ope
         }
     }
 
+    /* For historical reasons, the "site" property is included in log messages.
+     * However, it does not carry any useful meaning.
+     * We keep it around for compatibility reasons but may consider removing it at some point in the future.
+     */
     const str_view site_str = (site == 0) ? "Global" : str_view{};
 
     const str_view details_file_str = details_file ? str_view {details_file, strlen(details_file) - 1} : str_view{};

--- a/apache2/waf_logging/waf_log_util.cc
+++ b/apache2/waf_logging/waf_log_util.cc
@@ -33,6 +33,9 @@ struct property
     detail details;
     jsoncons::string_view hostname;
     jsoncons::string_view transactionId;
+    jsoncons::string_view policyId;
+    jsoncons::string_view policyScope;
+    jsoncons::string_view policyScopeName;
 };
 
 struct waf_log
@@ -46,7 +49,7 @@ struct waf_log
 }   // namespace waf_logging
 
 JSONCONS_TYPE_TRAITS_DECL(waf_logging::detail, message, data, file, line);
-JSONCONS_TYPE_TRAITS_DECL(waf_logging::property, instanceId, clientIp, clientPort, requestUri, ruleSetType, ruleSetVersion, ruleId, message, action, site, details, hostname, transactionId);
+JSONCONS_TYPE_TRAITS_DECL(waf_logging::property, instanceId, clientIp, clientPort, requestUri, ruleSetType, ruleSetVersion, ruleId, message, action, site, details, hostname, transactionId, policyId, policyScope, policyScopeName);
 JSONCONS_TYPE_TRAITS_DECL(waf_logging::waf_log, resourceId, operationName, category, properties);
 
 static std::string to_json_string(const waf_logging::waf_log& log) {
@@ -125,7 +128,8 @@ static std::string get_json_log_message(const char* resource_id, const char* ope
         const char* instance_id, const char* client_ip, const char* client_port, const char* request_uri,
         const char* rule_set_type, const char* rule_set_version, const char* rule_id, const char* messages,
         const int action, const int site, const char* details_messages, const char* details_data,
-        const char* details_file, const char* details_line, const char* hostname, const char* waf_unique_id) {
+        const char* details_file, const char* details_line, const char* hostname, const char* waf_unique_id,
+        const char* waf_policy_id, const char* waf_policy_scope, const char* waf_policy_scope_name) {
 
     using str_view = jsoncons::string_view;
     const auto make_string_view_strip_quotes = [] (const char* str) -> str_view {
@@ -198,7 +202,10 @@ static std::string get_json_log_message(const char* resource_id, const char* ope
                     details_line_str
                 },
             hostname,
-            waf_unique_id_str
+            waf_unique_id_str,
+            waf_policy_id,
+            waf_policy_scope,
+            waf_policy_scope_name
         }
     });
 }
@@ -208,13 +215,14 @@ char* generate_json(const char* resource_id, const char* operation_name, const c
         const char* instance_id, const char* client_ip, const char* client_port, const char* request_uri,
         const char* rule_set_type, const char* rule_set_version, const char* rule_id, const char* messages,
         const int action, const int site, const char* details_messages, const char* details_data,
-        const char* details_file, const char* details_line, const char* hostname, const char* waf_unique_id) {
+        const char* details_file, const char* details_line, const char* hostname, const char* waf_unique_id,
+        const char* waf_policy_id, const char* waf_policy_scope, const char* waf_policy_scope_name) {
     
     try {
         const std::string json_string = get_json_log_message(resource_id, operation_name, category,
                 instance_id, client_ip, client_port, request_uri, rule_set_type, rule_set_version,
                 rule_id, messages, action, site, details_messages, details_data, details_file,
-                details_line, hostname, waf_unique_id);
+                details_line, hostname, waf_unique_id, waf_policy_id, waf_policy_scope, waf_policy_scope_name);
         char* result = static_cast<char*>(std::malloc(json_string.length() + 2)); // Two extra bytes for \n and \0
         std::copy(json_string.begin(), json_string.end(), result);
         result[json_string.length()] = '\n';

--- a/apache2/waf_logging/waf_log_util.h
+++ b/apache2/waf_logging/waf_log_util.h
@@ -17,7 +17,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-char* generate_json(const char* resourceId, const char* operationName, const char* category, const char* instanceId, const char* clientIP, const char* clientPort, const char* requestUri, const char* ruleSetType, const char* ruleSetVersion, const char* ruleId, const char* messages, const int action, const int site, const char* details_messages, const char* details_data, const char* details_file, const char* details_line, const char* hostname, const char* waf_unique_id);
+char* generate_json(const char* resourceId, const char* operationName, const char* category, const char* instanceId, const char* clientIP, const char* clientPort, const char* requestUri, const char* ruleSetType, const char* ruleSetVersion, const char* ruleId, const char* messages, const int action, const int site, const char* details_messages, const char* details_data, const char* details_file, const char* details_line, const char* hostname, const char* waf_unique_id,
+const char* waf_policy_id, const char* waf_policy_scope, const char* waf_policy_scope_name);
 void free_json(char* str);
 // Returns 0 if succeeded, non-zero code otherwise
 int init_appgw_rules_id_hash();


### PR DESCRIPTION
## Description

With the introduction of per-site/per-URI support in WAF, we are going to have multiple WAF policies assigned to different contexts (global, listeners and locations) within a single gateway.
In order to be able to filter out messages for a specific policy and context, we need to log the following details:

- WAF policy identifier
- WAF scope (global, per-listener, per-location)
- WAF scope name

This fix adds corresponding functionality to ModSecurity.

## Testing

Tested locally with two different WAF policies and checked WAF log file with `tail -f`:
```
...
{
    "resourceId": "dummyResourceId", 
    "operationName": "ApplicationGatewayFirewall", 
    "category": "ApplicationGatewayFirewallLog", 
    "properties": {
        "instanceId": "dummyInstanceId", 
        "clientIp": "127.0.0.1", 
        "clientPort": "", 
        "requestUri": "/", 
        "ruleSetType": "", 
        "ruleSetVersion": "", 
        "ruleId": "980130", 
        "message": "Mandatory rule. Cannot be disabled. Inbound Anomaly Score Exceeded (Total Inbound Score: 5 - SQLI=5,XSS=0,RFI=0,LFI=0,RCE=0,PHPI=0,HTTP=0,SESS=0): SQL Injection Attack: SQL Tautology Detected.", 
        "action": "Blocked", 
        "site": "Global", 
        "details": {
            "message": "Warning. Operator GE matched 5 at TX:inbound_anomaly_score. ", 
            "data": "", 
            "file": "rules/RESPONSE-980-CORRELATION.conf", 
            "line": "73"
        }, 
        "hostname": "localhost:8080", 
        "transactionId": "zcAcAcAcAcAcWcA1AVAcAcAc", 
        "policyId": "secondPolicy", 
        "policyScope": "location", 
        "policyScopeName": "Two"
    }
}
{
    "resourceId": "dummyResourceId", 
    "operationName": "ApplicationGatewayFirewall", 
    "category": "ApplicationGatewayFirewallLog", 
    "properties": {
        "instanceId": "dummyInstanceId", 
        "clientIp": "127.0.0.1", 
        "clientPort": "", 
        "requestUri": "/", 
        "ruleSetType": "OWASP_CRS", 
        "ruleSetVersion": "3.0.0", 
        "ruleId": "942130", 
        "message": "SQL Injection Attack: SQL Tautology Detected.", 
        "action": "Matched", 
        "site": "Global", 
        "details": {
            "message": "Warning. Pattern match \"(?i:([\\s'\"`\\(\\)]*?)([\\d\\w]++)([\\s'\"`\\(\\)]*?)(?:(?:=|<=>|r?like|sounds\\s+like|regexp)([\\s'\"`\\(\\)]*?)\\2|(?:!=|<=|>=|<>|<|>|\\^|is\\s+not|not\\s+like|not\\s+regexp)([\\s'\"`\\(\\)]*?)(?!\\2)([\\d\\w]+)))\" at ARGS:svs .... ", 
            "data": "Matched Data: 1=1 found within ARGS:svs: 1=1", 
            "file": "rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf", 
            "line": "554"
        }, 
        "hostname": "localhost", 
        "transactionId": "GcAcAaDcYUAMGcAcgcABAcAc", 
        "policyId": "FirstPolicy", 
        "policyScope": "listener", 
        "policyScopeName": "One"
    }
}

...
```

Also tested that empty values are inserted when corresponding directives are missing from the ModSecurity configuration file.