### PR TITLE
Exclude `waf_iis` branch from Travis CI builds for Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 # As such, it should not be built on Linux.
 branches:
   except:
-    - iis_maintenance
+    - waf_iis
 
 install: 
 # Setting up docker credentials.


### PR DESCRIPTION
The `waf_iis` branch is dedicated to Windows development and as such is not intended, nor required, to stay Linux-compatible. 

Signed-off-by: Vladimir Krivopalov <vlkrivop@microsoft.com>