### PR TITLE
Fixed log timestamp format

### DIFF
--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -344,13 +344,13 @@ static void send_waf_log(struct waf_lock* lock, apr_file_t* fd, const char* str1
     get_short_filename(waf_filename);
     get_ruleset_type_version(waf_ruleset_info, waf_ruleset_type, waf_ruleset_version); 
 
-    // Format UTC time
+    // Format UTC timestamp
     time_t rawtime;
-    struct tm * timeinfo;
-    char timestamp[30];
     time(&rawtime);
-    timeinfo = gmtime(&rawtime);
-    strftime(timestamp, 30, "%Y-%m-%dT%H:%M:%S+00:00", timeinfo);
+    struct tm timeinfo;
+    gmtime_r(&rawtime, &timeinfo);
+    char timestamp[30];
+    strftime(timestamp, sizeof(timestamp), "%Y-%m-%dT%H:%M:%S+00:00", &timeinfo);
 
     char* json_str = generate_json(timestamp, msc_waf_resourceId, WAF_LOG_UTIL_OPERATION_NAME, WAF_LOG_UTIL_CATEGORY, msc_waf_instanceId, waf_ip, waf_port, uri, waf_ruleset_type, waf_ruleset_version, waf_id, waf_message, mode, 0, waf_detail_message, waf_data, waf_filename, waf_line, hostname, waf_unique_id, waf_policy_id, waf_policy_scope, waf_policy_scope_name);
     if (!json_str) {

--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -318,7 +318,7 @@ static int write_file_with_lock(struct waf_lock* lock, apr_file_t* fd, char* str
 /**
  * send all waf fields in json format to a file.
  */
-static void send_waf_log(const char* timestamp, struct waf_lock* lock, apr_file_t* fd, const char* str1, const char* ip_port, const char* uri, int mode, const char* hostname, char* unique_id, request_rec *r, const char* waf_policy_id, const char* waf_policy_scope, const char* waf_policy_scope_name) {
+static void send_waf_log(struct waf_lock* lock, apr_file_t* fd, const char* str1, const char* ip_port, const char* uri, int mode, const char* hostname, char* unique_id, request_rec *r, const char* waf_policy_id, const char* waf_policy_scope, const char* waf_policy_scope_name) {
     char waf_filename[1024] = "";
     char waf_line[1024] = "";
     char waf_id[1024] = "";
@@ -343,6 +343,14 @@ static void send_waf_log(const char* timestamp, struct waf_lock* lock, apr_file_
     get_detail_message(str1, waf_detail_message); 
     get_short_filename(waf_filename);
     get_ruleset_type_version(waf_ruleset_info, waf_ruleset_type, waf_ruleset_version); 
+
+    // Format UTC time
+    time_t rawtime;
+    struct tm * timeinfo;
+    char timestamp[30];
+    time(&rawtime);
+    timeinfo = gmtime(&rawtime);
+    strftime(timestamp, 30, "%Y-%m-%dT%H:%M:%S+00:00", timeinfo);
 
     char* json_str = generate_json(timestamp, msc_waf_resourceId, WAF_LOG_UTIL_OPERATION_NAME, WAF_LOG_UTIL_CATEGORY, msc_waf_instanceId, waf_ip, waf_port, uri, waf_ruleset_type, waf_ruleset_version, waf_id, waf_message, mode, 0, waf_detail_message, waf_data, waf_filename, waf_line, hostname, waf_unique_id, waf_policy_id, waf_policy_scope, waf_policy_scope_name);
     if (!json_str) {
@@ -481,7 +489,7 @@ static void internal_log_ex(request_rec *r, directory_config *dcfg, modsec_rec *
         const char* scope = apr_table_get(r->notes, WAF_POLICY_SCOPE);
         const char* scope_name = apr_table_get(r->notes, WAF_POLICY_SCOPE_NAME);
 
-        send_waf_log(current_logtime(msr->mp), msr->modsecurity->wafjsonlog_lock, msc_waf_log_fd, str1, r->useragent_ip ? r->useragent_ip : r->connection->client_ip, log_escape(msr->mp, r->uri), (!msr->allow_scope) ? dcfg->is_enabled : msr->allow_scope, r->hostname, unique_id, r, dcfg->waf_policy_id, scope ? scope : "", scope_name ? scope_name : "");
+        send_waf_log(msr->modsecurity->wafjsonlog_lock, msc_waf_log_fd, str1, r->useragent_ip ? r->useragent_ip : r->connection->client_ip, log_escape(msr->mp, r->uri), (!msr->allow_scope) ? dcfg->is_enabled : msr->allow_scope, r->hostname, unique_id, r, dcfg->waf_policy_id, scope ? scope : "", scope_name ? scope_name : "");
 #endif
 
 #if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER > 2

--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -345,8 +345,7 @@ static void send_waf_log(struct waf_lock* lock, apr_file_t* fd, const char* str1
     get_ruleset_type_version(waf_ruleset_info, waf_ruleset_type, waf_ruleset_version); 
 
     // Format UTC timestamp
-    time_t rawtime;
-    time(&rawtime);
+    time_t rawtime = time(NULL);
     struct tm timeinfo;
     gmtime_r(&rawtime, &timeinfo);
     char timestamp[30];


### PR DESCRIPTION
Log Analytics is not able to understand the previous log format "25/Oct/2019:22:35:48 +0000" introduced in https://github.com/microsoft/ModSecurity/pull/132 . AppGw uses the log format "2006-01-02T15:04:05+00:00", so I suggest we switch to this format.

I tested by manually cat'ing a log entry with this date format to waf_json.log, and ensured that it showed up as a sortable date/time column in Log Analytics.