### PR TITLE
 Fix infinite loop bug from static analysis

### DIFF
--- a/apache2/msc_remote_rules.c
+++ b/apache2/msc_remote_rules.c
@@ -714,7 +714,6 @@ int msc_remote_add_rules_from_uri(cmd_parms *orig_parms,
         if (plain_text[len]  == '\n')
         {
             const char *rule = NULL;
-            apr_size_t tmp = len;
             char *cmd_name = NULL;
             char *word = NULL;
             const command_rec *cmd;

--- a/apache2/msc_remote_rules.c
+++ b/apache2/msc_remote_rules.c
@@ -655,9 +655,9 @@ int msc_remote_add_rules_from_uri(cmd_parms *orig_parms,
 #ifdef WITH_REMOTE_RULES
     struct msc_curl_memory_buffer_t downloaded_content;
     unsigned char *plain_text = NULL;
-    int len = 0;
-    int start = 0;
-    int end = 0;
+    apr_size_t len = 0;
+    apr_size_t start = 0;
+    apr_size_t end = 0;
     int added_rules = 0;
     int res = 0;
     apr_size_t plain_text_len = 0;
@@ -714,7 +714,7 @@ int msc_remote_add_rules_from_uri(cmd_parms *orig_parms,
         if (plain_text[len]  == '\n')
         {
             const char *rule = NULL;
-            int tmp = len;
+            apr_size_t tmp = len;
             char *cmd_name = NULL;
             char *word = NULL;
             const command_rec *cmd;


### PR DESCRIPTION
Fixing Warning (SM02323) - cpp/infiniteloop in apache2/msc_remote_rules.c: 

In msc_remote_add_rules_from_uri, within the while condition (line 712), there is a comparison between len (type int) and plain_text_len of a wider type apr_size_t. This can cause an infinite loop if value of plain_text_len is outside the range of len.

Change:
Updated type of len and a few other variables handling the size to apr_size_t for proper comparison.