### PR TITLE
Malformed JSON body results in 400 Bad Request instead of 500

### DIFF
--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -1084,6 +1084,13 @@ static int hook_request_late(request_rec *r) {
                 r->connection->keepalive = AP_CONN_CLOSE;
                 return HTTP_BAD_REQUEST;
                 break;
+            case -8 : /* JSON body does not parse */
+                if (my_error_msg != NULL) {
+                    msr_log(msr, 4, "%s", my_error_msg);
+                }
+                r->connection->keepalive = AP_CONN_CLOSE;
+                return HTTP_BAD_REQUEST;
+                break;
             default :
                 /* allow through */
                 break;

--- a/apache2/msc_reqbody.c
+++ b/apache2/msc_reqbody.c
@@ -715,7 +715,7 @@ apr_status_t modsecurity_request_body_end(modsec_rec *msr, char **error_msg) {
                 msr->msc_reqbody_error = 1;
                 msr->msc_reqbody_error_msg = *error_msg;
                 msr_log(msr, 2, "%s", *error_msg);
-                 return -1;
+                 return -8;
              }
 #else
             *error_msg = apr_psprintf(msr->mp, "JSON support was not enabled");


### PR DESCRIPTION
* Introducing new return value (-8) in `modsecurity_request_body_end` when failing to parse JSON bodies
* This -8 return value in turn results in a 400 Bad Request response status code in NGINX