### PR TITLE
Pass scope info through nginx.conf instead of modsecurity.conf

### DIFF
--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -127,8 +127,6 @@ void *create_directory_config(apr_pool_t *mp, char *path)
 
     /* WAF policy identification information */
     dcfg->waf_policy_id = NOT_SET_P;
-    dcfg->waf_policy_scope = NOT_SET_P;
-    dcfg->waf_policy_scope_name = NOT_SET_P;
 
     /* Geo Lookups */
     dcfg->geo = NOT_SET_P;
@@ -576,10 +574,6 @@ void *merge_directory_configs(apr_pool_t *mp, void *_parent, void *_child)
     /* WAF policy identification information */
     merged->waf_policy_id = (child->waf_policy_id == NOT_SET_P
         ? parent->waf_policy_id : child->waf_policy_id);
-    merged->waf_policy_scope = (child->waf_policy_scope == NOT_SET_P
-        ? parent->waf_policy_scope : child->waf_policy_scope);
-    merged->waf_policy_scope_name = (child->waf_policy_scope_name == NOT_SET_P
-        ? parent->waf_policy_scope_name : child->waf_policy_scope_name);
 
     /* Geo Lookup */
     merged->geo = (child->geo == NOT_SET_P
@@ -745,8 +739,6 @@ void init_directory_config(directory_config *dcfg)
 
     /* WAF policy identification information */
     if (dcfg->waf_policy_id == NOT_SET_P) dcfg->waf_policy_id = "";
-    if (dcfg->waf_policy_scope == NOT_SET_P) dcfg->waf_policy_scope = "";
-    if (dcfg->waf_policy_scope_name == NOT_SET_P) dcfg->waf_policy_scope_name = "";
 
     /* Geo Lookup */
     if (dcfg->geo == NOT_SET_P) dcfg->geo = NULL;
@@ -1828,54 +1820,6 @@ static const char *cmd_waf_policy_id(cmd_parms *cmd, void *_dcfg, const char *p1
     }
 
     dcfg->waf_policy_id = p1;
-    return NULL;
-}
-
-/**
-* \brief Add SecWafPolicyScope configuration option
-*
-* \param cmd Pointer to configuration data
-* \param _dcfg Pointer to directory configuration
-* \param p1 Pointer to configuration option
-*
-* \retval NULL On Success
-* \retval apr_psprintf On Failue
-*/
-static const char *cmd_waf_policy_scope(cmd_parms *cmd, void *_dcfg, const char *p1)
-{
-    directory_config *dcfg = (directory_config *)_dcfg;
-    if (dcfg == NULL) {
-        return NULL;
-    }
-    if (p1 == NULL) {
-        return apr_psprintf(cmd->pool, "ModSecurity: No valid SecWafPolicyScope specified.");
-    }
-
-    dcfg->waf_policy_scope = p1;
-    return NULL;
-}
-
-/**
-* \brief Add SecWafPolicyScopeName configuration option
-*
-* \param cmd Pointer to configuration data
-* \param _dcfg Pointer to directory configuration
-* \param p1 Pointer to configuration option
-*
-* \retval NULL On Success
-* \retval apr_psprintf On Failue
-*/
-static const char *cmd_waf_policy_scope_name(cmd_parms *cmd, void *_dcfg, const char *p1)
-{
-    directory_config *dcfg = (directory_config *)_dcfg;
-    if (dcfg == NULL) {
-        return NULL;
-    }
-    if (p1 == NULL) {
-        return apr_psprintf(cmd->pool, "ModSecurity: No valid SecWafPolicyScopeName specified.");
-    }
-
-    dcfg->waf_policy_scope_name = p1;
     return NULL;
 }
 
@@ -3545,22 +3489,6 @@ const command_rec module_directives[] = {
         NULL,
         CMD_SCOPE_ANY,
         "WAF policy identifier"
-    ),
-
-    AP_INIT_TAKE1 (
-        "SecWafPolicyScope",
-        cmd_waf_policy_scope,
-        NULL,
-        CMD_SCOPE_ANY,
-        "WAF policy application scope"
-    ),
-
-    AP_INIT_TAKE1 (
-        "SecWafPolicyScopeName",
-        cmd_waf_policy_scope_name,
-        NULL,
-        CMD_SCOPE_ANY,
-        "name of the scope the WAF policy is assigned to"
     ),
 
     AP_INIT_FLAG (

--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -478,7 +478,10 @@ static void internal_log_ex(request_rec *r, directory_config *dcfg, modsec_rec *
             msc_waf_log_reopened = 0;
         }
 
-        send_waf_log(msr->modsecurity->wafjsonlog_lock, msc_waf_log_fd, str1, r->useragent_ip ? r->useragent_ip : r->connection->client_ip, log_escape(msr->mp, r->uri), (!msr->allow_scope) ? dcfg->is_enabled : msr->allow_scope, r->hostname, unique_id, r, dcfg->waf_policy_id, dcfg->waf_policy_scope, dcfg->waf_policy_scope_name);
+        const char* scope = apr_table_get(r->notes, WAF_POLICY_SCOPE);
+        const char* scope_name = apr_table_get(r->notes, WAF_POLICY_SCOPE_NAME);
+
+        send_waf_log(msr->modsecurity->wafjsonlog_lock, msc_waf_log_fd, str1, r->useragent_ip ? r->useragent_ip : r->connection->client_ip, log_escape(msr->mp, r->uri), (!msr->allow_scope) ? dcfg->is_enabled : msr->allow_scope, r->hostname, unique_id, r, dcfg->waf_policy_id, scope ? scope : "", scope_name ? scope_name : "");
 #endif
 
 #if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER > 2

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -617,8 +617,6 @@ struct directory_config {
 
     /* WAF policy identification information */
     const char          *waf_policy_id;
-    const char          *waf_policy_scope;
-    const char          *waf_policy_scope_name;
 
     /* Geo Lookup */
     geo_db              *geo;

--- a/apache2/waf_logging/waf_log_util.h
+++ b/apache2/waf_logging/waf_log_util.h
@@ -16,6 +16,10 @@
 #define WAF_LOG_UTIL_OPERATION_NAME "ApplicationGatewayFirewall"
 #define WAF_LOG_UTIL_CATEGORY "ApplicationGatewayFirewallLog"
 
+// WAF log values passed with request
+#define WAF_POLICY_SCOPE "WafPolicyScope"
+#define WAF_POLICY_SCOPE_NAME "WafPolicyScopeName"
+
 #define RULE_TYPE_OWASP_CRS "OWASP_CRS"
 
 #define RULE_HASH_SIZE 499


### PR DESCRIPTION
## Description

Storing policy scope and scope name inside `modsecurity.conf` appeared to be a bad idea because this forces us write different config files if the same policy is assigned to multiple different scopes. This removes the advantage of caching memory blocks allocated for configurations.

Instead, we will be passing scope information through `nginx.conf` so that it naturally gets inherited by inner scopes or overridden if those scopes have different policy assigned. It also allows us to benefit from configuration caching.

## Testing

Tested with the nginx.conf that has two WAF policies and three protected scopes (one policy is used twice):
```
http {
  ...
  ModSecurityEnabled on;                                                                                                                      
  ModSecurityConfig modsec/0b8f2984-3007-4d90-891d-09eb41f48e3f/modsecurity_appgateway.conf;
  ModSecurityScope Global;
  ModSecurityScopeName Global;
  ...
  server {
    listen 8200;
    ModSecurityEnabled on;                                                                                                                    
    ModSecurityConfig modsec/4cac648d-915f-48fb-a385-660e1a723917/modsecurity_appgateway.conf;
    ModSecurityScope Listener;
    ModSecurityScopeName ListenerOne;
    ...
     location ~* ^\Q/foo/\E {
       ...
       ModSecurityEnabled on;                                                                                                                  
       ModSecurityConfig modsec/0b8f2984-3007-4d90-891d-09eb41f48e3f/modsecurity_appgateway.conf;
       ModSecurityScope Location;
       ModSecurityScopeName LocationOne;
       ...
     }
  }
  ...
  server {                                                                                                                                    
    listen 8300;
    server_name ~.*;
    ...
   }
}
```
Requests to corresponding scopes with the query parameter `test=1=1` resulted in following logs:

```
{
    "resourceId": "dummyResourceId", 
    "operationName": "ApplicationGatewayFirewall", 
    "category": "ApplicationGatewayFirewallLog", 
    "properties": {
        "instanceId": "dummyInstanceId", 
        "clientIp": "127.0.0.1", 
        "clientPort": "", 
        "requestUri": "/", 
        "ruleSetType": "OWASP_CRS", 
        "ruleSetVersion": "3.0.0", 
        "ruleId": "942130", 
        "message": "SQL Injection Attack: SQL Tautology Detected.", 
        "action": "Matched", 
        "site": "Global", 
        "details": {
            "message": "Warning. Pattern match \"(?i:([\\s'\"`\\(\\)]*?)([\\d\\w]++)([\\s'\"`\\(\\)]*?)(?:(?:=|<=>|r?like|sounds\\s+like|regexp)([\\s'\"`\\(\\)]*?)\\2|(?:!=|<=|>=|<>|<|>|\\^|is\\s+not|not\\s+like|not\\s+regexp)([\\s'\"`\\(\\)]*?)(?!\\2)([\\d\\w]+)))\" at ARGS:test .... ", 
            "data": "Matched Data: 1=1 found within ARGS:test: 1=1", 
            "file": "rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf", 
            "line": "554"
        }, 
        "hostname": "localhost:8200", 
        "transactionId": "AcAcAcAcXcAcAcAc0ckjAcAc", 
        "policyId": "dummyPolicyId", 
        "policyScope": "Listener", 
        "policyScopeName": "ListenerOne"
    }
}

{
    "resourceId": "dummyResourceId", 
    "operationName": "ApplicationGatewayFirewall", 
    "category": "ApplicationGatewayFirewallLog", 
    "properties": {
        "instanceId": "dummyInstanceId", 
        "clientIp": "127.0.0.1", 
        "clientPort": "", 
        "requestUri": "/foo/bar", 
        "ruleSetType": "OWASP_CRS", 
        "ruleSetVersion": "3.0.0", 
        "ruleId": "942130", 
        "message": "SQL Injection Attack: SQL Tautology Detected.", 
        "action": "Matched", 
        "site": "Global", 
        "details": {
            "message": "Warning. Pattern match \"(?i:([\\s'\"`\\(\\)]*?)([\\d\\w]++)([\\s'\"`\\(\\)]*?)(?:(?:=|<=>|r?like|sounds\\s+like|regexp)([\\s'\"`\\(\\)]*?)\\2|(?:!=|<=|>=|<>|<|>|\\^|is\\s+not|not\\s+like|not\\s+regexp)([\\s'\"`\\(\\)]*?)(?!\\2)([\\d\\w]+)))\" at ARGS:test .... ", 
            "data": "Matched Data: 1=1 found within ARGS:test: 1=1", 
            "file": "rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf", 
            "line": "554"
        }, 
        "hostname": "localhost:8200", 
        "transactionId": "AcAcAcAcYgAcAEADAcAS9cAc", 
        "policyId": "dummyPolicyId", 
        "policyScope": "Location", 
        "policyScopeName": "LocationOne"
    }
}
{
    "resourceId": "dummyResourceId", 
    "operationName": "ApplicationGatewayFirewall", 
    "category": "ApplicationGatewayFirewallLog", 
    "properties": {
        "instanceId": "dummyInstanceId", 
        "clientIp": "127.0.0.1", 
        "clientPort": "", 
        "requestUri": "/", 
        "ruleSetType": "", 
        "ruleSetVersion": "", 
        "ruleId": "200002", 
        "message": "Mandatory rule. Cannot be disabled. Failed to parse request body.", 
        "action": "Blocked", 
        "site": "Global", 
        "details": {
            "message": "Access denied with code 400 (phase 2). Match of \"eq 0\" against \"REQBODY_ERROR\" required. ", 
            "data": "JSON parsing error: lexical error: probable comment found in input text, comments are not enabled.\\x0a", 
            "file": "\"/etc/nginx/modsec/default/modsecurity.conf", 
            "line": "74"
        }, 
        "hostname": "localhost", 
        "transactionId": "AcAcAcAcAcAczcAcAcAcAcAc", 
        "policyId": "dummyPolicyId", 
        "policyScope": "Global", 
        "policyScopeName": "Global"
    }
}

```

    
