### PR TITLE
Adding transaction id for waf log

### DIFF
--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -318,7 +318,7 @@ static int write_file_with_lock(struct waf_lock* lock, apr_file_t* fd, char* str
 /**
  * send all waf fields in json format to a file.
  */
-static void send_waf_log(struct waf_lock* lock, apr_file_t* fd, const char* str1, const char* ip_port, const char* uri, int mode, const char* hostname, char* unique_id, request_rec *r, const char* waf_policy_id, const char* waf_policy_scope, const char* waf_policy_scope_name) {
+static void send_waf_log(struct waf_lock* lock, apr_file_t* fd, const char* str1, const char* ip_port, const char* uri, int mode, const char* hostname, char* request_id, request_rec *r, const char* waf_policy_id, const char* waf_policy_scope, const char* waf_policy_scope_name) {
     char waf_filename[1024] = "";
     char waf_line[1024] = "";
     char waf_id[1024] = "";
@@ -330,7 +330,6 @@ static void send_waf_log(struct waf_lock* lock, apr_file_t* fd, const char* str1
     char waf_ruleset_type[50] = "";
     char waf_ruleset_version[50] = "";
     char waf_detail_message[1024] = "";
-	char waf_unique_id[100] = "";
 
     get_field_value("[file ", "]", str1, waf_filename);
     get_field_value("[id ", "]", str1, waf_id);
@@ -350,7 +349,7 @@ static void send_waf_log(struct waf_lock* lock, apr_file_t* fd, const char* str1
     char timestamp[30];
     strftime(timestamp, sizeof(timestamp), "%Y-%m-%dT%H:%M:%S+00:00", &timeinfo);
 
-    char* json_str = generate_json(timestamp, msc_waf_resourceId, WAF_LOG_UTIL_OPERATION_NAME, WAF_LOG_UTIL_CATEGORY, msc_waf_instanceId, waf_ip, waf_port, uri, waf_ruleset_type, waf_ruleset_version, waf_id, waf_message, mode, 0, waf_detail_message, waf_data, waf_filename, waf_line, hostname, unique_id, waf_policy_id, waf_policy_scope, waf_policy_scope_name);
+    char* json_str = generate_json(timestamp, msc_waf_resourceId, WAF_LOG_UTIL_OPERATION_NAME, WAF_LOG_UTIL_CATEGORY, msc_waf_instanceId, waf_ip, waf_port, uri, waf_ruleset_type, waf_ruleset_version, waf_id, waf_message, mode, 0, waf_detail_message, waf_data, waf_filename, waf_line, hostname, request_id, waf_policy_id, waf_policy_scope, waf_policy_scope_name);
     if (!json_str) {
 #if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER > 2
        ap_log_rerror(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, r,

--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -338,7 +338,6 @@ static void send_waf_log(struct waf_lock* lock, apr_file_t* fd, const char* str1
     get_field_value("[msg ", "]", str1, waf_message);
     get_field_value("[data ", "]", str1, waf_data);
 	get_field_value("[ver ", "]", str1, waf_ruleset_info);
-	get_field_value("[unique_id ", "]", unique_id, waf_unique_id);
 	get_ip_port(ip_port, waf_ip, waf_port);
     get_detail_message(str1, waf_detail_message); 
     get_short_filename(waf_filename);
@@ -351,7 +350,7 @@ static void send_waf_log(struct waf_lock* lock, apr_file_t* fd, const char* str1
     char timestamp[30];
     strftime(timestamp, sizeof(timestamp), "%Y-%m-%dT%H:%M:%S+00:00", &timeinfo);
 
-    char* json_str = generate_json(timestamp, msc_waf_resourceId, WAF_LOG_UTIL_OPERATION_NAME, WAF_LOG_UTIL_CATEGORY, msc_waf_instanceId, waf_ip, waf_port, uri, waf_ruleset_type, waf_ruleset_version, waf_id, waf_message, mode, 0, waf_detail_message, waf_data, waf_filename, waf_line, hostname, waf_unique_id, waf_policy_id, waf_policy_scope, waf_policy_scope_name);
+    char* json_str = generate_json(timestamp, msc_waf_resourceId, WAF_LOG_UTIL_OPERATION_NAME, WAF_LOG_UTIL_CATEGORY, msc_waf_instanceId, waf_ip, waf_port, uri, waf_ruleset_type, waf_ruleset_version, waf_id, waf_message, mode, 0, waf_detail_message, waf_data, waf_filename, waf_line, hostname, unique_id, waf_policy_id, waf_policy_scope, waf_policy_scope_name);
     if (!json_str) {
 #if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER > 2
        ap_log_rerror(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, r,
@@ -488,7 +487,7 @@ static void internal_log_ex(request_rec *r, directory_config *dcfg, modsec_rec *
         const char* scope = apr_table_get(r->notes, WAF_POLICY_SCOPE);
         const char* scope_name = apr_table_get(r->notes, WAF_POLICY_SCOPE_NAME);
 
-        send_waf_log(msr->modsecurity->wafjsonlog_lock, msc_waf_log_fd, str1, r->useragent_ip ? r->useragent_ip : r->connection->client_ip, log_escape(msr->mp, r->uri), (!msr->allow_scope) ? dcfg->is_enabled : msr->allow_scope, r->hostname, unique_id, r, dcfg->waf_policy_id, scope ? scope : "", scope_name ? scope_name : "");
+        send_waf_log(msr->modsecurity->wafjsonlog_lock, msc_waf_log_fd, str1, r->useragent_ip ? r->useragent_ip : r->connection->client_ip, log_escape(msr->mp, r->uri), (!msr->allow_scope) ? dcfg->is_enabled : msr->allow_scope, r->hostname, r->log_id, r, dcfg->waf_policy_id, scope ? scope : "", scope_name ? scope_name : "");
 #endif
 
 #if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER > 2

--- a/apache2/waf_logging/waf_log_util.cc
+++ b/apache2/waf_logging/waf_log_util.cc
@@ -130,7 +130,7 @@ static std::string get_json_log_message(const char* timestamp, const char* resou
         const char* category, const char* instance_id, const char* client_ip, const char* client_port, 
         const char* request_uri, const char* rule_set_type, const char* rule_set_version, const char* rule_id, 
         const char* messages, const int action, const int site, const char* details_messages, const char* details_data,
-        const char* details_file, const char* details_line, const char* hostname, const char* waf_unique_id,
+        const char* details_file, const char* details_line, const char* hostname, const char* request_id,
         const char* waf_policy_id, const char* waf_policy_scope, const char* waf_policy_scope_name) {
 
     using str_view = jsoncons::string_view;
@@ -209,7 +209,7 @@ static std::string get_json_log_message(const char* timestamp, const char* resou
                 details_line_str
             },
             hostname,
-            waf_unique_id,
+            request_id,
             waf_policy_id,
             waf_policy_scope,
             waf_policy_scope_name
@@ -222,14 +222,14 @@ char* generate_json(const char* timestamp, const char* resource_id, const char* 
         const char* instance_id, const char* client_ip, const char* client_port, const char* request_uri,
         const char* rule_set_type, const char* rule_set_version, const char* rule_id, const char* messages,
         const int action, const int site, const char* details_messages, const char* details_data,
-        const char* details_file, const char* details_line, const char* hostname, const char* waf_unique_id,
+        const char* details_file, const char* details_line, const char* hostname, const char* request_id,
         const char* waf_policy_id, const char* waf_policy_scope, const char* waf_policy_scope_name) {
     
     try {
         const std::string json_string = get_json_log_message(timestamp, resource_id, operation_name, category,
                 instance_id, client_ip, client_port, request_uri, rule_set_type, rule_set_version,
                 rule_id, messages, action, site, details_messages, details_data, details_file,
-                details_line, hostname, waf_unique_id, waf_policy_id, waf_policy_scope, waf_policy_scope_name);
+                details_line, hostname, request_id, waf_policy_id, waf_policy_scope, waf_policy_scope_name);
         char* result = static_cast<char*>(std::malloc(json_string.length() + 2)); // Two extra bytes for \n and \0
         std::copy(json_string.begin(), json_string.end(), result);
         result[json_string.length()] = '\n';

--- a/apache2/waf_logging/waf_log_util.cc
+++ b/apache2/waf_logging/waf_log_util.cc
@@ -185,7 +185,6 @@ static std::string get_json_log_message(const char* timestamp, const char* resou
     const str_view details_file_str = details_file ? str_view {details_file, strlen(details_file) - 1} : str_view{};
     const str_view details_data_str = make_string_view_strip_quotes(details_data);
     const str_view details_line_str = make_string_view_strip_quotes(details_line);
-    const str_view waf_unique_id_str = make_string_view_strip_quotes(waf_unique_id);
 
     return to_json_string({
         timestamp,
@@ -210,7 +209,7 @@ static std::string get_json_log_message(const char* timestamp, const char* resou
                 details_line_str
             },
             hostname,
-            waf_unique_id_str,
+            waf_unique_id,
             waf_policy_id,
             waf_policy_scope,
             waf_policy_scope_name

--- a/nginx/modsecurity/ngx_http_modsecurity.c
+++ b/nginx/modsecurity/ngx_http_modsecurity.c
@@ -258,6 +258,24 @@ ngx_http_modsecurity_method_number(unsigned int nginx)
     return MultiplyDeBruijnBitPosition[((uint32_t)((nginx & -nginx) * 0x077CB531U)) >> 27];
 }
 
+#ifdef WAF_JSON_LOGGING_ENABLE
+static ngx_uint_t request_id_index;
+
+static ngx_str_t get_request_id(ngx_http_request_t *r) {
+    ngx_str_t request_id_str;
+    request_id_str.data = NULL;
+    request_id_str.len = 0;
+
+    ngx_http_variable_value_t* request_id = ngx_http_get_indexed_variable(r, request_id_index);
+    if (request_id != NULL && !request_id->not_found) {
+        request_id_str.data = request_id->data;
+        request_id_str.len = request_id->len;
+    }
+
+    return request_id_str;
+}
+#endif
+
 /*
  * Use APR pool for all allocations because they should not depend on Nginx request pool.
  * In case of detection mode, processing will take place entirely in background and may last
@@ -351,6 +369,12 @@ ngx_http_modsecurity_load_request(ngx_http_request_t *r)
     req->hostname = dup_ngx_str_to_apr(req->pool, (ngx_str_t *)&ngx_cycle->hostname);
 
     req->header_only = r->header_only ? r->header_only : (r->method == NGX_HTTP_HEAD);
+
+#ifdef WAF_JSON_LOGGING_ENABLE
+    ngx_str_t  request_id;
+    request_id = get_request_id(r);
+    req->log_id = dup_ngx_str_to_apr(req->pool, &request_id);
+#endif
 
     return NGX_OK;
 }
@@ -646,6 +670,9 @@ ngx_http_modsecurity_init(ngx_conf_t *cf)
     if (result) {
         ngx_log_error(NGX_LOG_INFO, cf->log, 0, "ModSecurity: could not load application gateway rules IDs.");
     }
+
+    ngx_str_t request_id_varname = ngx_string("request_id");
+    request_id_index = (ngx_uint_t)ngx_http_get_variable_index(cf, &request_id_varname);    
 #endif    
 
     azwaf_processing_result_key = ngx_hash_key_lc(

--- a/nginx/modsecurity/ngx_http_modsecurity.c
+++ b/nginx/modsecurity/ngx_http_modsecurity.c
@@ -371,8 +371,7 @@ ngx_http_modsecurity_load_request(ngx_http_request_t *r)
     req->header_only = r->header_only ? r->header_only : (r->method == NGX_HTTP_HEAD);
 
 #ifdef WAF_JSON_LOGGING_ENABLE
-    ngx_str_t  request_id;
-    request_id = get_request_id(r);
+    ngx_str_t request_id = get_request_id(r);
     req->log_id = dup_ngx_str_to_apr(req->pool, &request_id);
 #endif
 


### PR DESCRIPTION
Adding nginx request_id into waf log:
example
{
    "timeStamp": "2019-11-15T00:32:34+00:00",
    "resourceId": "resource",
    "operationName": "ApplicationGatewayFirewall",
    "category": "ApplicationGatewayFirewallLog",
    "properties": {
        "instanceId": "abc",
        "clientIp": "127.0.0.1",
        "clientPort": "",
        "requestUri": "/",
        "ruleSetType": "",
        "ruleSetVersion": "",
        "ruleId": "949110",
        "message": "Mandatory rule. Cannot be disabled. Inbound Anomaly Score Exceeded (Total Score: 5)",
        "action": "Blocked",
        "site": "Global",
        "details": {
            "message": "Access denied with code 403 (phase 2). Operator GE matched 5 at TX:anomaly_score. ",
            "data": "",
            "file": "\"/root/CP/Nginx/crs/crs-3.0/rules/REQUEST-949-BLOCKING-EVALUATION.conf",
            "line": "57"
        },
        "hostname": "localhost:8080",
        "transactionId": "154826be7007cf6e6c363dc25ffb3866",
        "policyId": "",
        "policyScope": "",
        "policyScopeName": ""
    }
}
{
    "timeStamp": "2019-11-15T00:32:34+00:00",
    "resourceId": "resource",
    "operationName": "ApplicationGatewayFirewall",
    "category": "ApplicationGatewayFirewallLog",
    "properties": {
        "instanceId": "abc",
        "clientIp": "127.0.0.1",
        "clientPort": "",
        "requestUri": "/",
        "ruleSetType": "",
        "ruleSetVersion": "",
        "ruleId": "980130",
        "message": "Mandatory rule. Cannot be disabled. Inbound Anomaly Score Exceeded (Total Inbound Score: 5 - SQLI=5,XSS=0,RFI=0,LFI=0,RCE=0,PHPI=0,HTTP=0,SESS=0): SQL Injection Attack: SQL Tautology Detected.",
        "action": "Blocked",
        "site": "Global",
        "details": {
            "message": "Warning. Operator GE matched 5 at TX:inbound_anomaly_score. ",
            "data": "",
            "file": "\"/root/CP/Nginx/crs/crs-3.0/rules/RESPONSE-980-CORRELATION.conf",
            "line": "73"
        },
        "hostname": "localhost:8080",
        "transactionId": "154826be7007cf6e6c363dc25ffb3866",
        "policyId": "",
        "policyScope": "",                                    
}