### PR TITLE
12803822: Avoid an extra strdup call. Call free yajl error once the main error log string has been formatted

### DIFF
--- a/apache2/msc_json.c
+++ b/apache2/msc_json.c
@@ -277,9 +277,7 @@ int json_process_chunk(modsec_rec *msr, const char *buf, unsigned int size, char
     /* Feed our parser and catch any errors */
     msr->json->status = yajl_parse(msr->json->handle, buf, size);
     if (msr->json->status != yajl_status_ok) {
-        char *yajl_err = yajl_get_error(msr->json->handle, 0, buf, size);
-        *error_msg = apr_pstrdup(msr->mp, yajl_err);
-        yajl_free_error(msr->json->handle, yajl_err);
+        *error_msg = yajl_get_error(msr->json->handle, 0, buf, size);
         return -1;
     }
 
@@ -298,13 +296,21 @@ int json_complete(modsec_rec *msr, char **error_msg) {
     /* Wrap up the parsing process */
     msr->json->status = yajl_complete_parse(msr->json->handle);
     if (msr->json->status != yajl_status_ok) {
-        char *yajl_err = yajl_get_error(msr->json->handle, 0, NULL, 0);
-        *error_msg = apr_pstrdup(msr->mp, yajl_err);
-        yajl_free_error(msr->json->handle, yajl_err);
+        *error_msg = yajl_get_error(msr->json->handle, 0, NULL, 0);
         return -1;
     }
 
     return 1;
+}
+
+/**
+ * Frees yajl error string.
+ */
+void json_free_error(modsec_rec *msr, char **error_msg) {
+    if ((error_msg != NULL) && (*error_msg != NULL)) {
+        yajl_free_error(msr->json->handle, *error_msg);
+        *error_msg = NULL;
+    }
 }
 
 /**

--- a/apache2/msc_json.h
+++ b/apache2/msc_json.h
@@ -56,5 +56,7 @@ apr_status_t DSOLOCAL json_cleanup(modsec_rec *msr);
 int DSOLOCAL json_process_chunk(modsec_rec *msr, const char *buf,
 		unsigned int size, char **error_msg);
 
+void DSOLOCAL json_free_error(modsec_rec *msr, char **error_msg);
+
 #endif
 #endif

--- a/apache2/msc_reqbody.c
+++ b/apache2/msc_reqbody.c
@@ -370,7 +370,16 @@ apr_status_t modsecurity_request_body_store(modsec_rec *msr,
                 msr->msc_reqbody_error = 1;
                 msr->msc_reqbody_error_msg = *error_msg;
                 msr_log(msr, 2, "%s", *error_msg);
+                json_free_error(msr, &my_error_msg);
             }
+
+            /*
+	     * Jan 14 2022 - The way json_process_chunk is implemented, my_error_msg will be
+	     * initialized only in the case where a negative/error value is returned. It is
+	     * safe to avoid calling json_free_error here. If the implementation of json_process_chunk
+	     * were to change, it might be neccessary to call json_free_error outside the if block above
+	     * to avoid memory leaks.
+	     */
 #else
             *error_msg = apr_psprintf(msr->mp, "JSON support was not enabled");
             msr->msc_reqbody_error = 1;
@@ -715,8 +724,17 @@ apr_status_t modsecurity_request_body_end(modsec_rec *msr, char **error_msg) {
                 msr->msc_reqbody_error = 1;
                 msr->msc_reqbody_error_msg = *error_msg;
                 msr_log(msr, 2, "%s", *error_msg);
-                 return -1;
-             }
+                json_free_error(msr, &my_error_msg);
+                return -1;
+            }
+
+            /*
+	     * Jan 14 2022 - The way json_process_chunk is implemented, my_error_msg will be
+	     * initialized only in the case where a negative/error value is returned. It is
+	     * safe to avoid calling json_free_error here. If the implementation of json_process_chunk
+	     * were to change, it might be neccessary to call json_free_error outside the if block above
+	     * to avoid memory leaks.
+	     */
 #else
             *error_msg = apr_psprintf(msr->mp, "JSON support was not enabled");
             msr->msc_reqbody_error = 1;


### PR DESCRIPTION
apr_pstrdup call can be avoided. Also, it is better to avoid unbounded string calls.