### PR TITLE
Fix allow action for logging 

### DIFF
--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -478,7 +478,7 @@ static void internal_log_ex(request_rec *r, directory_config *dcfg, modsec_rec *
             msc_waf_log_reopened = 0;
         }
 
-        send_waf_log(msr->modsecurity->wafjsonlog_lock, msc_waf_log_fd, str1, r->useragent_ip ? r->useragent_ip : r->connection->client_ip, log_escape(msr->mp, r->uri), dcfg->is_enabled, r->hostname, unique_id, r, dcfg->waf_policy_id, dcfg->waf_policy_scope, dcfg->waf_policy_scope_name);
+        send_waf_log(msr->modsecurity->wafjsonlog_lock, msc_waf_log_fd, str1, r->useragent_ip ? r->useragent_ip : r->connection->client_ip, log_escape(msr->mp, r->uri), (!msr->allow_scope) ? dcfg->is_enabled : msr->allow_scope, r->hostname, unique_id, r, dcfg->waf_policy_id, dcfg->waf_policy_scope, dcfg->waf_policy_scope_name);
 #endif
 
 #if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER > 2

--- a/apache2/waf_logging/waf_log_util.cc
+++ b/apache2/waf_logging/waf_log_util.cc
@@ -111,6 +111,7 @@ static std::map<rule_set_info, rule_ids_vector> disableable_rule_ids_map;
 static const std::string WAF_ACTION_BLOCKED {"Blocked"};
 static const std::string WAF_ACTION_DETECTED {"Detected"};
 static const std::string WAF_ACTION_MATCHED {"Matched"};
+static const std::string WAF_ACTION_ALLOWED {"Allowed"};
 
 static bool is_mandatory_rule(const rule_set_types type, const rule_set_versions version, const int current_id) {
     const auto contains_current_id = [current_id] (const rule_ids_vector& rule_ids) {
@@ -150,9 +151,10 @@ static std::string get_json_log_message(const char* resource_id, const char* ope
     const bool is_mandatory = is_mandatory_rule(type, version, current_id);
 
     const str_view action_str =
-        (version != rule_set_versions::VERSION_2_2_9 && !is_mandatory)  ? WAF_ACTION_MATCHED :
-        action == MODSEC_MODE_DETECT                                    ? WAF_ACTION_DETECTED :
-        action == MODSEC_MODE_PREVENT                                   ? WAF_ACTION_BLOCKED :
+        (action == ACTION_ALLOW || action == ACTION_ALLOW_REQUEST || action == ACTION_ALLOW_PHASE) ? WAF_ACTION_ALLOWED :
+        (version != rule_set_versions::VERSION_2_2_9 && !is_mandatory)                             ? WAF_ACTION_MATCHED :
+        action == MODSEC_MODE_DETECT                                                               ? WAF_ACTION_DETECTED :
+        action == MODSEC_MODE_PREVENT                                                              ? WAF_ACTION_BLOCKED :
         str_view{};
 
     #define MANDATORY_RULE_MESSAGE ("Mandatory rule. Cannot be disabled. ")

--- a/apache2/waf_logging/waf_log_util.h
+++ b/apache2/waf_logging/waf_log_util.h
@@ -5,6 +5,9 @@
 #define WAF_LOG_UTIL_SUCCESS 0
 #define MODSEC_MODE_DETECT 1
 #define MODSEC_MODE_PREVENT 2
+#define ACTION_ALLOW 5
+#define ACTION_ALLOW_REQUEST 6
+#define ACTION_ALLOW_PHASE 7
 #define WAF_RULESET_PREFIX "/RuleSets/"
 #define WAF_LOG_UTIL_FILE "waf_json.log"
 #define WAF_LOG_UTIL_OPERATION_NAME "ApplicationGatewayFirewall"

--- a/apache2/waf_logging/waf_log_util.h
+++ b/apache2/waf_logging/waf_log_util.h
@@ -5,9 +5,12 @@
 #define WAF_LOG_UTIL_SUCCESS 0
 #define MODSEC_MODE_DETECT 1
 #define MODSEC_MODE_PREVENT 2
+
+// ACTION_ALLOW/ACTION_ALLOW_REQUEST/ACTION_ALLOW_PHASE are defined in the modsecurity.h and copied here
 #define ACTION_ALLOW 5
 #define ACTION_ALLOW_REQUEST 6
 #define ACTION_ALLOW_PHASE 7
+
 #define WAF_RULESET_PREFIX "/RuleSets/"
 #define WAF_LOG_UTIL_FILE "waf_json.log"
 #define WAF_LOG_UTIL_OPERATION_NAME "ApplicationGatewayFirewall"


### PR DESCRIPTION
when the action is allow, instead of log it with Matched or Blocked, it should be Allowed,

the example:
{
    "resourceId": "resource",
    "operationName": "ApplicationGatewayFirewall",
    "category": "ApplicationGatewayFirewallLog",
    "properties": {
        "instanceId": "abc",
        "clientIp": "127.0.0.1",
        "clientPort": "",
        "requestUri": "/",
        "ruleSetType": "",
        "ruleSetVersion": "",
        "ruleId": "1",
        "message": "Mandatory rule. Cannot be disabled. Custom rule with name: bb'bb, priority: 1",
        "action": "Allowed",
        "site": "Global",
        "details": {
            "message": "Access allowed (phase 2). Pattern match \"abc\" at ARGS:hello .... ",
            "data": "",
            "file": "\"/home/yanszhao/Share/Dev/nginx-mod2-json/conf/modsecurity_conf_new/mod-crs-3.0-responseOff-noinitcol.conf",
            "line": "6"
        },
        "hostname": "localhost:8080",
        "transactionId": "XcAfAoAcAY2cAcAcAcAtFxAc",
        "policyId": "",
        "policyScope": "",
        "policyScopeName": ""
    }
}
