### PR TITLE
Cleanup allocated resources explicitly upon validator exit

### DIFF
--- a/validator/main.c
+++ b/validator/main.c
@@ -40,5 +40,6 @@ int main(int argc, char* argv[])
         exit_with_error(err);
     }
 
+    modsecTerminate();
     exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
Now our debug builds use AddressSanitizer and it complains about memory
leaks.

Signed-off-by: Vladimir Krivopalov <vlkrivop@microsoft.com>