### PR TITLE
Infinite loop msc tree

### DIFF
--- a/apache2/msc_tree.c
+++ b/apache2/msc_tree.c
@@ -252,6 +252,7 @@ TreeNode *SetParentNode(TreeNode *node, TreeNode *new_node, CPTTree *tree)  {
 int InsertNetmask(TreeNode *node, TreeNode *parent, TreeNode *new_node,
         CPTTree *tree, unsigned char netmask, unsigned char bitlen) {
     int i;
+    unsigned int netmask_int = (unsigned int) netmask;
 
     if (netmask != NETMASK_256-1 && netmask != NETMASK_128) {
         if ((netmask != NETMASK_32 || (netmask == NETMASK_32 && bitlen != NETMASK_32))) {
@@ -259,7 +260,7 @@ int InsertNetmask(TreeNode *node, TreeNode *parent, TreeNode *new_node,
             node = new_node;
             parent = new_node->parent;
 
-            while (parent != NULL && netmask < (parent->bit + 1)) {
+            while (parent != NULL && netmask_int < (parent->bit + 1)) {
                 node = parent;
                 parent = parent->parent;
             }
@@ -298,7 +299,7 @@ TreeNode *CPTAddElement(unsigned char *ipdata, unsigned int ip_bitmask, CPTTree 
     unsigned char bitlen = 0;
     int bit_validation = 0, test_bit = 0;
     int i = 0, j = 0, temp = 0;
-    unsigned int x, y;
+    unsigned int x, y, netmask_int = (unsigned int) netmask;
     TreeNode *node = NULL, *new_node = NULL;
     TreeNode *parent = NULL, *i_node = NULL;
     TreeNode *bottom_node = NULL;
@@ -408,7 +409,7 @@ TreeNode *CPTAddElement(unsigned char *ipdata, unsigned int ip_bitmask, CPTTree 
                     return node;
 
                 parent = node->parent;
-                while (parent != NULL && netmask < (parent->bit + 1)) {
+                while (parent != NULL && netmask_int < (parent->bit + 1)) {
                     node = parent;
                     parent = parent->parent;
                 }


### PR DESCRIPTION
Due to comparison between variables of different types, CodeQL raised a warning on possibility of infinite loop. To mitigate that, casted variable of narrow type into the wider type.
Here, the issue is between comparison of netmask (unsigned char) & node->bit (unsigned int). Code here is an implementation of a radix tree where we are trying to insert a netmask. Netmask for ipv4 and ipv6 addresses can't exceed 128. Whereas node->bit stores the information about index of the ip address to use while deciding to go left (0) or right (1) from the current node in this tree. This also can't be more than 128. But in the node's struct, it is defined as an unsigned int and that's why comparison between them while inserting a netmask raises a codeql warning.

Scenario for infinite loop - This can only occur if implementation of radix tree is flawed and is CYCLIC in nature (highly unlikely) and node->bit value is > 128 for all the nodes in the tree (again impossible).

Discussed this with codeql team and they're of the opinion that as codeql is a static analysis tool it is beyond it's scope to identify this, hence they suggested if we feel like it's a FP then we can suppress the warning or just use a cast (latter has been used here).