### PR TITLE
Fix PCRE specific message and mandatory rules length comparison issue…

### DIFF
--- a/apache2/apache2.h
+++ b/apache2/apache2.h
@@ -74,8 +74,6 @@ apr_status_t DSOLOCAL read_request_body(modsec_rec *msr, char **error_msg);
 
 int DSOLOCAL perform_interception(modsec_rec *msr);
 
-modsec_rec DSOLOCAL *create_tx_context(request_rec *r);
-
 apr_status_t DSOLOCAL send_error_bucket(modsec_rec *msr, ap_filter_t *f, int status);
 
 int DSOLOCAL apache2_exec(modsec_rec *msr, const char *command, const char **argv, char **output);

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -128,6 +128,11 @@ void *create_directory_config(apr_pool_t *mp, char *path)
     /* WAF policy identification information */
     dcfg->waf_policy_id = NOT_SET_P;
 
+#ifdef WAF_JSON_LOGGING_ENABLE
+    /* WAF ruleset type/version information */
+    dcfg->waf_signature = NOT_SET_P;
+#endif
+
     /* Geo Lookups */
     dcfg->geo = NOT_SET_P;
 
@@ -575,6 +580,12 @@ void *merge_directory_configs(apr_pool_t *mp, void *_parent, void *_child)
     merged->waf_policy_id = (child->waf_policy_id == NOT_SET_P
         ? parent->waf_policy_id : child->waf_policy_id);
 
+#ifdef WAF_JSON_LOGGING_ENABLE
+    /* WAF ruleset type/version information */
+    merged->waf_signature = (child->waf_signature == NOT_SET_P
+        ? parent->waf_signature : child->waf_signature);
+#endif
+
     /* Geo Lookup */
     merged->geo = (child->geo == NOT_SET_P
         ? parent->geo : child->geo);
@@ -739,6 +750,11 @@ void init_directory_config(directory_config *dcfg)
 
     /* WAF policy identification information */
     if (dcfg->waf_policy_id == NOT_SET_P) dcfg->waf_policy_id = "";
+
+#ifdef WAF_JSON_LOGGING_ENABLE
+    /* WAF ruleset type version information */
+    if (dcfg->waf_signature == NOT_SET_P) dcfg->waf_signature = "";
+#endif
 
     /* Geo Lookup */
     if (dcfg->geo == NOT_SET_P) dcfg->geo = NULL;
@@ -1528,6 +1544,10 @@ static const char *cmd_component_signature(cmd_parms *cmd, void *_dcfg,
 
     /* ENH Enforce "Name/VersionX.Y.Z (comment)" format. */
     *(char **)apr_array_push(dcfg->component_signatures) = (char *)p1;
+
+#ifdef WAF_JSON_LOGGING_ENABLE
+    dcfg->waf_signature = (char *)p1;
+#endif
 
     return NULL;
 }

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -484,7 +484,7 @@ static void store_tx_context(modsec_rec *msr, request_rec *r) {
 /**
  * Creates a new transaction context.
  */
-modsec_rec *create_tx_context(request_rec *r) {
+static modsec_rec *create_tx_context(request_rec *r) {
     apr_allocator_t *allocator = NULL;
     modsec_rec *msr = NULL;
 
@@ -867,19 +867,11 @@ static int hook_request_early(request_rec *r) {
         return DECLINED;
     }
 
-    /* Check if the transaction context
-     * has already been initialised.
+    /* Initialise transaction context and
+     * create the initial configuration.
      */
-
-    msr = retrieve_tx_context(r);
-    if (msr == NULL) {
-
-        /* Initialise transaction context and
-        * create the initial configuration.
-        */
-        msr = create_tx_context(r);
-        if (msr == NULL) return DECLINED;
-    }
+    msr = create_tx_context(r);
+    if (msr == NULL) return DECLINED;
 
 #ifdef REQUEST_EARLY
 

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -619,6 +619,11 @@ struct directory_config {
     /* WAF policy identification information */
     const char          *waf_policy_id;
 
+#ifdef WAF_JSON_LOGGING_ENABLE
+    /* WAF rule set type/version information */
+    const char          *waf_signature;
+#endif
+
     /* Geo Lookup */
     geo_db              *geo;
 

--- a/apache2/msc_crypt.c
+++ b/apache2/msc_crypt.c
@@ -399,8 +399,11 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                                     em[i]->param,rc, my_error_msg);
 
                             if (msr->txcfg->debuglog_level >= 4)
+#ifdef WAF_JSON_LOGGING_ENABLE
+                                msr_log_with_errorcode(msr, 4, 1, "%s.", error_msg);
+#else
                                 msr_log(msr, 4, "%s.", error_msg);
-
+#endif
                             return 0; /* No match. */
                         }
                         else if (rc < -1) {
@@ -454,7 +457,11 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                                     em[i]->param,rc, my_error_msg);
 
                             if (msr->txcfg->debuglog_level >= 4)
+#ifdef WAF_JSON_LOGGING_ENABLE
+                                msr_log_with_errorcode(msr, 4, 1, "%s.", error_msg);
+#else
                                 msr_log(msr, 4, "%s.", error_msg);
+#endif                        
 
                             return 0; /* No match. */
                         }
@@ -509,7 +516,11 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                                     em[i]->param,rc, my_error_msg);
 
                             if (msr->txcfg->debuglog_level >= 4)
+#ifdef WAF_JSON_LOGGING_ENABLE
+                                msr_log_with_errorcode(msr, 4, 1, "%s.", error_msg);
+#else               
                                 msr_log(msr, 4, "%s.", error_msg);
+#endif                                
 
                             return 0; /* No match. */
                         }
@@ -564,7 +575,11 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                                     em[i]->param,rc, my_error_msg);
 
                             if (msr->txcfg->debuglog_level >= 4)
+#ifdef WAF_JSON_LOGGING_ENABLE
+                                msr_log_with_errorcode(msr, 4, 1, "%s.", error_msg);
+#else
                                 msr_log(msr, 4, "%s.", error_msg);
+#endif                                
 
                             return 0; /* No match. */
                         }
@@ -619,7 +634,11 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                                     em[i]->param,rc, my_error_msg);
 
                             if (msr->txcfg->debuglog_level >= 4)
+#ifdef WAF_JSON_LOGGING_ENABLE
+                                msr_log_with_errorcode(msr, 4, 1, "%s.", error_msg);
+#else
                                 msr_log(msr, 4, "%s.", error_msg);
+#endif
 
                             return 0; /* No match. */
                         }

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -848,8 +848,11 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
                 rule,((rule->actionset != NULL)&&(rule->actionset->id != NULL)) ? rule->actionset->id : "-",
                 rule->filename != NULL ? rule->filename : "-",
                 rule->line_num,rc, my_error_msg);
-
+#ifdef WAF_JSON_LOGGING_ENABLE
+        msr_log_with_errorcode(msr, 3, 1, "%s.", *error_msg);
+#else
         msr_log(msr, 3, "%s.", *error_msg);
+#endif
 
         return 0; /* No match. */
     }
@@ -1088,8 +1091,11 @@ static int msre_op_rx_execute(modsec_rec *msr, msre_rule *rule, msre_var *var, c
                 rule,((rule->actionset != NULL)&&(rule->actionset->id != NULL)) ? rule->actionset->id : "-",
                 rule->filename != NULL ? rule->filename : "-",
                 rule->line_num,rc, my_error_msg);
-
+#ifdef WAF_JSON_LOGGING_ENABLE
+        msr_log_with_errorcode(msr, 3, 1, "%s.", *error_msg);
+#else
         msr_log(msr, 3, "%s.", *error_msg);
+#endif
 
         return 0; /* No match. */
     }

--- a/apache2/waf_logging/waf_log_util.cc
+++ b/apache2/waf_logging/waf_log_util.cc
@@ -162,7 +162,7 @@ static std::string get_json_log_message(const char* timestamp, const char* resou
     #define MANDATORY_RULE_MESSAGE_LENGTH (sizeof(MANDATORY_RULE_MESSAGE) - 1)
     std::array<char, 1024> mandatory_message {MANDATORY_RULE_MESSAGE};
     str_view message_str;
-    if (messages) {
+    if (messages && strlen(messages) != 0) {
         if (is_mandatory) {
             size_t truncated_length = std::min(strlen(messages) - 1, mandatory_message.size() - MANDATORY_RULE_MESSAGE_LENGTH);
             if (truncated_length > 1) {

--- a/apache2/waf_logging/waf_log_util.h
+++ b/apache2/waf_logging/waf_log_util.h
@@ -24,6 +24,14 @@
 
 #define RULE_HASH_SIZE 499
 
+enum ERROR_ENUM {
+    none, pcre_limit_error,
+};
+
+static const char *ERROR_STRING[] = {
+    "", " Execution error - PCRE limits exceeded ",
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/nginx/modsecurity/ngx_http_modsecurity.c
+++ b/nginx/modsecurity/ngx_http_modsecurity.c
@@ -58,7 +58,14 @@ typedef struct {
 
 typedef struct {
     ngx_http_request_t *r;
-} ngx_http_modsecurity_thread_ctx_t;
+} ngx_http_modsecurity_prevention_thread_ctx_t;
+
+typedef struct {
+    conn_rec            *connection;
+    request_rec         *req;
+
+    apr_bucket_brigade  *brigade;
+} ngx_http_modsecurity_detection_thread_ctx_t;
 
 /*
 ** Module's registred function/handlers.
@@ -162,10 +169,12 @@ ngx_module_t ngx_http_modsecurity = {
 
 static ngx_http_upstream_t ngx_http_modsecurity_upstream;
 
-static inline char *
+static inline u_char *
 ngx_pstrdup0(ngx_pool_t *pool, ngx_str_t *src)
 {
-    char *dst = ngx_pnalloc(pool, src->len + 1);
+    u_char  *dst;
+
+    dst = ngx_pnalloc(pool, src->len + 1);
     if (dst == NULL) {
         return NULL;
     }
@@ -174,6 +183,35 @@ ngx_pstrdup0(ngx_pool_t *pool, ngx_str_t *src)
     dst[src->len] = '\0';
 
     return dst;
+}
+
+
+static inline char *
+dup_ngx_str_to_apr(apr_pool_t *pool, ngx_str_t *src)
+{
+    return apr_pstrmemdup(pool, (char *)src->data, src->len);
+}
+
+/*
+ * Helper to allocate a thread task using an Apache pool.
+ * This is useful when the background task can outlive the Nginx request
+ * it is initiated for.
+ */
+ngx_thread_task_t *
+apr_thread_task_alloc(apr_pool_t *pool, size_t size)
+{
+    ngx_thread_task_t  *task;
+
+    // The logic of ngx_thread_task_post relies on the task to be zero-initialized.
+    // That is why we use apr_pcalloc here.
+    task = apr_pcalloc(pool, sizeof(ngx_thread_task_t) + size);
+    if (task == NULL) {
+        return NULL;
+    }
+
+    task->ctx = task + 1;
+
+    return task;
 }
 
 static inline int
@@ -260,7 +298,7 @@ ngx_http_modsecurity_load_request(ngx_http_request_t *r)
     req = ctx->req;
 
     /* request line */
-    req->method = ngx_pstrdup0(r->pool, &r->method_name);
+    req->method = dup_ngx_str_to_apr(req->pool, &r->method_name);
 
     /* TODO: how to use ap_method_number_of ?
      * req->method_number = ap_method_number_of(req->method);
@@ -273,18 +311,18 @@ ngx_http_modsecurity_load_request(ngx_http_request_t *r)
         return NGX_ERROR;
     }
 
-    req->filename = (char *) path.data;
+    req->filename = dup_ngx_str_to_apr(req->pool, &path);
     req->path_info = req->filename;
 
-    req->args = ngx_pstrdup0(r->pool, &r->args);
+    req->args = dup_ngx_str_to_apr(req->pool, &r->args);
 
     req->proto_num = r->http_major *1000 + r->http_minor;
-    req->protocol = ngx_pstrdup0(r->pool, &r->http_protocol);
+    req->protocol = dup_ngx_str_to_apr(req->pool, &r->http_protocol);
     req->request_time = apr_time_make(r->start_sec, r->start_msec);
-    req->the_request = ngx_pstrdup0(r->pool, &r->request_line);
+    req->the_request = dup_ngx_str_to_apr(req->pool, &r->request_line);
 
-    req->unparsed_uri = ngx_pstrdup0(r->pool, &r->unparsed_uri);
-    req->uri = ngx_pstrdup0(r->pool, &r->uri);
+    req->unparsed_uri = dup_ngx_str_to_apr(req->pool, &r->unparsed_uri);
+    req->uri = dup_ngx_str_to_apr(req->pool, &r->uri);
 
     req->parsed_uri.scheme = "http";
 
@@ -294,7 +332,7 @@ ngx_http_modsecurity_load_request(ngx_http_request_t *r)
     }
 #endif
 
-    req->parsed_uri.path = ngx_pstrdup0(r->pool, &r->uri);
+    req->parsed_uri.path = dup_ngx_str_to_apr(req->pool, &r->uri);
     req->parsed_uri.is_initialized = 1;
 
     switch (r->connection->local_sockaddr->sa_family) {
@@ -319,22 +357,22 @@ ngx_http_modsecurity_load_request(ngx_http_request_t *r)
     }
 
     req->parsed_uri.port = port;
-    req->parsed_uri.port_str = ngx_pnalloc(r->pool, sizeof("65535"));
+    req->parsed_uri.port_str = apr_palloc(req->pool, sizeof("65535"));
     (void) ngx_sprintf((u_char *)req->parsed_uri.port_str, "%ui%c", port, '\0');
 
     req->parsed_uri.query = r->args.len ? req->args : NULL;
     req->parsed_uri.dns_looked_up = 0;
     req->parsed_uri.dns_resolved = 0;
 
-    req->parsed_uri.fragment = ngx_pstrdup0(r->pool, &r->exten);
+    req->parsed_uri.fragment = dup_ngx_str_to_apr(req->pool, &r->exten);
 
-    req->hostname = ngx_pstrdup0(r->pool, (ngx_str_t *)&ngx_cycle->hostname);
+    req->hostname = dup_ngx_str_to_apr(req->pool, (ngx_str_t *)&ngx_cycle->hostname);
 
     req->header_only = r->header_only ? r->header_only : (r->method == NGX_HTTP_HEAD);
 
 #ifdef WAF_JSON_LOGGING_ENABLE
     ngx_str_t request_id = get_request_id(r);
-    req->log_id = ngx_pstrdup0(r->pool, &request_id);
+    req->log_id = dup_ngx_str_to_apr(req->pool, &request_id);
 #endif
 
     return NGX_OK;
@@ -372,7 +410,15 @@ ngx_http_modsecurity_load_headers_in(ngx_http_request_t *r)
             i = 0;
         }
 
-        apr_table_setn(req->headers_in, (char *)h[i].key.data, (char *)h[i].value.data);
+        const char *key = dup_ngx_str_to_apr(req->pool, &h[i].key);
+        if (key == NULL) {
+            return NGX_ERROR;
+        }
+        const char *value = dup_ngx_str_to_apr(req->pool, &h[i].value);
+        if (value == NULL) {
+            return NGX_ERROR;
+        }
+        apr_table_setn(req->headers_in, key, value);
         ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                        "ModSecurity: load headers in: \"%V: %V\"",
                        &h[i].key, &h[i].value);
@@ -399,17 +445,17 @@ ngx_http_modsecurity_load_headers_in(ngx_http_request_t *r)
 
     req->ap_auth_type = (char *)apr_table_get(req->headers_in, "Authorization");
 
-    req->user = ngx_pstrdup0(r->pool, &r->headers_in.user);
+    req->user = dup_ngx_str_to_apr(req->pool, &r->headers_in.user);
 
     /* Add scope and scope name for logging purposes */
     ngx_http_modsecurity_loc_conf_t* cf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity);
-    const char* scope = ngx_pstrdup0(r->pool, &cf->scope);
+    const char* scope = dup_ngx_str_to_apr(req->pool, &cf->scope);
     if (scope == NULL) {
         return NGX_ERROR;
     }
     apr_table_setn(req->notes, WAF_POLICY_SCOPE, scope);
 
-    const char* scope_name = ngx_pstrdup0(r->pool, &cf->scope_name);
+    const char* scope_name = dup_ngx_str_to_apr(req->pool, &cf->scope_name);
     if (scope_name == NULL) {
         return NGX_ERROR;
     }
@@ -651,7 +697,7 @@ ngx_http_modsecurity_prevention_thread_func(void *data, ngx_log_t *log)
 {
     // Executed in a separate thread
 
-    ngx_http_modsecurity_thread_ctx_t *thread_ctx = data;
+    ngx_http_modsecurity_prevention_thread_ctx_t *thread_ctx = data;
     ngx_http_request_t *r = thread_ctx->r;
 
     ngx_http_modsecurity_ctx_t* mod_ctx = ngx_http_get_module_ctx(r, ngx_http_modsecurity);
@@ -701,7 +747,7 @@ ngx_http_modsecurity_prevention_thread_completion(ngx_event_t *ev)
     ngx_http_request_t  *r;
 
     r = ev->data;
-    r->main->blocked--; /* incremented in ngx_http_modsecurity_prevention_task_offload */
+    r->main->blocked--;
     r->aio = 0;
 
     ngx_http_modsecurity_ctx_t *ctx = ngx_http_get_module_ctx(r, ngx_http_modsecurity);
@@ -715,43 +761,53 @@ static void
 ngx_http_modsecurity_detection_thread_func(void *data, ngx_log_t *log)
 {
     // Executed in a separate thread
-    ngx_http_modsecurity_thread_ctx_t *thread_ctx = data;
-    ngx_http_modsecurity_ctx_t *mod_ctx = ngx_http_get_module_ctx(thread_ctx->r, ngx_http_modsecurity);
+    ngx_http_modsecurity_detection_thread_ctx_t *thread_ctx = data;
 
     // Processing request headers
-    ngx_int_t rc = ngx_http_modsecurity_status(modsecProcessRequestHeaders(mod_ctx->req));
+    ngx_int_t rc = ngx_http_modsecurity_status(modsecProcessRequestHeaders(thread_ctx->req));
     if (rc != NGX_DECLINED) {
         return;
     }
 
-    if (modsecContextState(mod_ctx->req) == MODSEC_DISABLED) {
+    if (modsecContextState(thread_ctx->req) == MODSEC_DISABLED) {
         return;
     }
 
     // The name of modsecProcessRequestBody is a bit misleading. This function call is needed even to just process GET args.
-    modsecProcessRequestBody(mod_ctx->req);
+    modsecProcessRequestBody(thread_ctx->req);
 }
+
 
 static void
 ngx_http_modsecurity_detection_thread_completion(ngx_event_t *ev)
 {
     // executed in nginx event loop after thread task is done, in order to pick up and continue processing request
-    ngx_http_request_t *r = ev->data;
-    /* 'blocked' is incremented in ngx_http_modsecurity_detection_task_offload */
-    --r->main->blocked;
-    /* This call will decrement r->main->count and do cleanup if needed */
-    ngx_http_finalize_request(r, NGX_DONE);
+    ngx_http_modsecurity_detection_thread_ctx_t *ctx = ev->data;
+
+    request_rec *req = ctx->req;
+    conn_rec *connection = ctx->connection;
+
+    if (req != NULL) {
+        modsecFinishRequest(req);
+    }
+    if (connection != NULL) {
+        modsecFinishConnection(connection);
+    }
 }
+
 
 static ngx_int_t
 ngx_http_modsecurity_prevention_task_offload(ngx_http_request_t *r)
 {
-    ngx_thread_task_t *task = ngx_thread_task_alloc(r->pool, sizeof(ngx_http_modsecurity_thread_ctx_t));
+    ngx_http_modsecurity_prevention_thread_ctx_t *thread_ctx;
+    ngx_thread_task_t *task;
+
+    task = ngx_thread_task_alloc(r->pool, sizeof(ngx_http_modsecurity_prevention_thread_ctx_t));
     if (task == NULL) {
         return NGX_ERROR;
     }
 
-    ngx_http_modsecurity_thread_ctx_t *thread_ctx = task->ctx;
+    thread_ctx = task->ctx;
     thread_ctx->r = r;
 
     task->handler = ngx_http_modsecurity_prevention_thread_func;
@@ -763,19 +819,17 @@ ngx_http_modsecurity_prevention_task_offload(ngx_http_request_t *r)
         return NGX_ERROR;
     }
 
-    ngx_http_modsecurity_ctx_t *ctx = ngx_http_get_module_ctx(r, ngx_http_modsecurity);
-    ctx->thread_running = 1;
-
     r->main->blocked++;
     r->aio = 1;
 
-    return NGX_DONE;
+    return NGX_OK;
 }
 
 static ngx_int_t
 ngx_http_modsecurity_detection_task_offload(ngx_http_request_t *r)
 {
     ngx_http_modsecurity_ctx_t *ctx = ngx_http_get_module_ctx(r, ngx_http_modsecurity);
+    request_rec *req = ctx->req;
 
     // Load request to request rec
     if (ngx_http_modsecurity_load_request(r) != NGX_OK ||
@@ -783,52 +837,39 @@ ngx_http_modsecurity_detection_task_offload(ngx_http_request_t *r)
         return NGX_ERROR;
     }
 
-    // ModSecurity implicitly initializes the internal request context when
-    // to modsecProcessRequestHeaders() is called.
-    // Because in our case we postpone this call, we need to initialize the context
-    // explicitly so that predicates like modsecIsRequestBodyAccessEnabled()
-    // work correctly.
-    const char *err = modsecInitializeRequestContext(ctx->req);
-    if (err) {
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, err);
-        return NGX_ERROR;
-    }
-
-    if (modsecIsRequestBodyAccessEnabled(ctx->req) && (r->headers_in.content_length || r->headers_in.chunked)) {
+    if (modsecIsRequestBodyAccessEnabled(req) && (r->headers_in.content_length || r->headers_in.chunked)) {
         if (ngx_http_modsecurity_load_request_body(r) != NGX_OK) {
             return NGX_ERROR;
         }
     }
 
-    ngx_thread_task_t *task = ngx_thread_task_alloc(r->pool, sizeof(ngx_http_modsecurity_thread_ctx_t));
+    ngx_thread_task_t *task = apr_thread_task_alloc(req->pool, sizeof(ngx_http_modsecurity_detection_thread_ctx_t));
     if (task == NULL) {
         return NGX_ERROR;
     }
 
-    ngx_http_modsecurity_thread_ctx_t *thread_ctx = task->ctx;
-    thread_ctx->r = r;
+    ngx_http_modsecurity_detection_thread_ctx_t *thread_ctx = task->ctx;
+    thread_ctx->connection = ctx->connection;
+    thread_ctx->req = ctx->req;
+    thread_ctx->brigade = ctx->brigade;
 
     task->handler = ngx_http_modsecurity_detection_thread_func;
     task->event.handler = ngx_http_modsecurity_detection_thread_completion;
-    task->event.data = r;
+    task->event.data = thread_ctx;
 
     ngx_thread_pool_t* thread_pool = ngx_thread_pool_get((ngx_cycle_t *)ngx_cycle, &thread_pool_name);
     if (ngx_thread_task_post(thread_pool, task) != NGX_OK) {
         return NGX_ERROR;
     }
 
-    /* Increment request reference count to make sure it lives long enough
-     * for the task to be completed.
-     * Note that it is safe to do that after posting the task to the thread pool because
-     * we decrement it in the completion handler and it will only run after the current code
-     * as it is scheduled on the same (main) thread.
-     * Besides the reference counter ('count') we need to increment 'blocked' because this
-     * guarantees that the request is not terminated when the connection is closed -
-     * see ngx_http_terminate_handler() for how it neglects the 'count' value in this case.
-     */
-    ++r->main->count;
-    ++r->main->blocked;
-    return NGX_DECLINED;
+    // We need to reset these so they don't get cleaned up when the request is complete.
+    // This is important as the background task can outlive the request and we need to
+    // make sure the memory it uses is still alive.
+    ctx->connection = NULL;
+    ctx->req = NULL;
+    ctx->brigade = NULL;
+
+    return NGX_OK;
 }
 
 static void
@@ -912,12 +953,23 @@ ngx_http_modsecurity_handler(ngx_http_request_t *r)
         return NGX_DECLINED;
     }
 
+    /* When in detection mode, don't wait for background task to complete because it won't affect the request status */
     if (cf->config->is_enabled == MODSEC_DETECTION_ONLY) {
-        return ngx_http_modsecurity_detection_task_offload(r);
+        if (ngx_http_modsecurity_detection_task_offload(r) != NGX_OK) {
+            return NGX_ERROR;
+        }
+
+        return NGX_DECLINED;
     }
 
-    return ngx_http_modsecurity_prevention_task_offload(r);
+    ctx->thread_running = 1;
+    if (ngx_http_modsecurity_prevention_task_offload(r) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    return NGX_DONE;
 }
+
 
 #define TXID_SIZE 25
 
@@ -958,9 +1010,9 @@ ngx_http_modsecurity_create_ctx(ngx_http_request_t *r)
         ctx->connection = modsecNewConnection();
 
         /* fill apr_sockaddr_t */
-        asa = ngx_palloc(r->pool, sizeof(apr_sockaddr_t));
+        asa = apr_palloc(ctx->connection->pool, sizeof(apr_sockaddr_t));
         asa->pool = ctx->connection->pool;
-        asa->hostname = ngx_pstrdup0(r->pool, &r->connection->addr_text);
+        asa->hostname = dup_ngx_str_to_apr(asa->pool, &r->connection->addr_text);
         asa->servname = asa->hostname;
         asa->next = NULL;
         asa->salen = r->connection->socklen;
@@ -1004,7 +1056,9 @@ ngx_http_modsecurity_create_ctx(ngx_http_request_t *r)
 
     ctx->req = modsecNewRequest(ctx->connection, cf->config);
 
-    apr_table_setn(ctx->req->notes, NOTE_NGINX_REQUEST_CTX, (const char *)ctx);
+    if (cf->config->is_enabled != MODSEC_DETECTION_ONLY) {
+        apr_table_setn(ctx->req->notes, NOTE_NGINX_REQUEST_CTX, (const char *)ctx);
+    }
     apr_generate_random_bytes(salt, TXID_SIZE);
 
     txid = apr_pcalloc (ctx->req->pool, TXID_SIZE);

--- a/standalone/api.c
+++ b/standalone/api.c
@@ -539,19 +539,6 @@ int modsecContextState(request_rec *r)
     return msr->txcfg->is_enabled;
 }
 
-const char* modsecInitializeRequestContext(request_rec *r)
-{
-    modsec_rec *msr = retrieve_msr(r);
-    if (msr == NULL) {
-        msr = create_tx_context(r);
-        if (msr == NULL) {
-            return "Failed to initialize request context";
-        }
-    }
-
-    return NULL;
-}
-
 int modsecIsRequestBodyAccessEnabled(request_rec *r)
 {
     modsec_rec *msr = retrieve_msr(r);

--- a/standalone/api.h
+++ b/standalone/api.h
@@ -117,12 +117,6 @@ void modsecSetWriteBody(apr_status_t (*func)(request_rec *r, char *buf, unsigned
 void modsecSetWriteResponse(apr_status_t (*func)(request_rec *r, char *buf, unsigned int length));
 void modsecSetDropAction(int (*func)(request_rec *r));
 
-/*
- * Creates internal request context if does not yet exist.
- * Must be called for a request_rec object that contains all request headers.
- */
-const char *modsecInitializeRequestContext(request_rec *r);
-
 int modsecIsResponseBodyAccessEnabled(request_rec *r);
 int modsecIsRequestBodyAccessEnabled(request_rec *r);
 


### PR DESCRIPTION
… (#158)

* fix specific pcre log error message

* Use Modsec cmd SecComponentSignature

* move from global to per licaton config

* add error code to avoid string match

* fix build

* fix build

(cherry picked from commit 7754cbeeb544e0b4a2d8de7917090d5ce29a3817)
Signed-off-by: Alon Pelled <alpelled@microsoft.com>