### PR TITLE
Fix reopen file issue.

### DIFF
--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -1565,6 +1565,12 @@ static const char *cmd_data_dir(cmd_parms *cmd, void *_dcfg, const char *p1)
         return apr_psprintf(cmd->pool, "ModSecurity: Failed to open wafjson log file: %s",
             wafjsonlog_path);
     }
+
+    rc = apr_file_inherit_unset(msc_waf_log_fd);
+    if (rc != APR_SUCCESS) {
+        return apr_psprintf(cmd->pool, "ModSecurity: Failed to set property for wafjson log file: %s",
+            wafjsonlog_path);
+    }
     
     // Global variable to share between threads
     strncpy( msc_waf_log_path, wafjsonlog_path, WAF_LOG_PATH_LENGTH );

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -95,7 +95,7 @@ TreeRoot DSOLOCAL *conn_write_state_suspicious_list = 0;
 #ifdef WAF_JSON_LOGGING_ENABLE
 char DSOLOCAL *msc_waf_resourceId = NULL;
 char DSOLOCAL *msc_waf_instanceId = NULL;
-sig_atomic_t DSOLOCAL msc_waf_log_reopened = 1;
+sig_atomic_t DSOLOCAL msc_waf_log_reopen_requested = 1;
 apr_file_t DSOLOCAL *msc_waf_log_fd = NULL;
 char DSOLOCAL msc_waf_log_path[WAF_LOG_PATH_LENGTH] = ""; 
 cmd_parms DSOLOCAL *msc_waf_log_cmd = NULL;

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -243,7 +243,7 @@ int modsecurity_init(msc_engine *msce, apr_pool_t *mp) {
 #ifdef WAF_JSON_LOGGING_ENABLE
 void modsecurity_handle_signals_for_reopen(int signum)
 {
-    msc_waf_log_reopened = 1;
+    msc_waf_log_reopen_requested = 1;
 }
 #endif
 

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -175,7 +175,7 @@ extern DSOLOCAL int *unicode_map_table;
 #ifdef WAF_JSON_LOGGING_ENABLE
 extern DSOLOCAL char *msc_waf_resourceId;
 extern DSOLOCAL char *msc_waf_instanceId;
-extern DSOLOCAL sig_atomic_t msc_waf_log_reopened;
+extern DSOLOCAL sig_atomic_t msc_waf_log_reopen_requested;
 extern DSOLOCAL apr_file_t *msc_waf_log_fd;
 extern DSOLOCAL char msc_waf_log_path[WAF_LOG_PATH_LENGTH];
 extern DSOLOCAL cmd_parms *msc_waf_log_cmd;

--- a/apache2/waf_logging/waf_log_util.cc
+++ b/apache2/waf_logging/waf_log_util.cc
@@ -56,7 +56,7 @@ JSONCONS_TYPE_TRAITS_DECL(waf_logging::waf_log, timeStamp, resourceId, operation
 static std::string to_json_string(const waf_logging::waf_log& log) {
     jsoncons::json_options options;
     std::string json_output;
-    jsoncons::encode_json(jsoncons::ojson{}, log, json_output, options, jsoncons::indenting::indent);
+    jsoncons::encode_json(jsoncons::ojson{}, log, json_output, options);
     return json_output;
 };
 

--- a/nginx/modsecurity/ngx_http_modsecurity.c
+++ b/nginx/modsecurity/ngx_http_modsecurity.c
@@ -894,7 +894,9 @@ ngx_http_modsecurity_handler(ngx_http_request_t *r)
         ngx_http_set_ctx(r, ctx, ngx_http_modsecurity);
     }
 
+#ifdef WAF_JSON_LOGGING_ENABLE
     modsecReopenLogfileIfNeeded(ctx->req);
+#endif
 
     // Sometimes Nginx calls ngx_http_modsecurity_handler multiple times for the same request, after a worker thread has already been started. This is to guard against it.
     if (ctx->thread_running) {

--- a/nginx/modsecurity/ngx_http_modsecurity.c
+++ b/nginx/modsecurity/ngx_http_modsecurity.c
@@ -946,7 +946,7 @@ ngx_http_modsecurity_handler(ngx_http_request_t *r)
         ngx_http_set_ctx(r, ctx, ngx_http_modsecurity);
     }
 
-    modsecReopenFileIfNeeded(ctx->req);
+    modsecReopenLogfileIfNeeded(ctx->req);
 
     // Sometimes Nginx calls ngx_http_modsecurity_handler multiple times for the same request, after a worker thread has already been started. This is to guard against it.
     if (ctx->thread_running) {

--- a/nginx/modsecurity/ngx_http_modsecurity.c
+++ b/nginx/modsecurity/ngx_http_modsecurity.c
@@ -946,6 +946,8 @@ ngx_http_modsecurity_handler(ngx_http_request_t *r)
         ngx_http_set_ctx(r, ctx, ngx_http_modsecurity);
     }
 
+    modsecReopenFileIfNeeded(ctx->req);
+
     // Sometimes Nginx calls ngx_http_modsecurity_handler multiple times for the same request, after a worker thread has already been started. This is to guard against it.
     if (ctx->thread_running) {
         return NGX_DONE;

--- a/standalone/api.c
+++ b/standalone/api.c
@@ -45,6 +45,10 @@
 #include "msc_status_engine.h"
 #endif
 
+#ifdef WAF_JSON_LOGGING_ENABLE
+#include "waf_lock_external.h"
+#endif
+
 extern void *modsecLogObj;
 extern void (*modsecLogHook)(void *obj, int level, char *str);
 extern int (*modsecDropAction)(request_rec *r);
@@ -780,5 +784,63 @@ void modsecReportRemoteLoadedRules()
             remote_rules_fail_message);
     }
 
+}
+#endif
+
+#ifdef WAF_JSON_LOGGING_ENABLE
+void modsecReopenFileIfNeeded(request_rec *r)
+{
+    modsec_rec *msr = NULL;
+    int rc = 0;
+    apr_file_t * fd = NULL;
+    /* Find the transaction context first. */
+    msr = retrieve_msr(r);
+
+    if (msr == NULL)
+        return;
+
+    if (msc_waf_log_reopened){
+        if (msr->modsecurity != NULL && msr->modsecurity->wafjsonlog_lock != NULL){
+            rc = waf_get_exclusive_lock(msr->modsecurity->wafjsonlog_lock);
+            if (waf_lock_is_error(rc)) {
+                ap_log_rerror(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, r,
+                        "ModSecurity not able to get lock for %s file", msc_waf_log_path);
+                return;
+            }
+
+            rc = apr_file_open(&fd, msc_waf_log_path,
+                   APR_WRITE | APR_APPEND | APR_CREATE | APR_BINARY,
+                   CREATEMODE | APR_WREAD, msc_waf_log_cmd->pool);
+
+            if (rc != APR_SUCCESS) {
+                ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, NULL, "ModSecurity: " \
+                    "not able to reopen file: %s",
+                    msc_waf_log_path);
+
+                waf_free_exclusive_lock(msr->modsecurity->wafjsonlog_lock);
+                return;
+            }
+
+            if (msc_waf_log_fd != NULL){
+                rc = apr_file_close(msc_waf_log_fd);
+                if (rc != APR_SUCCESS) {
+                    ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, NULL, "ModSecurity: " \
+                        "not able to get lock for file: %s",
+                        msc_waf_log_path);
+                }
+            }
+
+            msc_waf_log_fd = fd;
+
+            rc = waf_free_exclusive_lock(msr->modsecurity->wafjsonlog_lock);
+            if (waf_lock_is_error(rc)) {
+                ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, NULL, "ModSecurity: " \
+                    "not able to get lock for file: %s",
+                    msc_waf_log_path);
+            }
+        }
+
+        msc_waf_log_reopened = 0;
+    }
 }
 #endif

--- a/standalone/api.c
+++ b/standalone/api.c
@@ -788,7 +788,7 @@ void modsecReportRemoteLoadedRules()
 #endif
 
 #ifdef WAF_JSON_LOGGING_ENABLE
-void modsecReopenFileIfNeeded(request_rec *r)
+void modsecReopenLogfileIfNeeded(request_rec *r)
 {
     modsec_rec *msr = NULL;
     int rc = 0;
@@ -824,8 +824,8 @@ void modsecReopenFileIfNeeded(request_rec *r)
             if (msc_waf_log_fd != NULL){
                 rc = apr_file_close(msc_waf_log_fd);
                 if (rc != APR_SUCCESS) {
-                    ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, NULL, "ModSecurity: " \
-                        "not able to get lock for file: %s",
+                    ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, NULL, "ModSecurity: " \
+                        "cannot close file: %s",
                         msc_waf_log_path);
                 }
             }
@@ -835,7 +835,7 @@ void modsecReopenFileIfNeeded(request_rec *r)
             rc = waf_free_exclusive_lock(msr->modsecurity->wafjsonlog_lock);
             if (waf_lock_is_error(rc)) {
                 ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, NULL, "ModSecurity: " \
-                    "not able to get lock for file: %s",
+                    "cannot release lock for file: %s",
                     msc_waf_log_path);
             }
         }

--- a/standalone/api.h
+++ b/standalone/api.h
@@ -68,6 +68,10 @@ request_rec *modsecNewRequest(conn_rec *connection, directory_config *config);
 int modsecProcessRequestBody(request_rec *r);
 int modsecProcessRequestHeaders(request_rec *r);
 
+#ifdef WAF_JSON_LOGGING_ENABLE
+void modsecReopenFileIfNeeded(request_rec *r);
+#endif
+
 static inline int modsecProcessRequest(request_rec *r)    {
     int status;
     status = modsecProcessRequestHeaders(r);

--- a/standalone/api.h
+++ b/standalone/api.h
@@ -69,7 +69,7 @@ int modsecProcessRequestBody(request_rec *r);
 int modsecProcessRequestHeaders(request_rec *r);
 
 #ifdef WAF_JSON_LOGGING_ENABLE
-void modsecReopenFileIfNeeded(request_rec *r);
+void modsecReopenLogfileIfNeeded(request_rec *r);
 #endif
 
 static inline int modsecProcessRequest(request_rec *r)    {


### PR DESCRIPTION
based on the CRI, we have two issues in current reopen file function.
1. we don't close the old file handler
2. there is potential race condition in the threads when reopen the files.

the fix:
now we reopen file in the nginx event loop, which fix item2, and also we will first open the new file handler and then close the old file handler, overwrite it, which fix item1

Testing:
I have deploy in my local and force the logrotate, which works fine.