### PR TITLE
Fix memory leak that occurs on JSON parsing error

### DIFF
--- a/apache2/msc_json.c
+++ b/apache2/msc_json.c
@@ -277,8 +277,9 @@ int json_process_chunk(modsec_rec *msr, const char *buf, unsigned int size, char
     /* Feed our parser and catch any errors */
     msr->json->status = yajl_parse(msr->json->handle, buf, size);
     if (msr->json->status != yajl_status_ok) {
-        /* We need to free the yajl error message later, how to do this? */
-        *error_msg = yajl_get_error(msr->json->handle, 0, buf, size);
+        char *yajl_err = yajl_get_error(msr->json->handle, 0, buf, size);
+        *error_msg = apr_pstrdup(msr->mp, yajl_err);
+        yajl_free_error(msr->json->handle, yajl_err);
         return -1;
     }
 
@@ -297,8 +298,9 @@ int json_complete(modsec_rec *msr, char **error_msg) {
     /* Wrap up the parsing process */
     msr->json->status = yajl_complete_parse(msr->json->handle);
     if (msr->json->status != yajl_status_ok) {
-        /* We need to free the yajl error message later, how to do this? */
-        *error_msg = yajl_get_error(msr->json->handle, 0, NULL, 0);
+        char *yajl_err = yajl_get_error(msr->json->handle, 0, NULL, 0);
+        *error_msg = apr_pstrdup(msr->mp, yajl_err);
+        yajl_free_error(msr->json->handle, yajl_err);
         return -1;
     }
 


### PR DESCRIPTION
## Description
ModSecurity uses a dynamically allocated error message when JSON parsing
fails but never releases it properly.

## Testing
Unfortunately, AddressSanitizer wouldn't catch this leak because it originates from a third-party library function that is not instrumented when ModSecurity is built. However, `valgrind` reports the issue.

Before the fix the following request:
```
curl -X POST --header "Content-Type: application/json" --data "{...}" "http://localhost/"
```

results in the following Valgrind reported error:
```
10860 ==29251== 43 bytes in 1 blocks are definitely lost in loss record 605 of 720                                                                
10861 ==29251==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
10862 ==29251==    by 0x63B6FEE: ??? (in /usr/lib/x86_64-linux-gnu/libyajl.so.2.1.0)
10863 ==29251==    by 0x63183F: json_process_chunk (msc_json.c:281)
10864 ==29251==    by 0x63A831: modsecurity_request_body_store (msc_reqbody.c:368)
10865 ==29251==    by 0x665E72: read_request_body (apache2_io.c:298)
10866 ==29251==    by 0x62E986: hook_request_late (mod_security2.c:1042)
10867 ==29251==    by 0x627570: modsecProcessRequestBody (api.c:470)
10868 ==29251==    by 0x5ED402: ngx_http_modsecurity_prevention_thread_func (ngx_http_modsecurity.c:690)
10869 ==29251==    by 0x51B55A: ngx_thread_pool_cycle (ngx_thread_pool.c:342)
10870 ==29251==    by 0x50456B9: start_thread (pthread_create.c:333)
10871 ==29251==    by 0x782F41C: clone (clone.S:109)
```

After the fix, the leak is not longer reported for the same request.