### PR TITLE
Fix comparison of narrow type with wide type in loop condition

### DIFF
--- a/apache2/re_actions.c
+++ b/apache2/re_actions.c
@@ -391,7 +391,7 @@ static char *msre_action_id_validate(msre_engine *engine, apr_pool_t *mp, msre_a
     int id;
 
     if(action != NULL && action->param != NULL) {
-        for(id=0;id<strlen(action->param);id++) {
+        for(id=0;action->param[id];id++) {
             if(!apr_isdigit(action->param[id]))
                 return apr_psprintf(mp, "ModSecurity: Invalid value for action ID: %s", action->param);
         }


### PR DESCRIPTION
Comparisons between types of different widths in a loop condition can cause the loop to fail to terminate. Recommendation is to use appropriate types in the loop condition.

In msre_action_id_validate comparison between i of type int and call to strlen of wider type size_t is done resulting in comparison between narrow type with wide type in loop condition.