### PR TITLE
Write error messages to stderr instead ot stdout

### DIFF
--- a/validator/main.c
+++ b/validator/main.c
@@ -13,7 +13,7 @@ static void print_log(void* obj, int level, char* str)
 
 static int exit_with_error(const char* msg)
 {
-    puts(msg);
+    fputs(msg, stderr);
     return EXIT_FAILURE;
 }
 


### PR DESCRIPTION
This will facilitate integration with tenant code that expects errors to
be output into stderr.

Tested with tenant changes, error message is successfully read for invalid ModSecurity configurations:
```
10/11/2019 10:32:14 PM: ERROR - ModSecurity configuration validation failed, exitCode:1, error:Syntax error in config file C:\ModSecurityIIS\modsecurity.conf, line 41: ModSecurity: Invalid value for SecRequestBodyLimit: -104857600
10/11/2019 10:32:14 PM: ERROR - Modsec Configuration Failed.
```