### PR TITLE
Fix comparison of narrow type with wide type in loop condition

### DIFF
--- a/apache2/msc_status_engine.c
+++ b/apache2/msc_status_engine.c
@@ -111,7 +111,7 @@ int DSOLOCAL msc_status_engine_fill_with_dots(char *encoded_with_dots,
         goto return_length;
     }
 
-    for (i = 0; data[i] && i < len; i++) {
+    for (i = 0; i < len && data[i]; i++) {
         if (i % space == 0 && i != 0) {
             encoded_with_dots[count++] = '.';
         }

--- a/apache2/msc_status_engine.c
+++ b/apache2/msc_status_engine.c
@@ -111,7 +111,7 @@ int DSOLOCAL msc_status_engine_fill_with_dots(char *encoded_with_dots,
         goto return_length;
     }
 
-    for (i = 0; i < strlen(data) && i < len; i++) {
+    for (i = 0; data[i] && i < len; i++) {
         if (i % space == 0 && i != 0) {
             encoded_with_dots[count++] = '.';
         }


### PR DESCRIPTION
Comparisons between types of different widths in a loop condition can cause the loop to fail to terminate. Recommendation is to use appropriate types in the loop condition.

In msc_status_engine comparison between i of type int and call to strlen of wider type size_t is done resulting in comparison between narrow type with wide type in loop condition.
