### PR TITLE
Revert "Merge pull request #142: WAF v2 skips request body processing…

### DIFF
--- a/apache2/apache2.h
+++ b/apache2/apache2.h
@@ -74,8 +74,6 @@ apr_status_t DSOLOCAL read_request_body(modsec_rec *msr, char **error_msg);
 
 int DSOLOCAL perform_interception(modsec_rec *msr);
 
-modsec_rec DSOLOCAL *create_tx_context(request_rec *r);
-
 apr_status_t DSOLOCAL send_error_bucket(modsec_rec *msr, ap_filter_t *f, int status);
 
 int DSOLOCAL apache2_exec(modsec_rec *msr, const char *command, const char **argv, char **output);

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -483,7 +483,7 @@ static void store_tx_context(modsec_rec *msr, request_rec *r) {
 /**
  * Creates a new transaction context.
  */
-modsec_rec *create_tx_context(request_rec *r) {
+static modsec_rec *create_tx_context(request_rec *r) {
     apr_allocator_t *allocator = NULL;
     modsec_rec *msr = NULL;
 
@@ -866,19 +866,11 @@ static int hook_request_early(request_rec *r) {
         return DECLINED;
     }
 
-    /* Check if the transaction context
-     * has already been initialised.
+    /* Initialise transaction context and
+     * create the initial configuration.
      */
-
-    msr = retrieve_tx_context(r);
-    if (msr == NULL) {
-
-        /* Initialise transaction context and
-        * create the initial configuration.
-        */
-        msr = create_tx_context(r);
-        if (msr == NULL) return DECLINED;
-    }
+    msr = create_tx_context(r);
+    if (msr == NULL) return DECLINED;
 
 #ifdef REQUEST_EARLY
 

--- a/nginx/modsecurity/ngx_http_modsecurity.c
+++ b/nginx/modsecurity/ngx_http_modsecurity.c
@@ -837,17 +837,6 @@ ngx_http_modsecurity_detection_task_offload(ngx_http_request_t *r)
         return NGX_ERROR;
     }
 
-    // ModSecurity only initializes the internal request context upon the call
-    // to modsecProcessRequestHeaders().
-    // In our case, we postpone this call so we need to initialize the context
-    // explicitly because predicates like modsecIsRequestBodyAccessEnabled()
-    // use it for the checks they perform.
-    const char *err = modsecInitializeRequestContext(req);
-    if (err) {
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, err);
-        return NGX_ERROR;
-    }
-
     if (modsecIsRequestBodyAccessEnabled(req) && (r->headers_in.content_length || r->headers_in.chunked)) {
         if (ngx_http_modsecurity_load_request_body(r) != NGX_OK) {
             return NGX_ERROR;

--- a/standalone/api.c
+++ b/standalone/api.c
@@ -535,19 +535,6 @@ int modsecContextState(request_rec *r)
     return msr->txcfg->is_enabled;
 }
 
-const char* modsecInitializeRequestContext(request_rec *r)
-{
-    modsec_rec *msr = retrieve_msr(r);
-    if (msr == NULL) {
-        msr = create_tx_context(r);
-        if (msr == NULL) {
-            return "Failed to initialize request context";
-        }
-    }
-
-    return NULL;
-}
-
 int modsecIsRequestBodyAccessEnabled(request_rec *r)
 {
     modsec_rec *msr = retrieve_msr(r);

--- a/standalone/api.h
+++ b/standalone/api.h
@@ -113,12 +113,6 @@ void modsecSetWriteBody(apr_status_t (*func)(request_rec *r, char *buf, unsigned
 void modsecSetWriteResponse(apr_status_t (*func)(request_rec *r, char *buf, unsigned int length));
 void modsecSetDropAction(int (*func)(request_rec *r));
 
-/*
- * Creates internal request context if does not yet exist.
- * Must be called for a request_rec object that contains all request headers.
- */
-const char *modsecInitializeRequestContext(request_rec *r);
-
 int modsecIsResponseBodyAccessEnabled(request_rec *r);
 int modsecIsRequestBodyAccessEnabled(request_rec *r);
 


### PR DESCRIPTION
… in detection-only mode even if explicitly enabled"

This reverts commit e915a768de3f8ee8df872c514a6791b2289f4a64, reversing
changes made to cef00a63e2a7c87900dd4e4c500b68c4c391a2b4.

The fix has a data race that may cause undefined behavior due to a use-after-free bug. It will be refined and re-introduced but we revert it for the time being to unblock other pending changes.