### PR TITLE
Validation utility for ModSecurity configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,4 +92,5 @@ tests/run-unit-tests.pl
 tools/Makefile
 tools/Makefile.in
 tools/rules-updater.pl
+validator/validator
 nginx/modsecurity/config

--- a/configure.ac
+++ b/configure.ac
@@ -204,7 +204,7 @@ AC_ARG_ENABLE(standalone-module,
 ])
 AM_CONDITIONAL([BUILD_STANDALONE_MODULE], [test "$build_standalone_module" -eq 1])
 if test "$build_standalone_module" -eq 1; then
-  TOPLEVEL_SUBDIRS="$TOPLEVEL_SUBDIRS standalone"
+  TOPLEVEL_SUBDIRS="$TOPLEVEL_SUBDIRS standalone validator"
 fi
 
 
@@ -596,6 +596,8 @@ AC_ARG_ENABLE(waf_json_logging,
   waf_json_logging=""
 ])
 
+root_include="-I"`pwd`
+
 # Always Enable json waf logging support
 waf_lock="-I"`pwd`"/apache2/waf_lock"
 
@@ -865,7 +867,7 @@ else
   fi
 fi
 
-MODSEC_EXTRA_CFLAGS="$pcre_study $pcre_match_limit $pcre_match_limit_recursion $pcre_jit $request_early $htaccess_config $lua_cache $debug_conf $debug_cache $debug_acmp $debug_mem $perf_meas $modsec_api $cpu_type $unique_id $log_filename $log_server $log_collection_delete_problem $log_dechunk $log_stopwatch $log_handler $log_server_context $collection_global_lock $large_stream_input $collection_memory_database $waf_json_logging $waf_lock"
+MODSEC_EXTRA_CFLAGS="$pcre_study $pcre_match_limit $pcre_match_limit_recursion $pcre_jit $request_early $htaccess_config $lua_cache $debug_conf $debug_cache $debug_acmp $debug_mem $perf_meas $modsec_api $cpu_type $unique_id $log_filename $log_server $log_collection_delete_problem $log_dechunk $log_stopwatch $log_handler $log_server_context $collection_global_lock $large_stream_input $collection_memory_database $waf_json_logging $root_include $waf_lock"
 
 APXS_WRAPPER=build/apxs-wrapper
 APXS_EXTRA_CFLAGS=""
@@ -958,6 +960,7 @@ fi
 if test "$build_standalone_module" -ne 0; then
 AC_CONFIG_FILES([standalone/Makefile])
 AC_CONFIG_FILES([nginx/modsecurity/config])
+AC_CONFIG_FILES([validator/Makefile])
 fi
 if test "$build_extentions" -ne 0; then
 AC_CONFIG_FILES([ext/Makefile])

--- a/validator/Makefile.am
+++ b/validator/Makefile.am
@@ -1,0 +1,43 @@
+bin_PROGRAMS = validator
+
+validator_SOURCES = main.c
+
+    # FIXME: Standalone does not mean that it will be a nginx build.
+validator_CFLAGS = -DVERSION_NGINX \
+    @APR_CFLAGS@ \
+    @APU_CFLAGS@ \
+    @APXS_CFLAGS@ \
+    @CURL_CFLAGS@ \
+    @LIBXML2_CFLAGS@ \
+    @LUA_CFLAGS@ \
+    @MODSEC_EXTRA_CFLAGS@ \
+    @PCRE_CFLAGS@ \
+    @YAJL_CFLAGS@ \
+    @SSDEEP_CFLAGS@
+
+validator_CPPFLAGS = @APR_CPPFLAGS@ \
+    @LIBXML2_CPPFLAGS@ \
+    @PCRE_CPPFLAGS@
+
+validator_LDADD = ../standalone/.libs/standalone.a \
+    @APR_LDADD@ \
+    @APU_LDADD@ \
+    @CURL_LDADD@ \
+    @LIBXML2_LDADD@ \
+    @LUA_LDADD@ \
+    @PCRE_LDADD@ \
+    @YAJL_LDADD@ \
+    -lstdc++ \
+    -lm
+	
+validator_LDFLAGS = -no-undefined -module -avoid-version \
+    @APR_LDFLAGS@ \
+    @APU_LDFLAGS@ \
+    @CURL_LDFLAGS@ \
+    @APXS_LDFLAGS@ \
+    @LIBXML2_LDFLAGS@ \
+    @LUA_LDFLAGS@ \
+    @PCRE_LDFLAGS@ \
+    @YAJL_LDFLAGS@ \
+    @SSDEEP_LDFLAGS@
+

--- a/validator/main.c
+++ b/validator/main.c
@@ -1,0 +1,44 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include "standalone/api.h"
+
+static void print_log(void* obj, int level, char* str)
+{
+    if (str != NULL) {
+        puts(str);
+    }
+}
+
+static void exit_with_error(const char* msg)
+{
+    puts(msg);
+    exit(EXIT_FAILURE);
+}
+
+int main(int argc, char* argv[])
+{
+    if (argc != 2) {
+        exit_with_error("Invalid number of command line arguments");
+    }
+
+    server_rec* modsec_server = modsecInit();
+    if (modsec_server == NULL) {
+        exit_with_error("Failed to create ModSecurity server structure");        
+    }
+    char hostname[] = "localhost";
+    modsec_server->server_hostname = hostname;
+
+    modsecSetLogHook(NULL, print_log);
+    modsecStartConfig();
+    directory_config *config = modsecGetDefaultConfig();
+    if (config == NULL) {
+        exit_with_error("Error creating default config");
+    }
+
+    const char *err = modsecProcessConfig(config, argv[1], NULL);
+    if (err != NULL) {
+        exit_with_error(err);
+    }
+
+    exit(EXIT_SUCCESS);
+}


### PR DESCRIPTION
## Description
This utility attemps to load ModSecurity configuraiton and reports the
status. It also outputs to stdout any logs that may be emitted by
ModSecurity engine during configuration loading.

## Testing
1. Tested manually with the following scenarios:
  a) Clean and valid ModSecurity configuration - no output, OK status code.
  b) Syntax error in the main configuration file - error message output, failure status code
  c) Syntax error in a configuration file included from the main file - error message output, failure status code
  d) Invalid syntax that does not cause config load failure: `SecRuleUpdateTargetById 10001-999999 "!REQUEST_COOKIES:'idsrv\\.external'"` - error message output, OK status code.

2. Integrated with AppGW&WAF OneBox and unit tests and made sure they have all passed fine.

Signed-off-by: Vladimir Krivopalov <vlkrivop@microsoft.com>