### PR TITLE
Fix PCRE specific message and mandatory rules length comparison issue

### DIFF
--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -1529,6 +1529,10 @@ static const char *cmd_component_signature(cmd_parms *cmd, void *_dcfg,
     /* ENH Enforce "Name/VersionX.Y.Z (comment)" format. */
     *(char **)apr_array_push(dcfg->component_signatures) = (char *)p1;
 
+#ifdef WAF_JSON_LOGGING_ENABLE
+    msc_waf_signature = (char *)p1;
+#endif
+
     return NULL;
 }
 

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -128,6 +128,11 @@ void *create_directory_config(apr_pool_t *mp, char *path)
     /* WAF policy identification information */
     dcfg->waf_policy_id = NOT_SET_P;
 
+#ifdef WAF_JSON_LOGGING_ENABLE
+    /* WAF ruleset type/version information */
+    dcfg->waf_signature = NOT_SET_P;
+#endif
+
     /* Geo Lookups */
     dcfg->geo = NOT_SET_P;
 
@@ -575,6 +580,12 @@ void *merge_directory_configs(apr_pool_t *mp, void *_parent, void *_child)
     merged->waf_policy_id = (child->waf_policy_id == NOT_SET_P
         ? parent->waf_policy_id : child->waf_policy_id);
 
+#ifdef WAF_JSON_LOGGING_ENABLE
+    /* WAF ruleset type/version information */
+    merged->waf_signature = (child->waf_signature == NOT_SET_P
+        ? parent->waf_signature : child->waf_signature);
+#endif
+
     /* Geo Lookup */
     merged->geo = (child->geo == NOT_SET_P
         ? parent->geo : child->geo);
@@ -739,6 +750,11 @@ void init_directory_config(directory_config *dcfg)
 
     /* WAF policy identification information */
     if (dcfg->waf_policy_id == NOT_SET_P) dcfg->waf_policy_id = "";
+
+#ifdef WAF_JSON_LOGGING_ENABLE
+    /* WAF ruleset type version information */
+    if (dcfg->waf_signature == NOT_SET_P) dcfg->waf_signature = "";
+#endif
 
     /* Geo Lookup */
     if (dcfg->geo == NOT_SET_P) dcfg->geo = NULL;
@@ -1530,7 +1546,7 @@ static const char *cmd_component_signature(cmd_parms *cmd, void *_dcfg,
     *(char **)apr_array_push(dcfg->component_signatures) = (char *)p1;
 
 #ifdef WAF_JSON_LOGGING_ENABLE
-    msc_waf_signature = (char *)p1;
+    dcfg->waf_signature = (char *)p1;
 #endif
 
     return NULL;

--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -316,6 +316,25 @@ static int write_file_with_lock(struct waf_lock* lock, apr_file_t** fd, char* st
 }
 
 /**
+ * get pcre specific error message.
+ */
+static void get_pcre_error_message(const char* orig_string, char* message) {
+    const char* pcre_error_message = " Execution error - PCRE limits exceeded ";
+
+    if (strlen(message) != 0) {
+        return;
+    }
+
+    if (orig_string && (strstr(orig_string, pcre_error_message) != NULL)) {
+        // since message is preallocated as 1024, so don't need to check boundary here.
+        strcpy(message, pcre_error_message);
+    }
+
+    return;
+}
+
+
+/**
  * send all waf fields in json format to a file.
  */
 static void send_waf_log(struct waf_lock* lock, apr_file_t** fd, const char* str1, const char* ip_port, const char* uri, int mode, const char* hostname, char* request_id, request_rec *r, const char* waf_policy_id, const char* waf_policy_scope, const char* waf_policy_scope_name) {
@@ -335,6 +354,7 @@ static void send_waf_log(struct waf_lock* lock, apr_file_t** fd, const char* str
     get_field_value("[id ", "]", str1, waf_id);
     get_field_value("[line ", "]", str1, waf_line);
     get_field_value("[msg ", "]", str1, waf_message);
+    get_pcre_error_message(str1, waf_message);
     get_field_value("[data ", "]", str1, waf_data);
 	get_field_value("[ver ", "]", str1, waf_ruleset_info);
 	get_ip_port(ip_port, waf_ip, waf_port);

--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -539,7 +539,11 @@ void msr_log_error(modsec_rec *msr, const char *text, ...) {
     va_list ap;
 
     va_start(ap, text);
+#ifdef WAF_JSON_LOGGING_ENABLE
     internal_log_ex(msr->r, msr->txcfg, msr, 3, 1, 0, text, ap);
+#else
+    internal_log_ex(msr->r, msr->txcfg, msr, 3, 1, text, ap);
+#endif
     va_end(ap);
 }
 
@@ -553,7 +557,11 @@ void msr_log_warn(modsec_rec *msr, const char *text, ...) {
     va_list ap;
 
     va_start(ap, text);
+#ifdef WAF_JSON_LOGGING_ENABLE
     internal_log_ex(msr->r, msr->txcfg, msr, 4, 1, 0, text, ap);
+#else
+    internal_log_ex(msr->r, msr->txcfg, msr, 4, 1, text, ap);
+#endif
     va_end(ap);
 }
 

--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -386,7 +386,11 @@ static void send_waf_log(struct waf_lock* lock, apr_file_t** fd, const char* str
  * required bytes will be escaped.
  */
 static void internal_log_ex(request_rec *r, directory_config *dcfg, modsec_rec *msr,
+#ifdef WAF_JSON_LOGGING_ENABLE
     int level, int fixup, enum ERROR_ENUM error_code, const char *text, va_list ap)
+#else
+    int level, int fixup, const char *text, va_list ap)
+#endif
 {
     apr_size_t nbytes, nbytes_written;
     apr_file_t *debuglog_fd = NULL;
@@ -505,10 +509,15 @@ void msr_log(modsec_rec *msr, int level, const char *text, ...) {
     va_list ap;
 
     va_start(ap, text);
+#ifdef WAF_JSON_LOGGING_ENABLE
     internal_log_ex(msr->r, msr->txcfg, msr, level, 0, 0, text, ap);
+#else
+    internal_log_ex(msr->r, msr->txcfg, msr, level, 0, text, ap);
+#endif
     va_end(ap);
 }
 
+#ifdef WAF_JSON_LOGGING_ENABLE
 /**
  * Logs one message with error code at the given level to the debug log (and to the
  * Apache error log if the message is important enough.
@@ -520,6 +529,7 @@ void msr_log_with_errorcode(modsec_rec *msr, int level, enum ERROR_ENUM error_co
     internal_log_ex(msr->r, msr->txcfg, msr, level, 0, error_code, text, ap);
     va_end(ap);
 }
+#endif
 
 /**
  * Logs one message at level 3 to the debug log and to the

--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -274,20 +274,19 @@ static void get_short_filename(char* waf_filename) {
  * get crs type and version.
  */
 static void get_ruleset_type_version(char* waf_ruleset_info, char* waf_ruleset_type, char* waf_ruleset_version) {
-    char ruleset_info_no_quote[200] = "";
     char *type_start = NULL;
     char *type_end = NULL;
 
-    get_field_value("\"", "\"", waf_ruleset_info, ruleset_info_no_quote);
-    type_start = ruleset_info_no_quote;
+    type_start = waf_ruleset_info;
+
+    if (type_start == NULL){
+        return;
+    }
 
     type_end = strstr(type_start, "/");
     if (type_end != NULL) {
         strncpy(waf_ruleset_type, type_start, type_end - type_start);
         strcpy(waf_ruleset_version, type_end + 1);
-    }
-    else {
-        strcpy(waf_ruleset_type, type_start + 1);
     }
 }
 
@@ -345,7 +344,6 @@ static void send_waf_log(struct waf_lock* lock, apr_file_t** fd, const char* str
     char waf_data[1024] = "";
     char waf_ip[50] = "";
     char waf_port[50] = "";
-    char waf_ruleset_info[200] = "";
     char waf_ruleset_type[50] = "";
     char waf_ruleset_version[50] = "";
     char waf_detail_message[1024] = "";
@@ -356,11 +354,10 @@ static void send_waf_log(struct waf_lock* lock, apr_file_t** fd, const char* str
     get_field_value("[msg ", "]", str1, waf_message);
     get_pcre_error_message(str1, waf_message);
     get_field_value("[data ", "]", str1, waf_data);
-	get_field_value("[ver ", "]", str1, waf_ruleset_info);
 	get_ip_port(ip_port, waf_ip, waf_port);
     get_detail_message(str1, waf_detail_message); 
     get_short_filename(waf_filename);
-    get_ruleset_type_version(waf_ruleset_info, waf_ruleset_type, waf_ruleset_version); 
+    get_ruleset_type_version(msc_waf_signature, waf_ruleset_type, waf_ruleset_version); 
 
     // Format UTC timestamp
     time_t rawtime = time(NULL);

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -100,7 +100,6 @@ struct waf_lock DSOLOCAL *wafjsonlog_lock = NULL;
 apr_file_t DSOLOCAL *msc_waf_log_fd = NULL;
 char DSOLOCAL msc_waf_log_path[WAF_LOG_PATH_LENGTH] = ""; 
 cmd_parms DSOLOCAL *msc_waf_log_cmd = NULL;
-char DSOLOCAL *msc_waf_signature = NULL;
 #endif
 
 #ifndef _WIN32

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -100,6 +100,7 @@ struct waf_lock DSOLOCAL *wafjsonlog_lock = NULL;
 apr_file_t DSOLOCAL *msc_waf_log_fd = NULL;
 char DSOLOCAL msc_waf_log_path[WAF_LOG_PATH_LENGTH] = ""; 
 cmd_parms DSOLOCAL *msc_waf_log_cmd = NULL;
+char DSOLOCAL *msc_waf_signature = NULL;
 #endif
 
 #ifndef _WIN32

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -180,7 +180,6 @@ extern DSOLOCAL struct waf_lock *wafjsonlog_lock;;
 extern DSOLOCAL apr_file_t *msc_waf_log_fd;
 extern DSOLOCAL char msc_waf_log_path[WAF_LOG_PATH_LENGTH];
 extern DSOLOCAL cmd_parms *msc_waf_log_cmd;
-extern DSOLOCAL char *msc_waf_signature;
 #endif
 
 #ifndef _WIN32
@@ -619,6 +618,11 @@ struct directory_config {
 
     /* WAF policy identification information */
     const char          *waf_policy_id;
+
+#ifdef WAF_JSON_LOGGING_ENABLE
+    /* WAF rule set type/version information */
+    const char          *waf_signature;
+#endif
 
     /* Geo Lookup */
     geo_db              *geo;

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -180,6 +180,7 @@ extern DSOLOCAL struct waf_lock *wafjsonlog_lock;;
 extern DSOLOCAL apr_file_t *msc_waf_log_fd;
 extern DSOLOCAL char msc_waf_log_path[WAF_LOG_PATH_LENGTH];
 extern DSOLOCAL cmd_parms *msc_waf_log_cmd;
+extern DSOLOCAL char *msc_waf_signature;
 #endif
 
 #ifndef _WIN32

--- a/apache2/msc_crypt.c
+++ b/apache2/msc_crypt.c
@@ -399,7 +399,7 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                                     em[i]->param,rc, my_error_msg);
 
                             if (msr->txcfg->debuglog_level >= 4)
-                                msr_log(msr, 4, "%s.", error_msg);
+                                msr_log_with_errorcode(msr, 4, 1, "%s.", error_msg);
 
                             return 0; /* No match. */
                         }
@@ -454,7 +454,7 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                                     em[i]->param,rc, my_error_msg);
 
                             if (msr->txcfg->debuglog_level >= 4)
-                                msr_log(msr, 4, "%s.", error_msg);
+                                msr_log_with_errorcode(msr, 4, 1, "%s.", error_msg);
 
                             return 0; /* No match. */
                         }
@@ -509,7 +509,7 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                                     em[i]->param,rc, my_error_msg);
 
                             if (msr->txcfg->debuglog_level >= 4)
-                                msr_log(msr, 4, "%s.", error_msg);
+                                msr_log_with_errorcode(msr, 4, 1, "%s.", error_msg);
 
                             return 0; /* No match. */
                         }
@@ -564,7 +564,7 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                                     em[i]->param,rc, my_error_msg);
 
                             if (msr->txcfg->debuglog_level >= 4)
-                                msr_log(msr, 4, "%s.", error_msg);
+                                msr_log_with_errorcode(msr, 4, 1, "%s.", error_msg);
 
                             return 0; /* No match. */
                         }
@@ -619,7 +619,7 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                                     em[i]->param,rc, my_error_msg);
 
                             if (msr->txcfg->debuglog_level >= 4)
-                                msr_log(msr, 4, "%s.", error_msg);
+                                msr_log_with_errorcode(msr, 4, 1, "%s.", error_msg);
 
                             return 0; /* No match. */
                         }

--- a/apache2/msc_crypt.c
+++ b/apache2/msc_crypt.c
@@ -399,8 +399,11 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                                     em[i]->param,rc, my_error_msg);
 
                             if (msr->txcfg->debuglog_level >= 4)
+#ifdef WAF_JSON_LOGGING_ENABLE
                                 msr_log_with_errorcode(msr, 4, 1, "%s.", error_msg);
-
+#else
+                                msr_log(msr, 4, "%s.", error_msg);
+#endif
                             return 0; /* No match. */
                         }
                         else if (rc < -1) {
@@ -454,7 +457,11 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                                     em[i]->param,rc, my_error_msg);
 
                             if (msr->txcfg->debuglog_level >= 4)
+#ifdef WAF_JSON_LOGGING_ENABLE
                                 msr_log_with_errorcode(msr, 4, 1, "%s.", error_msg);
+#else
+                                msr_log(msr, 4, "%s.", error_msg);
+#endif                        
 
                             return 0; /* No match. */
                         }
@@ -509,7 +516,11 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                                     em[i]->param,rc, my_error_msg);
 
                             if (msr->txcfg->debuglog_level >= 4)
+#ifdef WAF_JSON_LOGGING_ENABLE
                                 msr_log_with_errorcode(msr, 4, 1, "%s.", error_msg);
+#else               
+                                msr_log(msr, 4, "%s.", error_msg);
+#endif                                
 
                             return 0; /* No match. */
                         }
@@ -564,7 +575,11 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                                     em[i]->param,rc, my_error_msg);
 
                             if (msr->txcfg->debuglog_level >= 4)
+#ifdef WAF_JSON_LOGGING_ENABLE
                                 msr_log_with_errorcode(msr, 4, 1, "%s.", error_msg);
+#else
+                                msr_log(msr, 4, "%s.", error_msg);
+#endif                                
 
                             return 0; /* No match. */
                         }
@@ -619,7 +634,11 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                                     em[i]->param,rc, my_error_msg);
 
                             if (msr->txcfg->debuglog_level >= 4)
+#ifdef WAF_JSON_LOGGING_ENABLE
                                 msr_log_with_errorcode(msr, 4, 1, "%s.", error_msg);
+#else
+                                msr_log(msr, 4, "%s.", error_msg);
+#endif
 
                             return 0; /* No match. */
                         }

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -848,8 +848,11 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
                 rule,((rule->actionset != NULL)&&(rule->actionset->id != NULL)) ? rule->actionset->id : "-",
                 rule->filename != NULL ? rule->filename : "-",
                 rule->line_num,rc, my_error_msg);
-
+#ifdef WAF_JSON_LOGGING_ENABLE
         msr_log_with_errorcode(msr, 3, 1, "%s.", *error_msg);
+#else
+        msr_log(msr, 3, "%s.", *error_msg);
+#endif
 
         return 0; /* No match. */
     }
@@ -1088,8 +1091,11 @@ static int msre_op_rx_execute(modsec_rec *msr, msre_rule *rule, msre_var *var, c
                 rule,((rule->actionset != NULL)&&(rule->actionset->id != NULL)) ? rule->actionset->id : "-",
                 rule->filename != NULL ? rule->filename : "-",
                 rule->line_num,rc, my_error_msg);
-
+#ifdef WAF_JSON_LOGGING_ENABLE
         msr_log_with_errorcode(msr, 3, 1, "%s.", *error_msg);
+#else
+        msr_log(msr, 3, "%s.", *error_msg);
+#endif
 
         return 0; /* No match. */
     }

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -849,7 +849,7 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
                 rule->filename != NULL ? rule->filename : "-",
                 rule->line_num,rc, my_error_msg);
 
-        msr_log(msr, 3, "%s.", *error_msg);
+        msr_log_with_errorcode(msr, 3, 1, "%s.", *error_msg);
 
         return 0; /* No match. */
     }
@@ -1089,7 +1089,7 @@ static int msre_op_rx_execute(modsec_rec *msr, msre_rule *rule, msre_var *var, c
                 rule->filename != NULL ? rule->filename : "-",
                 rule->line_num,rc, my_error_msg);
 
-        msr_log(msr, 3, "%s.", *error_msg);
+        msr_log_with_errorcode(msr, 3, 1, "%s.", *error_msg);
 
         return 0; /* No match. */
     }

--- a/apache2/waf_logging/waf_log_util.cc
+++ b/apache2/waf_logging/waf_log_util.cc
@@ -162,7 +162,7 @@ static std::string get_json_log_message(const char* timestamp, const char* resou
     #define MANDATORY_RULE_MESSAGE_LENGTH (sizeof(MANDATORY_RULE_MESSAGE) - 1)
     std::array<char, 1024> mandatory_message {MANDATORY_RULE_MESSAGE};
     str_view message_str;
-    if (messages) {
+    if (messages && strlen(messages) != 0) {
         if (is_mandatory) {
             size_t truncated_length = std::min(strlen(messages) - 1, mandatory_message.size() - MANDATORY_RULE_MESSAGE_LENGTH);
             if (truncated_length > 1) {

--- a/apache2/waf_logging/waf_log_util.h
+++ b/apache2/waf_logging/waf_log_util.h
@@ -24,6 +24,14 @@
 
 #define RULE_HASH_SIZE 499
 
+enum ERROR_ENUM {
+    none, pcre_limit_error,
+};
+
+static const char *ERROR_STRING[] = {
+    "", " Execution error - PCRE limits exceeded ",
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Issue:
   if it's pcre timeout, in the waf_json.log, we will see bunch of  0s in the message. 
Root Cause:
  right now, we are using "[message]" to get message field. but for pcre error, original string is like:
Rule 7f5786fc56f8 [id \"920100\"][file \"/etc/nginx/modsec/default/RuleSets/crs3.0/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf\"][line \"65\"] - Execution error - PCRE limits exceeded (-8): (null).
so message will be "" after processing. 
when we add mandatory rules into messages, the comparison is using str(message) - 1 (get rid of trailing "), which is wrong in the case message is ""

Testoutput:

{"timeStamp":"2020-02-28T00:36:26+00:00","resourceId":"/A/B/C","operationName":"ApplicationGatewayFirewall","category":"ApplicationGatewayFirewallLog","properties":{"instanceId":"dummyRole_0","clientIp":"127.0.0.1","clientPort":"","requestUri":"/","ruleSetType":"","ruleSetVersion":"","ruleId":"942440","message":"Mandatory rule. Cannot be disabled. Execution error - PCRE limits exceeded","action":"Blocked","site":"Global","details":{"message":"Rule 7f15d5b4dbe0 [id \"942440\"]","data":"","file":"rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf","line":"1053"},"hostname":"localhost","transactionId":"39b44edf51d85515c5e0c9d0ea84600f","policyId":"default","policyScope":"Global","policyScopeName":"Global"}}


