### PR TITLE
Enable request body processing in detection mode in Nginx

### DIFF
--- a/apache2/apache2.h
+++ b/apache2/apache2.h
@@ -74,6 +74,8 @@ apr_status_t DSOLOCAL read_request_body(modsec_rec *msr, char **error_msg);
 
 int DSOLOCAL perform_interception(modsec_rec *msr);
 
+modsec_rec DSOLOCAL *create_tx_context(request_rec *r);
+
 apr_status_t DSOLOCAL send_error_bucket(modsec_rec *msr, ap_filter_t *f, int status);
 
 int DSOLOCAL apache2_exec(modsec_rec *msr, const char *command, const char **argv, char **output);

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -483,7 +483,7 @@ static void store_tx_context(modsec_rec *msr, request_rec *r) {
 /**
  * Creates a new transaction context.
  */
-static modsec_rec *create_tx_context(request_rec *r) {
+modsec_rec *create_tx_context(request_rec *r) {
     apr_allocator_t *allocator = NULL;
     modsec_rec *msr = NULL;
 

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -866,11 +866,19 @@ static int hook_request_early(request_rec *r) {
         return DECLINED;
     }
 
-    /* Initialise transaction context and
-     * create the initial configuration.
+    /* Check if the transaction context
+     * has already been initialised.
      */
-    msr = create_tx_context(r);
-    if (msr == NULL) return DECLINED;
+
+    msr = retrieve_tx_context(r);
+    if (msr == NULL) {
+
+        /* Initialise transaction context and
+        * create the initial configuration.
+        */
+        msr = create_tx_context(r);
+        if (msr == NULL) return DECLINED;
+    }
 
 #ifdef REQUEST_EARLY
 

--- a/standalone/api.c
+++ b/standalone/api.c
@@ -535,6 +535,19 @@ int modsecContextState(request_rec *r)
     return msr->txcfg->is_enabled;
 }
 
+const char* modsecInitializeRequestContext(request_rec *r)
+{
+    modsec_rec *msr = retrieve_msr(r);
+    if (msr == NULL) {
+        msr = create_tx_context(r);
+        if (msr == NULL) {
+            return "Failed to initialize request context";
+        }
+    }
+
+    return NULL;
+}
+
 int modsecIsRequestBodyAccessEnabled(request_rec *r)
 {
     modsec_rec *msr = retrieve_msr(r);

--- a/standalone/api.h
+++ b/standalone/api.h
@@ -113,6 +113,12 @@ void modsecSetWriteBody(apr_status_t (*func)(request_rec *r, char *buf, unsigned
 void modsecSetWriteResponse(apr_status_t (*func)(request_rec *r, char *buf, unsigned int length));
 void modsecSetDropAction(int (*func)(request_rec *r));
 
+/*
+ * Creates internal request context if does not yet exist.
+ * Must be called for a request_rec object that contains all request headers.
+ */
+const char *modsecInitializeRequestContext(request_rec *r);
+
 int modsecIsResponseBodyAccessEnabled(request_rec *r);
 int modsecIsRequestBodyAccessEnabled(request_rec *r);
 


### PR DESCRIPTION
## Description

The driver for this change is a bug in the current behavior in detection-only mode that causes request body to be skipped on processing.

In order to address it, a more fundamental change has been applied to processing tasks spawned for asynchronous execution in detection-only mode. Instead of copying all the data for processing using Apache-specific memory pools, we now rely on internal Nginx reference counting for HTTP requests making them live long enough for processing to complete.

This allows us to save on memory allocations as there is no longer a need to copy request headers. But more importantly, this guarantees that stored request body buffers live long enough to be processed without opening a window for data races. This approach is considered the optimal one because request body can be stored in temporary files and maintaining their lifetime or copying files around is both more heavyweight and error-prone.

## Testing

All the listed tests are performed on an AddressSanitizer-instrumented debug binary of Nginx that terminates the process immediately on catching any memory issue. Logs have been tracked to seek for reported issues as well as processes to not be terminated.

All tests listed below are performed on each of the two following configurations:
 - WAF in detection-only mode, request body processing enabled
 - WAF in prevention mode, request body processing enabled

1.  `curl -X POST --header "Content-Type: application/json" --data "{\"value\": \"/etc/passwd\"}" "http://localhost/" -o /dev/null -s -w "got HTTP %{http_code} after %{time_total}s\n"`
    WAF messages for `/etc/passwd` appear in `waf_json.log`, no ASan-reported issues.
2. `curl -X POST --header "Content-Type: application/json" --data "{\"value\": \"/etc/passwd\"}" "http://localhost/" -o /dev/null -s -w "got HTTP %{http_code} after %{time_total}s\n"`
    WAF messages for weird sequences of characters appear in `waf_json.log`, no ASan-reported issues.
3. (From two terminals simultaneously) `./apib --input-file ./jsonpayload --method POST -H "Connection: Keep-Alive" -H "Accept: */*" --concurrency 10 --duration 600 http://localhost/`
 where `jsonpayload` contains `{"name": "John", "age": 31, "city": "New York"}`
  No ASan-reported errors.
4. `for i in `seq 1 50`; curl -X POST --data "$(openssl rand -hex 65535)" "http://localhost/" -o /dev/null -s -w "got HTTP %{http_code} after %{time_total}s\n" done`
  No ASan-reported errors.
5. Manual testing with `testbackend1.westus.cloudapp.azure.com` and `testbackend2.westus.cloudapp.azure.com` backends and various typical WAF options like `a=1=1` and `test=/etc/passwd` in query parameters and body. No issues discovered.