### PR TITLE
WAF v2 skips request body processing in detection-only mode even if explicitly enabled

### DIFF
--- a/apache2/apache2.h
+++ b/apache2/apache2.h
@@ -74,6 +74,8 @@ apr_status_t DSOLOCAL read_request_body(modsec_rec *msr, char **error_msg);
 
 int DSOLOCAL perform_interception(modsec_rec *msr);
 
+modsec_rec DSOLOCAL *create_tx_context(request_rec *r);
+
 apr_status_t DSOLOCAL send_error_bucket(modsec_rec *msr, ap_filter_t *f, int status);
 
 int DSOLOCAL apache2_exec(modsec_rec *msr, const char *command, const char **argv, char **output);

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -483,7 +483,7 @@ static void store_tx_context(modsec_rec *msr, request_rec *r) {
 /**
  * Creates a new transaction context.
  */
-static modsec_rec *create_tx_context(request_rec *r) {
+modsec_rec *create_tx_context(request_rec *r) {
     apr_allocator_t *allocator = NULL;
     modsec_rec *msr = NULL;
 

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -866,11 +866,19 @@ static int hook_request_early(request_rec *r) {
         return DECLINED;
     }
 
-    /* Initialise transaction context and
-     * create the initial configuration.
+    /* Check if the transaction context
+     * has already been initialised.
      */
-    msr = create_tx_context(r);
-    if (msr == NULL) return DECLINED;
+
+    msr = retrieve_tx_context(r);
+    if (msr == NULL) {
+
+        /* Initialise transaction context and
+        * create the initial configuration.
+        */
+        msr = create_tx_context(r);
+        if (msr == NULL) return DECLINED;
+    }
 
 #ifdef REQUEST_EARLY
 

--- a/nginx/modsecurity/ngx_http_modsecurity.c
+++ b/nginx/modsecurity/ngx_http_modsecurity.c
@@ -837,6 +837,17 @@ ngx_http_modsecurity_detection_task_offload(ngx_http_request_t *r)
         return NGX_ERROR;
     }
 
+    // ModSecurity only initializes the internal request context upon the call
+    // to modsecProcessRequestHeaders().
+    // In our case, we postpone this call so we need to initialize the context
+    // explicitly because predicates like modsecIsRequestBodyAccessEnabled()
+    // use it for the checks they perform.
+    const char *err = modsecInitializeRequestContext(req);
+    if (err) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, err);
+        return NGX_ERROR;
+    }
+
     if (modsecIsRequestBodyAccessEnabled(req) && (r->headers_in.content_length || r->headers_in.chunked)) {
         if (ngx_http_modsecurity_load_request_body(r) != NGX_OK) {
             return NGX_ERROR;

--- a/standalone/api.c
+++ b/standalone/api.c
@@ -535,6 +535,19 @@ int modsecContextState(request_rec *r)
     return msr->txcfg->is_enabled;
 }
 
+const char* modsecInitializeRequestContext(request_rec *r)
+{
+    modsec_rec *msr = retrieve_msr(r);
+    if (msr == NULL) {
+        msr = create_tx_context(r);
+        if (msr == NULL) {
+            return "Failed to initialize request context";
+        }
+    }
+
+    return NULL;
+}
+
 int modsecIsRequestBodyAccessEnabled(request_rec *r)
 {
     modsec_rec *msr = retrieve_msr(r);

--- a/standalone/api.h
+++ b/standalone/api.h
@@ -113,6 +113,12 @@ void modsecSetWriteBody(apr_status_t (*func)(request_rec *r, char *buf, unsigned
 void modsecSetWriteResponse(apr_status_t (*func)(request_rec *r, char *buf, unsigned int length));
 void modsecSetDropAction(int (*func)(request_rec *r));
 
+/*
+ * Creates internal request context if does not yet exist.
+ * Must be called for a request_rec object that contains all request headers.
+ */
+const char *modsecInitializeRequestContext(request_rec *r);
+
 int modsecIsResponseBodyAccessEnabled(request_rec *r);
 int modsecIsRequestBodyAccessEnabled(request_rec *r);
 


### PR DESCRIPTION
## Overview
This happens because the API predicate `modsecIsRequestBodyAccessEnabled()` that is used to determine whether the request body needs to be processed or not depends implicitly on the internal request context. This context is implicitly created during the call to `modsecProcessRequestHeaders()`.

In detection-only mode, however, we postpone the call to `modsecProcessRequestHeaders()` and so the context is not initialized when we call `modsecIsRequestBodyAccessEnabled()` to check if we need to process the body or not. As a result, it returns 'false' and body processing is skipped.

## Fix Description
This fix adds a public API for explicitly initializing the request context for the cases like ours when we need it before calling `modsecProcessRequestHeaders()` that would otherwise implicitly initialize it.

## Testing
Before the fix:
```
curl -X POST --header "Content-Type: application/json" --data "{\"value\": \"/etc/passwd\"}" "http://localhost" -o /dev/null -s -w "got HTTP %{http_code} after %{time_total}s\n"
```
The following command wouldn't produce any logs.

After the fix, it results in the following messages being output into the log file:
```
{
    "timeStamp": "2019-11-22T22:10:39+00:00", 
    "resourceId": "dummyResourceId", 
    "operationName": "ApplicationGatewayFirewall", 
    "category": "ApplicationGatewayFirewallLog", 
    "properties": {
        "instanceId": "dummyInstanceId", 
        "clientIp": "127.0.0.1", 
        "clientPort": "", 
        "requestUri": "/", 
        "ruleSetType": "OWASP_CRS", 
        "ruleSetVersion": "3.0.0", 
        "ruleId": "930120", 
        "message": "OS File Access Attempt", 
        "action": "Matched", 
        "site": "Global", 
        "details": {
            "message": "Warning. Matched phrase \"etc/passwd ...\" at ARGS:value. ", 
            "data": "Matched Data: etc/passwd found within ARGS:value: /etc/passwd", 
            "file": "rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf", 
            "line": "106"
        }, 
        "hostname": "localhost", 
        "transactionId": "AcyUAcAcAcjzAcAcAcAcAcWc", 
        "policyId": "default", 
        "policyScope": "Global", 
        "policyScopeName": "Global"
    }
}
{
    "timeStamp": "2019-11-22T22:10:39+00:00", 
    "resourceId": "dummyResourceId", 
    "operationName": "ApplicationGatewayFirewall", 
    "category": "ApplicationGatewayFirewallLog", 
    "properties": {
        "instanceId": "dummyInstanceId", 
        "clientIp": "127.0.0.1", 
        "clientPort": "", 
        "requestUri": "/", 
        "ruleSetType": "OWASP_CRS", 
        "ruleSetVersion": "3.0.0", 
        "ruleId": "932160", 
        "message": "Remote Command Execution: Unix Shell Code Found", 
        "action": "Matched", 
        "site": "Global", 
        "details": {
            "message": "Warning. Matched phrase \"etc/passwd ...\" at ARGS:value. ", 
            "data": "Matched Data: etc/passwd found within ARGS:value: /etc/passwd", 
            "file": "rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf", 
            "line": "448"
        }, 
        "hostname": "localhost", 
        "transactionId": "AcyUAcAcAcjzAcAcAcAcAcWc", 
        "policyId": "default", 
        "policyScope": "Global", 
        "policyScopeName": "Global"
    }
}
{
    "timeStamp": "2019-11-22T22:10:39+00:00", 
    "resourceId": "dummyResourceId", 
    "operationName": "ApplicationGatewayFirewall", 
    "category": "ApplicationGatewayFirewallLog", 
    "properties": {
        "instanceId": "dummyInstanceId", 
        "clientIp": "127.0.0.1", 
        "clientPort": "", 
        "requestUri": "/", 
        "ruleSetType": "", 
        "ruleSetVersion": "", 
        "ruleId": "949110", 
        "message": "Mandatory rule. Cannot be disabled. Inbound Anomaly Score Exceeded (Total Score: 10)", 
        "action": "Detected", 
        "site": "Global", 
        "details": {
            "message": "Warning. Operator GE matched 5 at TX:anomaly_score. ", 
            "data": "", 
            "file": "rules/REQUEST-949-BLOCKING-EVALUATION.conf", 
            "line": "57"
        }, 
        "hostname": "localhost", 
        "transactionId": "AcyUAcAcAcjzAcAcAcAcAcWc", 
        "policyId": "default", 
        "policyScope": "Global", 
        "policyScopeName": "Global"
    }
}
{
    "timeStamp": "2019-11-22T22:10:39+00:00", 
    "resourceId": "dummyResourceId", 
    "operationName": "ApplicationGatewayFirewall", 
    "category": "ApplicationGatewayFirewallLog", 
    "properties": {
        "instanceId": "dummyInstanceId", 
        "clientIp": "127.0.0.1", 
        "clientPort": "", 
        "requestUri": "/", 
        "ruleSetType": "", 
        "ruleSetVersion": "", 
        "ruleId": "980130", 
        "message": "Mandatory rule. Cannot be disabled. Inbound Anomaly Score Exceeded (Total Inbound Score: 10 - SQLI=0,XSS=0,RFI=0,LFI=5,RCE=5,PHPI=0,HTTP=0,SESS=0): Remote Command Execution: Unix Shell Code Found", 
        "action": "Detected", 
        "site": "Global", 
        "details": {
            "message": "Warning. Operator GE matched 5 at TX:inbound_anomaly_score. ", 
            "data": "", 
            "file": "rules/RESPONSE-980-CORRELATION.conf", 
            "line": "73"
        }, 
        "hostname": "localhost", 
        "transactionId": "AcyUAcAcAcjzAcAcAcAcAcWc", 
        "policyId": "default", 
        "policyScope": "Global", 
        "policyScopeName": "Global"
    }
}
```

We will also add a onebox test to cover this case.