### PR TITLE
Integrate ModSecurity configuration validation utility into Windows build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,5 @@ tests/run-unit-tests.pl
 tools/Makefile
 tools/Makefile.in
 tools/rules-updater.pl
+validator/validator
+nginx/modsecurity/config

--- a/configure.ac
+++ b/configure.ac
@@ -204,7 +204,7 @@ AC_ARG_ENABLE(standalone-module,
 ])
 AM_CONDITIONAL([BUILD_STANDALONE_MODULE], [test "$build_standalone_module" -eq 1])
 if test "$build_standalone_module" -eq 1; then
-  TOPLEVEL_SUBDIRS="$TOPLEVEL_SUBDIRS standalone"
+  TOPLEVEL_SUBDIRS="$TOPLEVEL_SUBDIRS standalone validator"
 fi
 
 
@@ -612,6 +612,8 @@ AC_ARG_ENABLE(waf_json_logging,
   waf_json_logging=""
 ])
 
+root_include="-I"`pwd`
+
 # Always Enable json waf logging support
 waf_lock="-I"`pwd`"/apache2/waf_lock"
 
@@ -881,7 +883,7 @@ else
   fi
 fi
 
-MODSEC_EXTRA_CFLAGS="$pcre_study $pcre_match_limit $pcre_match_limit_recursion $pcre_jit $request_early $htaccess_config $lua_cache $debug_conf $debug_cache $debug_acmp $debug_mem $perf_meas $modsec_api $cpu_type $unique_id $log_filename $log_server $log_collection_delete_problem $log_dechunk $log_stopwatch $log_handler $log_server_context $collection_global_lock $large_stream_input $collection_memory_database $waf_json_logging $waf_lock"
+MODSEC_EXTRA_CFLAGS="$pcre_study $pcre_match_limit $pcre_match_limit_recursion $pcre_jit $request_early $htaccess_config $lua_cache $debug_conf $debug_cache $debug_acmp $debug_mem $perf_meas $modsec_api $cpu_type $unique_id $log_filename $log_server $log_collection_delete_problem $log_dechunk $log_stopwatch $log_handler $log_server_context $collection_global_lock $large_stream_input $collection_memory_database $waf_json_logging $root_include $waf_lock"
 
 APXS_WRAPPER=build/apxs-wrapper
 APXS_EXTRA_CFLAGS=""
@@ -974,6 +976,7 @@ fi
 if test "$build_standalone_module" -ne 0; then
 AC_CONFIG_FILES([standalone/Makefile])
 AC_CONFIG_FILES([nginx/modsecurity/config])
+AC_CONFIG_FILES([validator/Makefile])
 fi
 if test "$build_extentions" -ne 0; then
 AC_CONFIG_FILES([ext/Makefile])

--- a/iis/build_modsecurity.bat
+++ b/iis/build_modsecurity.bat
@@ -25,6 +25,13 @@ nmake -f Makefile.win clean
 nmake -f Makefile.win APACHE=..\iis\%DEPENDENCIES_DIR%\Apache24 PCRE=..\iis\%DEPENDENCIES_DIR%\pcre\build CURL=..\iis\%DEPENDENCIES_DIR%\curl YAJL=..\iis\%DEPENDENCIES_DIR%\yajl\build\yajl-2.1.0 SSDEEP=..\iis\%DEPENDENCIES_DIR%\ssdeep VERSION=VERSION_IIS
 @if NOT (%ERRORLEVEL%) == (0) goto build_failed
 
+@echo validator...
+cd ..\validator
+del *.obj *.dll *.lib
+nmake -f Makefile.win clean
+NMAKE -f Makefile.win APACHE=..\iis\%DEPENDENCIES_DIR%\Apache24 PCRE=..\iis\%DEPENDENCIES_DIR%\pcre\build LIBXML2=..\iis\%DEPENDENCIES_DIR%\libxml2 LUA=..\iis\%DEPENDENCIES_DIR%\lua\src VERSION=VERSION_IIS YAJL=..\iis\%DEPENDENCIES_DIR%\yajl\build\yajl-2.1.0 CURL=..\iis\%DEPENDENCIES_DIR%\curl
+@if NOT (%ERRORLEVEL%) == (0) goto build_failed
+
 @echo iis...
 cd ..\iis
 del *.obj *.dll *.lib
@@ -36,6 +43,7 @@ cd %CURRENT_DIR%
 
 @echo Copy...
 copy /y ..\mlogc\mlogc.exe %OUTPUT_DIR%
+copy /y ..\validator\modsec-validator.exe %OUTPUT_DIR%
 copy /y ..\iis\modsecurityiis.dll %OUTPUT_DIR%
 copy /y ..\iis\modsecurityiis.pdb %OUTPUT_DIR%
 

--- a/validator/Makefile.am
+++ b/validator/Makefile.am
@@ -1,0 +1,43 @@
+bin_PROGRAMS = validator
+
+validator_SOURCES = main.c
+
+    # FIXME: Standalone does not mean that it will be a nginx build.
+validator_CFLAGS = -DVERSION_NGINX \
+    @APR_CFLAGS@ \
+    @APU_CFLAGS@ \
+    @APXS_CFLAGS@ \
+    @CURL_CFLAGS@ \
+    @LIBXML2_CFLAGS@ \
+    @LUA_CFLAGS@ \
+    @MODSEC_EXTRA_CFLAGS@ \
+    @PCRE_CFLAGS@ \
+    @YAJL_CFLAGS@ \
+    @SSDEEP_CFLAGS@
+
+validator_CPPFLAGS = @APR_CPPFLAGS@ \
+    @LIBXML2_CPPFLAGS@ \
+    @PCRE_CPPFLAGS@
+
+validator_LDADD = ../standalone/.libs/standalone.a \
+    @APR_LDADD@ \
+    @APU_LDADD@ \
+    @CURL_LDADD@ \
+    @LIBXML2_LDADD@ \
+    @LUA_LDADD@ \
+    @PCRE_LDADD@ \
+    @YAJL_LDADD@ \
+    -lstdc++ \
+    -lm
+	
+validator_LDFLAGS = -no-undefined -module -avoid-version \
+    @APR_LDFLAGS@ \
+    @APU_LDFLAGS@ \
+    @CURL_LDFLAGS@ \
+    @APXS_LDFLAGS@ \
+    @LIBXML2_LDFLAGS@ \
+    @LUA_LDFLAGS@ \
+    @PCRE_LDFLAGS@ \
+    @YAJL_LDFLAGS@ \
+    @SSDEEP_LDFLAGS@
+

--- a/validator/Makefile.win
+++ b/validator/Makefile.win
@@ -1,0 +1,112 @@
+###########################################################################
+#
+# Usage:   NMAKE -f Makefile.win APACHE={httpd installion dir}  PCRE={pcre dir} LIBXML2={LibXML2 dir} [   LUA={Lua dir} ]
+#
+!IF "$(APACHE)" == "" || "$(PCRE)" == "" || "$(LIBXML2)" == "" || "$(CURL)" == ""
+!ERROR NMAKE arguments: APACHE=dir PCRE=dir LIBXML2=dir CURL=dir are required to build mod_security2 for Windows
+!ENDIF
+
+# Linking libraries
+LIBS = $(APACHE)\lib\libapr-1.lib \
+       $(APACHE)\lib\libaprutil-1.lib \
+       $(PCRE)\pcre.lib \
+       $(CURL)\libcurl.lib \
+       $(LIBXML2)\win32\bin.msvc\libxml2.lib \
+       "kernel32.lib" "user32.lib" "gdi32.lib" "winspool.lib" "comdlg32.lib" "advapi32.lib" "shell32.lib" "ole32.lib" \
+       "oleaut32.lib" "uuid.lib" "odbc32.lib" "odbccp32.lib" "ws2_32.lib" "iphlpapi.lib"
+###########################################################################
+###########################################################################
+
+CC = CL
+LINK = link.exe
+
+MT = mt
+
+DEFS = /nologo /O2 /W3 /wd4244 /wd4018 -DWITH_YAJL -DWIN32 -DWINNT -Dinline=APR_INLINE -D_CONSOLE -DAP_DECLARE_STATIC -D_MBCS -D$(VERSION)
+
+EXE = modsec-validator.exe
+
+INCLUDES = -I. -I.. \
+           -I$(YAJL)\.. \
+           -I$(PCRE)\include -I$(PCRE) \
+           -I$(LIBXML2)\include \
+           -I$(CURL)\include -I$(CURL) \
+           -I$(APACHE)\include \
+           -I..\apache2 \
+           -I..\standalone \
+           -I..\apache2\ag_mdb \
+           -I..\apache2\waf_lock
+
+# Lua is optional
+!IF "$(LUA)" != ""
+LIBS = $(LIBS) $(LUA)\lua5.1.lib
+DEFS=$(DEFS) -DWITH_LUA
+INCLUDES = $(INCLUDES) -I$(LUA)\include -I$(LUA) \
+!ENDIF
+
+# Yajl/Json is optional
+!IF "$(YAJL)" != ""
+LIBS = $(LIBS) $(YAJL)\lib\yajl.lib
+DEFS=$(DEFS) -DWITH_YAJL
+INCLUDES = $(INCLUDES) -I$(YAJL)\include -I$(YAJL) \
+!ENDIF
+
+DEFS=$(DEFS) -DMSC_LARGE_STREAM_INPUT
+
+CFLAGS = -MT $(INCLUDES) $(DEFS)
+
+LDFLAGS =
+
+OBJS = main.obj
+OBJS1 = mod_security2.obj apache2_config.obj apache2_io.obj apache2_util.obj \
+       re.obj re_operators.obj re_actions.obj re_tfns.obj re_variables.obj \
+       msc_logging.obj msc_xml.obj msc_multipart.obj modsecurity.obj \
+       msc_parsers.obj msc_util.obj msc_pcre.obj persist_dbm.obj \
+       msc_reqbody.obj msc_geo.obj msc_gsb.obj msc_unicode.obj acmp.obj msc_lua.obj \
+       msc_release.obj msc_crypt.obj msc_tree.obj \
+       msc_status_engine.obj \
+       msc_json.obj \
+       msc_remote_rules.obj 
+
+OBJS2 = api.obj buckets.obj config.obj filters.obj hooks.obj regex.obj server.obj
+OBJS3 = libinjection_html5.obj \
+    libinjection_sqli.obj \
+    libinjection_xss.obj
+    
+OBJS4 = murmur3.obj
+OBJS5 = ag_mdb.obj
+OBJS6 = waf_lock.obj
+
+all: $(EXE)
+
+exe: $(EXE)
+
+$(OBJS1): ..\apache2\$*.c
+        $(CC) $(CFLAGS) -c ..\apache2\$*.c -Fo$@
+		
+$(OBJS2): ..\standalone\$*.c
+        $(CC) $(CFLAGS) -c ..\standalone\$*.c -Fo$@
+
+$(OBJS3): ..\apache2\libinjection\$*.c
+        $(CC) $(CFLAGS) -c ..\apache2\libinjection\$*.c -Fo$@
+     
+$(OBJS4): ..\apache2\ag_mdb\$*.c
+        $(CC) $(CFLAGS) -c ..\apache2\ag_mdb\$*.c -Fo$@
+        
+$(OBJS5): ..\apache2\ag_mdb\$*.cpp
+        $(CC) $(CFLAGS) -c ..\apache2\ag_mdb\$*.cpp -Fo$@
+   
+$(OBJS6): ..\apache2\waf_lock\$*.cpp
+        $(CC) $(CFLAGS) -c ..\apache2\waf_lock\$*.cpp -Fo$@
+
+.c.obj:
+        $(CC) $(CFLAGS) -c $< -Fo$@
+
+$(EXE): $(OBJS) $(OBJS1) $(OBJS2)  $(OBJS3)  $(OBJS4) $(OBJS5) $(OBJS6)
+        $(LINK) $(LDFLAGS) $(OBJS) $(OBJS1) $(OBJS2) $(OBJS3) $(OBJS4) $(OBJS5) $(OBJS6) $(LIBS) /subsystem:console /OUT:modsec-validator.exe
+
+clean:
+    del /f *.obj
+    del /f *.exe
+    del /f *.exp
+    del /f *.lib

--- a/validator/main.c
+++ b/validator/main.c
@@ -1,0 +1,44 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include "standalone/api.h"
+
+static void print_log(void* obj, int level, char* str)
+{
+    if (str != NULL) {
+        puts(str);
+    }
+}
+
+static void exit_with_error(const char* msg)
+{
+    puts(msg);
+    exit(EXIT_FAILURE);
+}
+
+int main(int argc, char* argv[])
+{
+    if (argc != 2) {
+        exit_with_error("Invalid number of command line arguments");
+    }
+
+    server_rec* modsec_server = modsecInit();
+    if (modsec_server == NULL) {
+        exit_with_error("Failed to create ModSecurity server structure");        
+    }
+    char hostname[] = "localhost";
+    modsec_server->server_hostname = hostname;
+
+    modsecSetLogHook(NULL, print_log);
+    modsecStartConfig();
+    directory_config *config = modsecGetDefaultConfig();
+    if (config == NULL) {
+        exit_with_error("Error creating default config");
+    }
+
+    const char *err = modsecProcessConfig(config, argv[1], NULL);
+    if (err != NULL) {
+        exit_with_error(err);
+    }
+
+    exit(EXIT_SUCCESS);
+}

--- a/validator/main.c
+++ b/validator/main.c
@@ -1,3 +1,5 @@
+#define WIN32_LEAN_AND_MEAN
+
 #include <stdlib.h>
 #include <stdio.h>
 #include "standalone/api.h"
@@ -9,21 +11,21 @@ static void print_log(void* obj, int level, char* str)
     }
 }
 
-static void exit_with_error(const char* msg)
+static int exit_with_error(const char* msg)
 {
     puts(msg);
-    exit(EXIT_FAILURE);
+    return EXIT_FAILURE;
 }
 
 int main(int argc, char* argv[])
 {
     if (argc != 2) {
-        exit_with_error("Invalid number of command line arguments");
+        return exit_with_error("Invalid number of command line arguments");
     }
 
     server_rec* modsec_server = modsecInit();
     if (modsec_server == NULL) {
-        exit_with_error("Failed to create ModSecurity server structure");        
+        return exit_with_error("Failed to create ModSecurity server structure");        
     }
     char hostname[] = "localhost";
     modsec_server->server_hostname = hostname;
@@ -32,13 +34,13 @@ int main(int argc, char* argv[])
     modsecStartConfig();
     directory_config *config = modsecGetDefaultConfig();
     if (config == NULL) {
-        exit_with_error("Error creating default config");
+        return exit_with_error("Error creating default config");
     }
 
     const char *err = modsecProcessConfig(config, argv[1], NULL);
     if (err != NULL) {
-        exit_with_error(err);
+        return exit_with_error(err);
     }
 
-    exit(EXIT_SUCCESS);
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Description

Use the same ModSecurity configuration validation utility previously added for Linux builds in PR #130.

As such, the changes from #130 are cherry-picked here and Windows-specific changes are added on top.

## Testing

Running the tool without parameters:
```
C:\code\ModSecurity\iis\dependencies\release_files>modsec-validator.exe
Invalid number of command line arguments
```
Running the tool on a valid configuration file:
```
C:\code\ModSecurity\iis\dependencies\release_files>modsec-validator.exe C:\code\modsecurity.conf

C:\code\ModSecurity\iis\dependencies\release_files>echo %errorlevel%
0
```

Running the tool on an invalid configuration file:
```
C:\code\ModSecurity\iis\dependencies\release_files>modsec-validator.exe C:\code\modsecurity.conf
Syntax error in config file C:\code\modsecurity.conf, line 193: ModSecurity: Failed to open the audit log file: \var/log/modsec_audit.log

C:\code\ModSecurity\iis\dependencies\release_files>echo %errorlevel%
1
```