### PR TITLE
Change handling of invalid request JSON or XML

### DIFF
--- a/apache2/apache2_io.c
+++ b/apache2/apache2_io.c
@@ -193,7 +193,7 @@ apr_status_t read_request_body(modsec_rec *msr, char **error_msg) {
         msr_log(msr, 4, "Input filter: Reading request body.");
     }
     if (modsecurity_request_body_start(msr, error_msg) < 0) {
-        return -1;
+        return BODY_PARSER_ERR_GENERIC;
     }
 
     finished_reading = 0;
@@ -226,7 +226,7 @@ apr_status_t read_request_body(modsec_rec *msr, char **error_msg) {
                     return -2;
                 default :
                     *error_msg = apr_psprintf(msr->mp, "Error reading request body: %s", get_apr_error(msr->mp, rc));
-                    return -1;
+                    return BODY_PARSER_ERR_GENERIC;
             }
         }
 
@@ -321,7 +321,7 @@ apr_status_t read_request_body(modsec_rec *msr, char **error_msg) {
                     }
 
                     if((msr->txcfg->is_enabled == MODSEC_ENABLED) && (msr->txcfg->if_limit_action == REQUEST_BODY_LIMIT_ACTION_REJECT))
-                        return -1;
+                        return BODY_PARSER_ERR_GENERIC;
                 }
 
             }

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -1071,12 +1071,6 @@ static int hook_request_late(request_rec *r) {
                 }
                 break;
             case -6 : /* EOF when reading request body. */
-                if (my_error_msg != NULL) {
-                    msr_log(msr, 4, "%s", my_error_msg);
-                }
-                r->connection->keepalive = AP_CONN_CLOSE;
-                return HTTP_BAD_REQUEST;
-                break;
             case -7 : /* Partial recieved */
                 if (my_error_msg != NULL) {
                     msr_log(msr, 4, "%s", my_error_msg);
@@ -1084,6 +1078,7 @@ static int hook_request_late(request_rec *r) {
                 r->connection->keepalive = AP_CONN_CLOSE;
                 return HTTP_BAD_REQUEST;
                 break;
+            case BODY_PARSER_ERR_INVALID_BODY : /* Error Parsing Body. To be handled by modsec rules */
             default :
                 /* allow through */
                 break;

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -273,6 +273,11 @@ extern DSOLOCAL char *msc_waf_lock_group;
 
 #define NBSP                            160
 
+
+#define BODY_PARSER_ERR_GENERIC         -1
+#define BODY_PARSER_ERR_INVALID_BODY    -8
+#define BODY_PARSER_OK_SUCCESS          1
+
 struct rule_exception {
     int                  type;
     const char          *param;

--- a/apache2/msc_json.c
+++ b/apache2/msc_json.c
@@ -292,7 +292,7 @@ int json_process_chunk(modsec_rec *msr, const char *buf, unsigned int size, char
 int json_complete(modsec_rec *msr, char **error_msg) {
     char *json_data = (char *) NULL;
 
-    if (error_msg == NULL) return -1;
+    if (error_msg == NULL) return BODY_PARSER_ERR_GENERIC;
     *error_msg = NULL;
 
     /* Wrap up the parsing process */
@@ -301,10 +301,10 @@ int json_complete(modsec_rec *msr, char **error_msg) {
         char *yajl_err = yajl_get_error(msr->json->handle, 0, NULL, 0);
         *error_msg = apr_pstrdup(msr->mp, yajl_err);
         yajl_free_error(msr->json->handle, yajl_err);
-        return -1;
+        return BODY_PARSER_ERR_INVALID_BODY;
     }
 
-    return 1;
+    return BODY_PARSER_OK_SUCCESS;
 }
 
 /**

--- a/apache2/msc_xml.c
+++ b/apache2/msc_xml.c
@@ -36,7 +36,7 @@ int xml_init(modsec_rec *msr, char **error_msg) {
         entity = xmlParserInputBufferCreateFilenameDefault(xml_unload_external_entity);
     }
 
-    return 1;
+    return BODY_PARSER_OK_SUCCESS;
 }
 
 #if 0
@@ -59,7 +59,7 @@ static void xml_receive_sax_error(void *data, const char *msg, ...) {
  * Feed one chunk of data to the XML parser.
  */
 int xml_process_chunk(modsec_rec *msr, const char *buf, unsigned int size, char **error_msg) {
-    if (error_msg == NULL) return -1;
+    if (error_msg == NULL) return BODY_PARSER_ERR_GENERIC;
     *error_msg = NULL;
 
     /* We want to initialise our parsing context here, to
@@ -87,7 +87,7 @@ int xml_process_chunk(modsec_rec *msr, const char *buf, unsigned int size, char 
         msr->xml->parsing_ctx = xmlCreatePushParserCtxt(NULL, NULL, buf, size, "body.xml");
         if (msr->xml->parsing_ctx == NULL) {
             *error_msg = apr_psprintf(msr->mp, "XML: Failed to create parsing context.");
-            return -1;
+            return BODY_PARSER_ERR_GENERIC;
         }
     } else {
 
@@ -96,18 +96,18 @@ int xml_process_chunk(modsec_rec *msr, const char *buf, unsigned int size, char 
         xmlParseChunk(msr->xml->parsing_ctx, buf, size, 0);
         if (msr->xml->parsing_ctx->wellFormed != 1) {
             *error_msg = apr_psprintf(msr->mp, "XML: Failed parsing document.");
-            return -1;
+            return BODY_PARSER_ERR_INVALID_BODY;
         }
     }
 
-    return 1;
+    return BODY_PARSER_OK_SUCCESS;
 }
 
 /**
  * Finalise XML parsing.
  */
 int xml_complete(modsec_rec *msr, char **error_msg) {
-    if (error_msg == NULL) return -1;
+    if (error_msg == NULL) return BODY_PARSER_ERR_GENERIC;
     *error_msg = NULL;
 
     /* Only if we have a context, meaning we've done some work. */
@@ -126,11 +126,11 @@ int xml_complete(modsec_rec *msr, char **error_msg) {
 
         if (msr->xml->well_formed != 1) {
             *error_msg = apr_psprintf(msr->mp, "XML: Failed parsing document.");
-            return -1;
+            return BODY_PARSER_ERR_INVALID_BODY;
         }
     }
 
-    return 1;
+    return BODY_PARSER_OK_SUCCESS;
 }
 
 /**
@@ -149,5 +149,5 @@ apr_status_t xml_cleanup(modsec_rec *msr) {
         msr->xml->doc = NULL;
     }
 
-    return 1;
+    return BODY_PARSER_OK_SUCCESS;
 }


### PR DESCRIPTION
## Description

* This MR changes the behaviour of modsecurity when handling invalid request JSON or XML.
* Modsecurity currently fails at parsing these request bodies when content type is specified
  and throws an `HTTP 500` status. This behaviour isn't exactly compliant with the HTTP RFC.
* This MR proposes a standardized mechanism for handling body parser errors.
* The return codes are standardized in the common header file and a special return code
  `BODY_PARSER_ERR_INVALID_BODY` now indicates that the body parser failed.
* Modsecurity proceeds to evaluate the standard modsec-recommended rule `200002` which
  handles the `REQBODY_ERROR` target to return a block decision with `HTTP 400`.

## Changes

### modsecurity.h
* Standardize body parser return codes

### msc_json.c, msc_xml.c
* Return special error code on body parsing failure

### msc_reqbody.c, apache2_io.c, mod_security2.c
* Change body parsing error codes to refer to constants
  defined in header.