### PR TITLE
Case-Normalization for `filename*` extension parameters.

### DIFF
--- a/apache2/msc_util.c
+++ b/apache2/msc_util.c
@@ -1820,7 +1820,7 @@ char *rfc5987_decode(apr_pool_t *mptmp, char *value)
     // The decode that we perform will be in place, hence lets allocate a new buffer for URL encoded value that we are processing.
     urlEncodedValue = apr_pstrdup(mptmp, urlEncodedValue);
 
-    if (strncmp(value, utf8, strlen(utf8)) == 0)
+    if (strncasecmp(value, utf8, strlen(utf8)) == 0)
     {
         // The value is an extended value with UTF-8 encoding.
         int invalid_count;
@@ -1830,7 +1830,7 @@ char *rfc5987_decode(apr_pool_t *mptmp, char *value)
             return urlEncodedValue;
         }
     }
-    else if (strncmp(value, iso88591, strlen(iso88591)) == 0)
+    else if (strncasecmp(value, iso88591, strlen(iso88591)) == 0)
     {
         // The value is an extended value with ISO-8859-1 encoding.
         int invalid_count;


### PR DESCRIPTION
Issue:

Previously, the `rfc5987_decode` method matches the charset parameter in the `filename*` extension parameter case-sensitively. However, according to [RFC 5987 Section 3.2.1](https://tools.ietf.org/html/rfc5987#section-3.2.1):

> The value part of an extended parameter (ext-value) is a token that consists of three parts: the REQUIRED character set name (charset), the OPTIONAL language information (language), and a character sequence representing the actual value (value-chars), separated by single quote characters.  Note that **both character set names and language tags are restricted to the US-ASCII character set, and are matched case-insensitively** (see [[RFC2978], Section 2.3](https://tools.ietf.org/html/rfc2978#section-2.3) and [[RFC5646], Section 2.1.1)](https://tools.ietf.org/html/rfc5646#section-2.1.1).

This is fixed by changing the `strncmp` calls to `strncasecmp` calls when matching for the charset parameter in the `rfc5987_decode` method.