### PR TITLE
CodeQL fix - cpp/no-space-for-terminator

### DIFF
--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -1812,7 +1812,7 @@ static int msre_op_gsbLookup_execute(modsec_rec *msr, msre_rule *rule, msre_var 
 
                         }
 
-                        url = apr_pstrdup(rule->ruleset->mp, strlen(canon));
+                        url = apr_pcalloc(rule->ruleset->mp, strlen(canon) + 1);
                         count_slash = 0;
 
                         while(*canon != '\0') {

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -1812,7 +1812,7 @@ static int msre_op_gsbLookup_execute(modsec_rec *msr, msre_rule *rule, msre_var 
 
                         }
 
-                        url = apr_palloc(rule->ruleset->mp, strlen(canon));
+                        url = apr_pstrdup(rule->ruleset->mp, strlen(canon));
                         count_slash = 0;
 
                         while(*canon != '\0') {


### PR DESCRIPTION
Issue:

Issue is that it is using the `strlen()` function to determine the size of the memory block to be allocated. This assumes that `canon` is a null-terminated string, which may not always be the case. If `canon` is not null-terminated, then the `strlen()` function will not return the correct length of the string, which could cause issues with the memory allocation.

Replacing apr_palloc() with apr_pcalloc()

https://msazure.visualstudio.com/DefaultCollection/One/_workitems/edit/17751620